### PR TITLE
chore(release): bump version to 0.1.2

### DIFF
--- a/desktop/apps/electron/package.json
+++ b/desktop/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amphi",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Bridgic Agent desktop app",
   "repository": {
     "type": "git",

--- a/desktop/apps/electron/src/shared/app-meta.ts
+++ b/desktop/apps/electron/src/shared/app-meta.ts
@@ -84,7 +84,7 @@ export const APP_BUNDLE_ID = 'ai.bridgic.agent'
 export const APP_DEEPLINK_SCHEME = 'amphi'
 
 /** App version — keep in sync with root and apps/electron package.json. */
-export const APP_VERSION = '0.1.1'
+export const APP_VERSION = '0.1.2'
 
 /** GitHub page used for user-confirmed issue reports from the desktop app. */
 export const APP_NEW_ISSUE_URL = 'https://github.com/bitsky-tech/bridgic-agent/issues/new'

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bridgic-agent-desktop",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "license": "SEE LICENSE IN ../LICENSE",
   "description": "Bridgic Agent — Electron GUI client for the Bridgic Agent backend daemon",

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -11,7 +11,7 @@ The command-line entry is ``python -m src <subcommand>`` (see
 :mod:`.amphi_cli`).
 """
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 
 __all__ = ["__version__"]


### PR DESCRIPTION
Bumps all four version sites to `0.1.2` via `bun run set-version 0.1.2`.

| File | Role |
|---|---|
| `src/__init__.py` | truth source — what the daemon reports over `/api/gateway/health` |
| `desktop/package.json` | electron-builder's `${version}`; names every artifact and is what the update feed advertises |
| `desktop/apps/electron/package.json` | app package metadata |
| `.../shared/app-meta.ts` `APP_VERSION` | User-Agent and the About box |

`pyproject.toml` is untouched by design — it takes its version dynamically from `src/__init__.py`.

## Why this has to land before the tag

The Package workflow's `meta` job compares the tag against `desktop/package.json` at the commit the tag points at, and fails the run when they disagree. That guard exists because a mismatch is silent in the worst way: CI stays green, the Release page looks correct, but the update manifest advertises the old version, so every client concludes it is already up to date and nobody receives the release. That is what happened to `0.1.1`.

## What 0.1.2 will ship over 0.1.1

- `feat(about)` — X, Discord (per UI language) and WeChat contact rows in Settings → About
- `feat(landing)` — build tagline rendered as inline code
- Privacy and approval copy refinements (EN + ZH)
- README refresh, header image, Windows installer guidance

## Verification

- [x] `uv run pytest tests/test_release_version_contract.py` — 5 passed
- [x] `bun run test` — 1358 pass, 6 skip, 0 fail
- [x] `bun run typecheck` / `lint` / `check:naming` / `check:locales`

🤖 Generated with [Claude Code](https://claude.com/claude-code)