### PR TITLE
fix(ui): make text legible and unify the component layer

### DIFF
--- a/desktop/apps/electron/src/renderer/components/amphi/BuildConfirmCard.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/BuildConfirmCard.tsx
@@ -43,7 +43,7 @@ export function BuildConfirmCard({
   return (
     <div className={floating ? 'w-full' : 'max-w-xl rounded-lg border border-border-subtle bg-bg-elevated p-4 shadow-sm'}>
       <div className="flex items-start gap-3">
-        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-accent-purple-subtle text-brand-purple">
+        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-accent-purple-subtle text-text-accent-purple">
           {Icons.workflow(17)}
         </span>
         <div className="min-w-0 flex-1">

--- a/desktop/apps/electron/src/renderer/components/amphi/CenterPageLayout.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/CenterPageLayout.tsx
@@ -1,0 +1,51 @@
+/**
+ * The shared skeleton of a center-column page (Workflows, Skills, Schedules,
+ * My Assets): title block on the left, actions on the right, an optional filter
+ * row, then the scrolling body.
+ *
+ * Written because the four pages had drifted on every measurement, and the drift
+ * was visible: switching between them moved the content baseline. The body's top
+ * padding alone had three values (20px / 16px / an 18px one-off that bypassed
+ * the scale), and Schedules aligned its header with items-start while the other
+ * three used items-center.
+ *
+ * The one rule with a condition in it: the body sits 20px below the header when
+ * there is no filter row, and 16px when there is. Not a compromise — a single
+ * fixed number would make the filtered pages push their content noticeably
+ * lower, since the filter row and its own gap come first. Equal *total* space
+ * from title to content is what makes the pages feel identical while switching.
+ */
+import type { ReactNode } from 'react'
+import { cn } from '@/lib/cn'
+
+export function CenterPageLayout({
+  title,
+  subtitle,
+  actions,
+  filters,
+  children,
+}: {
+  title: ReactNode
+  subtitle?: ReactNode
+  actions?: ReactNode
+  filters?: ReactNode
+  children: ReactNode
+}) {
+  return (
+    <div className="flex-1 flex flex-col overflow-hidden">
+      <div className="px-8 pt-5 flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold text-text-primary m-0">{title}</h2>
+          {subtitle ? <p className="text-sm text-text-secondary mt-1">{subtitle}</p> : null}
+        </div>
+        {actions ? <div className="flex items-center gap-2">{actions}</div> : null}
+      </div>
+
+      {filters ? <div className="px-8 pt-4">{filters}</div> : null}
+
+      <div className={cn('flex-1 overflow-auto px-8 pb-8', filters ? 'pt-4' : 'pt-5')}>
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/desktop/apps/electron/src/renderer/components/amphi/CenterViews.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/CenterViews.tsx
@@ -40,6 +40,11 @@ import {
 } from '@/lib/amphiClient'
 import { formatBytes } from '@/lib/toolDisplay'
 import { formatWorkflowRunShortTimestamp, workflowRunInputBlocks } from '@/lib/workflowRun'
+import { CenterPageLayout } from './CenterPageLayout'
+import { EmptyState } from './EmptyState'
+import { FilterTabs } from './FilterTabs'
+import { RefreshButton } from './RefreshButton'
+import { SearchBox } from './SearchBox'
 import { Icons } from './Icons'
 import { StructuredInput } from './StructuredInput'
 import { WindowedList } from './WindowedList'
@@ -124,13 +129,11 @@ export function CenterWorkflows({
   }
 
   return (
-    <div className="flex-1 flex flex-col overflow-hidden">
-      <div className="px-8 pt-5 flex items-center justify-between">
-        <div>
-          <h2 className="text-2xl font-bold text-text-primary m-0">{t('center.common.workflows')}</h2>
-          <p className="text-sm text-text-secondary mt-1">{t('center.workflows.subtitle')}</p>
-        </div>
-        <div className="flex gap-2">
+    <CenterPageLayout
+      title={t('center.common.workflows')}
+      subtitle={t('center.workflows.subtitle')}
+      actions={
+        <>
           <input
             ref={importInputRef}
             type="file"
@@ -142,37 +145,25 @@ export function CenterWorkflows({
               event.target.value = ''
             }}
           />
-          <label className="flex items-center gap-1.5 px-3.5 py-2 rounded-md bg-bg-input border border-border-subtle w-[220px]">
-            {Icons.search(14)}
-            <input
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              placeholder={t('center.workflows.searchPlaceholder')}
-              className="w-full bg-transparent text-sm text-text-primary outline-none placeholder:text-text-tertiary"
-            />
-          </label>
-          <Btn variant="default" size="md" onClick={() => importInputRef.current?.click()}>
+          <SearchBox
+            value={query}
+            onChange={setQuery}
+            placeholder={t('center.workflows.searchPlaceholder')}
+          />
+          <Btn variant="primary" size="md" onClick={() => importInputRef.current?.click()}>
             {Icons.download(14)} {t('center.common.import')}
           </Btn>
-        </div>
-      </div>
-
-      <div className="flex-1 overflow-auto px-8 pt-5 pb-8">
+        </>
+      }
+    >
+      <>
         {visible.length === 0 ? (
-          <div className="h-full flex items-center justify-center">
-            <div className="text-center">
-              <div className="mx-auto mb-3 w-11 h-11 rounded-md bg-accent-blue-subtle flex items-center justify-center text-brand-blue">
-                {Icons.workflow(22)}
-              </div>
-              {/* "No search matches" and "there are none at all" are two different things — the former suggests changing the keyword, the latter points to /build. */}
-              <div className="text-sm font-semibold text-text-primary">
-                {isSearching ? t('center.workflows.empty.noMatchTitle') : t('center.workflows.empty.title')}
-              </div>
-              <div className="mt-1 text-xs text-text-secondary">
-                {isSearching ? t('center.workflows.empty.noMatchDesc') : t('center.workflows.empty.desc')}
-              </div>
-            </div>
-          </div>
+          /* "No search matches" and "there are none at all" are two different things — the former suggests changing the keyword, the latter points to /build. */
+          <EmptyState
+            icon={Icons.workflow}
+            title={isSearching ? t('center.workflows.empty.noMatchTitle') : t('center.workflows.empty.title')}
+            description={isSearching ? t('center.workflows.empty.noMatchDesc') : t('center.workflows.empty.desc')}
+          />
         ) : (
           <div className="grid grid-cols-2 gap-3">
             {visible.map((w) => (
@@ -185,7 +176,7 @@ export function CenterWorkflows({
                 <div className="px-[18px] py-4">
                   <div className="flex items-start justify-between mb-2.5">
                     <div className="flex min-w-0 flex-1 items-center gap-2.5">
-                      <div className="w-9 h-9 rounded-md bg-accent-blue-subtle flex items-center justify-center text-brand-blue">
+                      <div className="w-9 h-9 rounded-md bg-accent-blue-subtle flex items-center justify-center text-text-accent">
                         {Icons.workflow(18)}
                       </div>
                       <div className="min-w-0 flex-1">
@@ -331,8 +322,8 @@ export function CenterWorkflows({
             ))}
           </div>
         )}
-      </div>
-    </div>
+      </>
+    </CenterPageLayout>
   )
 }
 
@@ -388,7 +379,7 @@ function SkillRow({
           className={cn(
             'w-9 h-9 rounded-md flex items-center justify-center flex-shrink-0',
             skill.enabled
-              ? 'bg-accent-purple-subtle text-brand-purple'
+              ? 'bg-accent-purple-subtle text-text-accent-purple'
               : 'bg-bg-hover text-text-tertiary',
           )}
         >
@@ -412,7 +403,7 @@ function SkillRow({
               {clamped && (
                 <button
                   type="button"
-                  className="mt-1 text-xs font-semibold text-brand-blue"
+                  className="mt-1 text-xs font-semibold text-text-accent"
                   onClick={() => setExpanded((x) => !x)}
                 >
                   {expanded ? t('center.common.collapse') : t('center.common.expandFull')}
@@ -464,13 +455,13 @@ function SkillsBody({
 }) {
   const { t } = useTranslation()
   if (state === 'loading' && skills.length === 0) {
-    return <div className="text-sm text-text-tertiary py-8 text-center">{t('center.common.loading')}</div>
+    return <EmptyState title={t('center.common.loading')} />
   }
   if (state === 'error') {
-    return <div className="text-sm text-status-error py-8 text-center">{t('center.skills.loadFailed')}</div>
+    return <EmptyState title={t('center.skills.loadFailed')} tone="error" />
   }
   if (skills.length === 0) {
-    return <div className="text-sm text-text-tertiary py-8 text-center">{t('center.skills.empty')}</div>
+    return <EmptyState icon={Icons.terminal} title={t('center.skills.empty')} />
   }
   return (
     <div className="flex flex-col gap-3">
@@ -512,22 +503,19 @@ export function CenterSkills() {
   }
 
   return (
-    <div className="flex-1 flex flex-col overflow-hidden">
-      <div className="px-8 pt-5 flex items-center justify-between">
-        <div>
-          <h2 className="text-2xl font-bold text-text-primary m-0">Skills</h2>
-          <p className="text-sm text-text-secondary mt-1">{t('center.skills.subtitle')}</p>
-        </div>
-        <div className="flex gap-2">
-          <div className="flex items-center gap-1.5 px-3.5 py-2 rounded-md bg-bg-input border border-border-subtle w-[220px]">
-            {Icons.search(14)}
-            <input
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder={t('center.skills.searchPlaceholder')}
-              className="bg-transparent outline-none text-sm text-text-primary placeholder:text-text-tertiary w-full"
-            />
-          </div>
+    <CenterPageLayout
+      /* Not run through i18n, unlike the three sibling pages — "Skills" is left
+         as-is here rather than silently introducing a key the locale files do
+         not have. */
+      title="Skills"
+      subtitle={t('center.skills.subtitle')}
+      actions={
+        <>
+          <SearchBox
+            value={query}
+            onChange={setQuery}
+            placeholder={t('center.skills.searchPlaceholder')}
+          />
           <Btn
             variant="primary"
             size="md"
@@ -536,40 +524,24 @@ export function CenterSkills() {
           >
             {Icons.download(14)} {t('center.skills.manualImport')}
           </Btn>
-        </div>
-      </div>
-
-      {/* Filter tabs — §LS1: flip only color/background, never the font weight or border width. */}
-      <div className="px-8 pt-4">
-        <div className="flex gap-1 p-1 rounded-md border border-border-subtle bg-bg-surface w-fit">
-          {SKILL_FILTER_KEYS.map((key) => (
-            <button
-              key={key}
-              type="button"
-              data-testid={`skill-filter-${key}`}
-              onClick={() => setFilter(key)}
-              className={cn(
-                'px-3 py-1 rounded-[5px] text-sm',
-                filter === key
-                  ? 'bg-bg-hover text-text-primary'
-                  : 'text-text-tertiary hover:text-text-secondary',
-              )}
-            >
-              {getSkillFilterLabel(t, key)}
-            </button>
-          ))}
-        </div>
-      </div>
-
-      <div className="flex-1 overflow-auto px-8 pt-4 pb-8">
-        <SkillsBody
-          state={hydrationState}
-          skills={visible}
-          onToggle={handleToggle}
-          onDelete={handleDelete}
+        </>
+      }
+      filters={
+        <FilterTabs
+          tabs={SKILL_FILTER_KEYS.map((key) => ({ key, label: getSkillFilterLabel(t, key) }))}
+          value={filter}
+          onChange={setFilter}
+          testIdPrefix="skill-filter-"
         />
-      </div>
-    </div>
+      }
+    >
+      <SkillsBody
+        state={hydrationState}
+        skills={visible}
+        onToggle={handleToggle}
+        onDelete={handleDelete}
+      />
+    </CenterPageLayout>
   )
 }
 
@@ -614,7 +586,7 @@ function runStatus(t: TFunction, run: WorkflowRunSummary): { label: string; tone
   if (run.status === 'paused') return { label: t('center.common.status.paused'), tone: 'bg-bg-hover text-text-tertiary' }
   if (run.status === 'cancelled') return { label: t('center.common.status.cancelled'), tone: 'bg-bg-hover text-text-tertiary' }
   if (run.status === 'waiting') return { label: t('center.common.status.waiting'), tone: 'bg-status-warning-bg text-status-warning' }
-  return { label: t('center.common.status.running'), tone: 'bg-accent-blue-subtle text-brand-blue' }
+  return { label: t('center.common.status.running'), tone: 'bg-accent-blue-subtle text-text-accent' }
 }
 
 function SessionFilesTable({
@@ -650,12 +622,12 @@ function SessionFilesTable({
             className="grid grid-cols-[minmax(0,1fr)_100px_110px_minmax(150px,220px)] items-center gap-3 border-t border-border-subtle px-4 py-2.5"
           >
             <div className="flex min-w-0 items-center gap-2.5">
-              <span className={cn('flex shrink-0', asset.exists ? 'text-brand-blue' : 'text-status-error')}>
+              <span className={cn('flex shrink-0', asset.exists ? 'text-text-accent' : 'text-status-error')}>
                 {asset.kind === 'folder' ? Icons.folder(17) : Icons.file(17)}
               </span>
               <span className="min-w-0">
                 <span className="block truncate text-sm font-medium text-text-primary">{asset.name}</span>
-                <span className="mt-0.5 block truncate font-mono text-[10px] text-text-tertiary">{asset.path}</span>
+                <span className="mt-0.5 block truncate font-mono text-2xs text-text-tertiary">{asset.path}</span>
               </span>
             </div>
             <span className={cn('text-xs', asset.exists ? 'text-text-secondary' : 'text-status-error')}>{mountSize(t, asset)}</span>
@@ -664,7 +636,7 @@ function SessionFilesTable({
             <button
               type="button"
               onClick={() => onOpenSession(asset.session_id)}
-              className="truncate text-left text-xs font-medium text-brand-blue hover:underline"
+              className="truncate text-left text-xs font-medium text-text-accent hover:underline"
             >
               {asset.session_title || asset.session_id}
             </button>
@@ -728,7 +700,7 @@ function WorkflowResultsTree({
               >
                 <span className="flex min-w-0 items-center gap-2.5">
                   <span className="shrink-0 text-text-tertiary">{open ? Icons.chevronDown(14) : Icons.chevronRight(14)}</span>
-                  <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-accent-blue-subtle text-brand-blue">{Icons.workflow(15)}</span>
+                  <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-accent-blue-subtle text-text-accent">{Icons.workflow(15)}</span>
                   <span className="truncate text-sm font-semibold text-text-primary">{group.workflowName}</span>
                 </span>
                 <span className="text-xs text-text-secondary">{t('center.assets.runs.runCount', { n: group.runs.length })}</span>
@@ -748,9 +720,9 @@ function WorkflowResultsTree({
                         <span className="block truncate text-sm font-medium text-text-primary">
                           <StructuredInput blocks={workflowRunInputBlocks(run)} />
                         </span>
-                        <span className="mt-0.5 block truncate font-mono text-[10px] text-text-tertiary">{run.id}</span>
+                        <span className="mt-0.5 block truncate font-mono text-2xs text-text-tertiary">{run.id}</span>
                       </span>
-                      <span className={cn('w-fit rounded-full px-2 py-0.5 text-[10px] font-semibold', status.tone)}>{status.label}</span>
+                      <span className={cn('w-fit rounded-full px-2 py-0.5 text-2xs font-semibold', status.tone)}>{status.label}</span>
                       <span className="font-mono text-xs text-text-secondary">{formatWorkflowRunShortTimestamp(run.created_at)}</span>
                     </button>
                     {run.status === 'completed' ? (
@@ -851,29 +823,27 @@ export function CenterAssets() {
   }
 
   return (
-    <div className="flex-1 flex flex-col overflow-hidden">
-      <div className="px-8 pt-5 flex items-center justify-between">
-        <div>
-          <h2 className="text-2xl font-bold text-text-primary m-0">{t('center.common.myAssets')}</h2>
-          <p className="text-sm text-text-secondary mt-1">{t('center.assets.subtitle')}</p>
-        </div>
-        <div className="flex items-center gap-2">
-          <label className="flex items-center gap-1.5 px-3.5 py-2 rounded-md bg-bg-input border border-border-subtle w-[260px]">
-            {Icons.search(14)}
-            <input
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              placeholder={t('center.assets.searchPlaceholder')}
-              className="w-full bg-transparent text-sm text-text-primary outline-none placeholder:text-text-tertiary"
-            />
-          </label>
-          <Btn variant="ghost" size="sm" onClick={() => void hydrate()}>{Icons.refresh(14)} {t('center.common.refresh')}</Btn>
-        </div>
-      </div>
-
-      <div className="flex-1 overflow-auto px-8 pt-5 pb-8">
+    <CenterPageLayout
+      title={t('center.common.myAssets')}
+      subtitle={t('center.assets.subtitle')}
+      actions={
+        <>
+          <SearchBox
+            value={query}
+            onChange={setQuery}
+            placeholder={t('center.assets.searchPlaceholder')}
+          />
+          {/* The page-level "loading" line only renders while there is nothing to
+              show (`sessionFiles.length === 0 && ...`) — deliberately, so a
+              refresh never blanks out content you are reading. That left the
+              button as the only place a refresh could be seen at all. */}
+          <RefreshButton onRefresh={hydrate} label={t('center.common.refresh')} />
+        </>
+      }
+    >
+      <>
         {hydrationState === 'loading' && sessionFiles.length === 0 && workflowRuns.length === 0 ? (
-          <div className="py-12 text-center text-sm text-text-tertiary">{t('center.assets.loading')}</div>
+          <EmptyState title={t('center.assets.loading')} />
         ) : null}
         {hydrationError ? (
           <div className="mb-4 flex items-center justify-between rounded-md bg-status-error-bg px-4 py-2.5 text-sm text-status-error">
@@ -900,7 +870,7 @@ export function CenterAssets() {
           })}
           onDeleteRun={(run) => void deleteWorkflowRun(run)}
         />
-      </div>
-    </div>
+      </>
+    </CenterPageLayout>
   )
 }

--- a/desktop/apps/electron/src/renderer/components/amphi/CompletedInteractionCard.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/CompletedInteractionCard.tsx
@@ -54,7 +54,7 @@ export function CompletedInteractionCard({ block, sessionId }: { block: Complete
             </div>
           </div>
           <div className="px-3.5 py-3.5">
-            <div className="mb-1 text-[11px] font-semibold text-text-tertiary">{t('session.interaction.card.newMessageLabel')}</div>
+            <div className="mb-1 text-xs font-semibold text-text-tertiary">{t('session.interaction.card.newMessageLabel')}</div>
             <MarkdownMessage content={block.response} className="text-sm leading-6 text-text-primary" />
           </div>
         </div>
@@ -65,7 +65,7 @@ export function CompletedInteractionCard({ block, sessionId }: { block: Complete
         return (
           <div className="max-w-xl overflow-hidden rounded-lg border border-brand-blue/30 bg-bg-elevated shadow-sm">
             <div className="flex items-center gap-2.5 px-3.5 py-3">
-              <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-accent-blue-subtle text-brand-blue">
+              <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-accent-blue-subtle text-text-accent">
                 {Icons.workflowResult(16)}
               </span>
               <div>
@@ -92,7 +92,7 @@ export function CompletedInteractionCard({ block, sessionId }: { block: Complete
         <div className="max-w-xl overflow-hidden rounded-lg border border-brand-blue/30 bg-bg-elevated shadow-sm">
           <div className="flex items-center justify-between gap-3 border-b border-border-subtle px-3.5 py-3">
             <div className="flex min-w-0 items-center gap-2.5">
-              <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-accent-blue-subtle text-brand-blue">
+              <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-accent-blue-subtle text-text-accent">
                 {Icons.workflowResult(16)}
               </span>
               <div>
@@ -100,14 +100,14 @@ export function CompletedInteractionCard({ block, sessionId }: { block: Complete
                 <div className="text-xs text-text-tertiary">{t('session.interaction.card.acceptanceDesc')}</div>
               </div>
             </div>
-            <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-status-success-bg px-2 py-1 text-[11px] font-semibold text-status-success">
+            <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-status-success-bg px-2 py-1 text-xs font-semibold text-status-success">
               {Icons.check(11)} {t('session.interaction.card.acceptanceCount', { n: rules.length })}
             </span>
           </div>
           <ol aria-label={t('session.interaction.card.acceptanceTitle')} className="max-h-[420px] divide-y divide-border-subtle overflow-y-auto">
             {rules.map((rule, index) => (
               <li key={rule.id} className="grid grid-cols-[64px_minmax(0,1fr)] gap-3 px-3.5 py-3.5">
-                <span className="mt-0.5 inline-flex h-6 items-center justify-center rounded-md bg-accent-blue-subtle px-2 text-[11px] font-semibold text-brand-blue">
+                <span className="mt-0.5 inline-flex h-6 items-center justify-center rounded-md bg-accent-blue-subtle px-2 text-xs font-semibold text-text-accent">
                   {t('session.interaction.card.ruleBadge', { n: index + 1 })}
                 </span>
                 <MarkdownMessage
@@ -165,7 +165,7 @@ export function CompletedInteractionCard({ block, sessionId }: { block: Complete
     return (
       <div className="max-w-xl overflow-hidden rounded-lg border border-border-subtle bg-bg-elevated shadow-sm">
         <div className="flex items-center gap-2.5 border-b border-border-subtle px-3.5 py-3">
-          <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-accent-blue-subtle text-brand-blue">
+          <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-accent-blue-subtle text-text-accent">
             {Icons.chat(15)}
           </span>
           <div>
@@ -182,14 +182,14 @@ export function CompletedInteractionCard({ block, sessionId }: { block: Complete
           <ol aria-label={t('session.interaction.card.qaListLabel')} className="divide-y divide-border-subtle">
             {pairs.map((pair, index) => (
               <li key={`${index}:${pair.question}`} className="grid grid-cols-[24px_minmax(0,1fr)] gap-3 px-3.5 py-3.5">
-                <span className="flex h-5 w-5 items-center justify-center rounded-full bg-bg-hover text-[10px] font-semibold text-text-secondary">
+                <span className="flex h-5 w-5 items-center justify-center rounded-full bg-bg-hover text-2xs font-semibold text-text-secondary">
                   {index + 1}
                 </span>
                 <div className="min-w-0">
-                  <div className="mb-1 text-[11px] font-semibold text-text-tertiary">{t('session.interaction.card.questionLabel')}</div>
+                  <div className="mb-1 text-xs font-semibold text-text-tertiary">{t('session.interaction.card.questionLabel')}</div>
                   <MarkdownMessage content={pair.question} className="text-sm leading-6 text-text-primary" />
                   <div className="mt-2.5 border-l-2 border-status-success pl-3">
-                    <div className="mb-1 flex items-center gap-1 text-[11px] font-semibold text-status-success">
+                    <div className="mb-1 flex items-center gap-1 text-xs font-semibold text-status-success">
                       {Icons.check(11)} {t('session.interaction.card.answerLabel')}
                     </div>
                     <MarkdownMessage content={pair.answer} className="text-sm leading-6 text-text-primary" />
@@ -209,7 +209,7 @@ export function CompletedInteractionCard({ block, sessionId }: { block: Complete
       <div className="max-w-xl overflow-hidden rounded-lg border border-border-subtle bg-bg-elevated shadow-sm">
         <div className="flex items-center justify-between gap-3 border-b border-border-subtle px-3.5 py-3">
           <div className="flex min-w-0 items-center gap-2.5">
-            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-accent-purple-subtle text-brand-purple">
+            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-accent-purple-subtle text-text-accent-purple">
               {Icons.workflow(15)}
             </span>
             <div className="min-w-0">
@@ -218,7 +218,7 @@ export function CompletedInteractionCard({ block, sessionId }: { block: Complete
             </div>
           </div>
           <span className={cn(
-            'inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-1 text-[11px] font-semibold',
+            'inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-1 text-xs font-semibold',
             cancelled ? 'bg-bg-hover text-text-tertiary' : 'bg-status-success-bg text-status-success',
           )}>
             {cancelled ? Icons.x(11) : Icons.check(11)}
@@ -241,7 +241,7 @@ export function CompletedInteractionCard({ block, sessionId }: { block: Complete
       <div className="max-w-xl overflow-hidden rounded-lg border border-border-subtle bg-bg-elevated shadow-sm">
         <div className="flex items-center justify-between gap-3 border-b border-border-subtle px-3.5 py-3">
           <div className="flex min-w-0 items-center gap-2.5">
-            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-accent-blue-subtle text-brand-blue">
+            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-accent-blue-subtle text-text-accent">
               {Icons.file(15)}
             </span>
             <div className="min-w-0">
@@ -250,7 +250,7 @@ export function CompletedInteractionCard({ block, sessionId }: { block: Complete
             </div>
           </div>
           <span className={cn(
-            'inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-1 text-[11px] font-semibold',
+            'inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-1 text-xs font-semibold',
             revised
               ? 'bg-status-warning-bg text-status-warning'
               : 'bg-status-success-bg text-status-success',
@@ -277,7 +277,7 @@ export function CompletedInteractionCard({ block, sessionId }: { block: Complete
     <div className="max-w-xl overflow-hidden rounded-lg border border-border-subtle bg-bg-elevated shadow-sm">
       <div className="flex items-center justify-between gap-3 px-3.5 py-3">
         <div className="flex min-w-0 items-center gap-2.5">
-          <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-accent-purple-subtle text-brand-purple">
+          <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-accent-purple-subtle text-text-accent-purple">
             {Icons.workflow(15)}
           </span>
           <div className="min-w-0">
@@ -286,7 +286,7 @@ export function CompletedInteractionCard({ block, sessionId }: { block: Complete
           </div>
         </div>
         <span className={cn(
-          'inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-1 text-[11px] font-semibold',
+          'inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-1 text-xs font-semibold',
           cancelled ? 'bg-bg-hover text-text-tertiary' : 'bg-status-success-bg text-status-success',
         )}>
           {cancelled ? Icons.x(11) : Icons.check(11)}

--- a/desktop/apps/electron/src/renderer/components/amphi/EmptyState.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/EmptyState.tsx
@@ -1,0 +1,57 @@
+/**
+ * The "nothing here" panel a center page shows in place of its list.
+ *
+ * Two shapes, chosen by whether an icon is given:
+ * - With an icon: the full empty state — a dashed circle, a heading, a line of
+ *   explanation, and optionally the action that would fill the page. The dashed
+ *   ring is the point: a solid tinted badge reads as a status, a dashed outline
+ *   reads as an empty slot.
+ * - Without one: a single centred line, for the transient "loading" / "failed"
+ *   notes that are not really empty states but need the same vertical rhythm.
+ *
+ * This replaced four hand-rolled versions that disagreed on every axis — 44px
+ * solid square vs 52px dashed circle vs no icon, py-8 vs py-12 vs py-20 vs
+ * h-full centring, 13px vs 16px headings.
+ */
+import type { ReactNode } from 'react'
+import { cn } from '@/lib/cn'
+
+export function EmptyState({
+  icon,
+  title,
+  description,
+  action,
+  tone = 'default',
+}: {
+  icon?: (size?: number) => ReactNode
+  title: ReactNode
+  description?: ReactNode
+  action?: ReactNode
+  /** 'error' paints the note red; it has no effect on the full, icon-bearing shape. */
+  tone?: 'default' | 'error'
+}) {
+  if (!icon) {
+    return (
+      <div
+        className={cn(
+          'py-12 text-center text-sm',
+          tone === 'error' ? 'text-status-error' : 'text-text-tertiary',
+        )}
+      >
+        {title}
+      </div>
+    )
+  }
+  return (
+    <div className="flex flex-col items-center justify-center py-20 text-center">
+      <div className="w-[52px] h-[52px] rounded-full border-[1.5px] border-dashed border-border-strong flex items-center justify-center text-text-tertiary mb-4">
+        {icon(22)}
+      </div>
+      <div className="text-lg font-semibold text-text-primary mb-1.5">{title}</div>
+      {description ? (
+        <div className="text-sm text-text-secondary max-w-[340px]">{description}</div>
+      ) : null}
+      {action ? <div className="mt-[18px]">{action}</div> : null}
+    </div>
+  )
+}

--- a/desktop/apps/electron/src/renderer/components/amphi/FileTreeView.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/FileTreeView.tsx
@@ -169,10 +169,10 @@ function TreeNodeRow({
           </span>
         </Tooltip>
         {node.unreadable && (
-          <span className="text-[10px] text-text-tertiary flex-shrink-0">{t('asset.tree.noPermission')}</span>
+          <span className="text-2xs text-text-tertiary flex-shrink-0">{t('asset.tree.noPermission')}</span>
         )}
         {node.sizeBytes !== null && (
-          <span className="text-[10px] text-text-tertiary flex-shrink-0">
+          <span className="text-2xs text-text-tertiary flex-shrink-0">
             {formatSize(node.sizeBytes)}
           </span>
         )}
@@ -206,7 +206,7 @@ function TreeNodeRow({
             }}
             aria-label={t('asset.tree.mention', { name: node.name })}
             // Always rendered, shown/hidden via opacity: it appears on hover without causing row-width jitter (§LS1).
-            className="w-4 text-center text-[11px] font-semibold text-brand-blue flex-shrink-0 opacity-0 group-hover/tree-row:opacity-100 transition-opacity"
+            className="w-4 text-center text-xs font-semibold text-text-accent flex-shrink-0 opacity-0 group-hover/tree-row:opacity-100 transition-opacity"
           >
             @
           </button>
@@ -284,14 +284,14 @@ function ExpandedBody({
   if (node.children === undefined) {
     return (
       <div className={shell}>
-        <div className="px-2 py-[5px] text-[10px] text-text-tertiary">{t('asset.common.loading')}</div>
+        <div className="px-2 py-[5px] text-2xs text-text-tertiary">{t('asset.common.loading')}</div>
       </div>
     )
   }
   if (node.children.length === 0) {
     return (
       <div className={shell}>
-        <div className="px-2 py-[5px] text-[10px] text-text-tertiary">{t('asset.common.emptyFolder')}</div>
+        <div className="px-2 py-[5px] text-2xs text-text-tertiary">{t('asset.common.emptyFolder')}</div>
       </div>
     )
   }

--- a/desktop/apps/electron/src/renderer/components/amphi/FileTreeView.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/FileTreeView.tsx
@@ -230,8 +230,14 @@ interface TreeRowMenuDropdownProps {
 /** Child-row ⋯ dropdown: copy path / reveal in file manager (no "remove" — see the props comment). */
 function TreeRowMenuDropdown({ node, menu }: TreeRowMenuDropdownProps) {
   const { t } = useTranslation()
+  /* hover is --bg-active, one step stronger than the --bg-hover used by list
+     rows: a dropdown is a point-and-click decision, so the row under the
+     cursor has to be unmistakable. The container is --bg-elevated, not
+     --bg-input — in the light theme bg-input (#F2F3F7) is *darker* than
+     bg-hover (#F5F6F9), so hovering used to lighten the row instead of
+     darkening it, at 1.03:1. That is why the highlight was invisible. */
   const itemCls =
-    'w-full text-left px-2.5 py-1.5 text-xs text-text-secondary hover:text-text-primary hover:bg-bg-hover'
+    'w-full text-left px-2.5 py-1.5 text-xs text-text-secondary hover:text-text-primary hover:bg-bg-active'
   return (
     <>
       <div
@@ -241,7 +247,7 @@ function TreeRowMenuDropdown({ node, menu }: TreeRowMenuDropdownProps) {
           menu.onToggle(node.relPath)
         }}
       />
-      <div className="absolute right-1 top-full -mt-1 z-50 min-w-[168px] rounded-md border border-border-default bg-bg-input shadow-md py-1">
+      <div className="absolute right-1 top-full -mt-1 z-50 min-w-[168px] rounded-md border border-border-default bg-bg-elevated shadow-md py-1">
         <button
           type="button"
           onClick={(e) => {

--- a/desktop/apps/electron/src/renderer/components/amphi/FileTreeView.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/FileTreeView.tsx
@@ -21,6 +21,7 @@ import type { DirTreeNode } from '@shared/dir-tree'
 import { cn } from '@/lib/cn'
 import { extColor, formatSize } from '@/lib/fileTree'
 import { Icons } from './Icons'
+import { RowActionMenu } from './RowActionMenu'
 import { Tooltip } from './Tooltip'
 import { WindowedList } from './WindowedList'
 
@@ -230,46 +231,14 @@ interface TreeRowMenuDropdownProps {
 /** Child-row ⋯ dropdown: copy path / reveal in file manager (no "remove" — see the props comment). */
 function TreeRowMenuDropdown({ node, menu }: TreeRowMenuDropdownProps) {
   const { t } = useTranslation()
-  /* hover is --bg-active, one step stronger than the --bg-hover used by list
-     rows: a dropdown is a point-and-click decision, so the row under the
-     cursor has to be unmistakable. The container is --bg-elevated, not
-     --bg-input — in the light theme bg-input (#F2F3F7) is *darker* than
-     bg-hover (#F5F6F9), so hovering used to lighten the row instead of
-     darkening it, at 1.03:1. That is why the highlight was invisible. */
-  const itemCls =
-    'w-full text-left px-2.5 py-1.5 text-xs text-text-secondary hover:text-text-primary hover:bg-bg-active'
   return (
-    <>
-      <div
-        className="fixed inset-0 z-40"
-        onClick={(e) => {
-          e.stopPropagation()
-          menu.onToggle(node.relPath)
-        }}
-      />
-      <div className="absolute right-1 top-full -mt-1 z-50 min-w-[168px] rounded-md border border-border-default bg-bg-elevated shadow-md py-1">
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation()
-            menu.onCopyPath(node)
-          }}
-          className={itemCls}
-        >
-          {t('asset.common.copyPath')}
-        </button>
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation()
-            menu.onReveal(node)
-          }}
-          className={itemCls}
-        >
-          {t('asset.common.revealInFileManager')}
-        </button>
-      </div>
-    </>
+    <RowActionMenu
+      onDismiss={() => menu.onToggle(node.relPath)}
+      items={[
+        { label: t('asset.common.copyPath'), onSelect: () => menu.onCopyPath(node) },
+        { label: t('asset.common.revealInFileManager'), onSelect: () => menu.onReveal(node) },
+      ]}
+    />
   )
 }
 

--- a/desktop/apps/electron/src/renderer/components/amphi/FilterTabs.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/FilterTabs.tsx
@@ -1,0 +1,64 @@
+/**
+ * Segmented filter control — the row of tabs that sits above a list view and
+ * narrows it (Skills' source tiers, Schedules' all/active/paused). Shared by
+ * those two views, which were hand-written copies that had drifted apart on
+ * padding, size, weight, selected background and unselected colour all at once.
+ *
+ * Not to be confused with two neighbours that stay separate on purpose:
+ * - `Primitives.TabBar` is the underlined tab strip inside modals — a different
+ *   visual language, not a variant of this one.
+ * - The pill filters in `RightPanel` / `WorkbenchToolPrimitives` invert to a
+ *   solid `--text-primary` fill; also a different language.
+ *
+ * The rules it holds:
+ * - Selected reads as --bg-selected, the one selected-state token used app-wide
+ *   (sidebar nav, session rows, mention menu, mode pill, tool rail). Retune that
+ *   token rather than reaching for --bg-hover or --bg-active here.
+ * - Unselected is --text-secondary, never --text-tertiary. Selection is shown by
+ *   the selected item gaining a background, not by the others being dimmed.
+ * - The font weight never changes between states (§LS1). Going 400→600 widens
+ *   CJK glyphs, which pushes every later tab in the group — and the count
+ *   parentheses after them — sideways on each selection.
+ */
+import { cn } from '@/lib/cn'
+
+export interface FilterTab<K extends string> {
+  key: K
+  label: string
+  /** Rendered as "(n)" after the label. Omit for filters that show no count. */
+  count?: number
+}
+
+export function FilterTabs<K extends string>({
+  tabs,
+  value,
+  onChange,
+  testIdPrefix,
+}: {
+  tabs: readonly FilterTab<K>[]
+  value: K
+  onChange: (key: K) => void
+  testIdPrefix: string
+}) {
+  return (
+    <div className="flex gap-1 p-1 rounded-md border border-border-subtle bg-bg-surface w-fit">
+      {tabs.map((tab) => (
+        <button
+          key={tab.key}
+          type="button"
+          data-testid={`${testIdPrefix}${tab.key}`}
+          onClick={() => onChange(tab.key)}
+          className={cn(
+            'px-3 py-1 rounded-[5px] text-sm',
+            tab.key === value
+              ? 'bg-bg-selected text-text-primary'
+              : 'text-text-secondary hover:text-text-primary',
+          )}
+        >
+          {tab.label}
+          {tab.count === undefined ? null : <span className="ml-1">({tab.count})</span>}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/desktop/apps/electron/src/renderer/components/amphi/Landing.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/Landing.tsx
@@ -95,7 +95,7 @@ function LandingInput({ needsModelConfig, onConfigureModel, inputSlot }: Landing
           used to have cursor:pointer but no onClick, so clicking did nothing and misled users; it has been removed. */}
       <div className="flex-1">
         <div className="text-md text-text-tertiary leading-[1.6]">
-          {t('landing.inputHint.before')}<span className="text-brand-blue">/build</span>{t('landing.inputHint.after')}
+          {t('landing.inputHint.before')}<span className="text-text-accent">/build</span>{t('landing.inputHint.after')}
         </div>
       </div>
       <div className="flex items-center gap-1.5">
@@ -212,7 +212,7 @@ function WorkflowMarket({ cards, onPick }: WorkflowMarketProps) {
             onClick={() => onPick?.(c)}
           >
             <div className="flex items-start justify-between mb-2.5">
-              <div className="w-9 h-9 rounded-md bg-accent-blue-subtle flex items-center justify-center text-brand-blue">
+              <div className="w-9 h-9 rounded-md bg-accent-blue-subtle flex items-center justify-center text-text-accent">
                 {Icons.workflow(18)}
               </div>
               {c.status === 'verified' && <Badge color="success">{t('landing.market.verified')}</Badge>}

--- a/desktop/apps/electron/src/renderer/components/amphi/LeftSidebar.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/LeftSidebar.tsx
@@ -26,6 +26,7 @@ import { backendStateAtom } from '@/atoms/backend'
 import { BackendState } from '../../../main/python-client/types'
 import { cn } from '@/lib/cn'
 import { Icons } from './Icons'
+import { NavItem } from './NavItem'
 import { Tooltip } from './Tooltip'
 import { WindowedList } from './WindowedList'
 import { SettingsTabId } from './Modals'
@@ -187,27 +188,17 @@ export function LeftSidebar({
       </div>
 
       {/* Nav items — these change the CENTER content, not the sidebar itself */}
-      <div className="pt-2 px-2 flex flex-col gap-px">
-        {navItems.map((m) => {
-          const active = activeNav === m.id
-          return (
-            <div
-              key={m.id}
-              data-testid={`nav-${m.id}`}
-              onClick={() => onSelectNav?.(m.id)}
-              className={cn(
-                'flex items-center gap-2.5 px-2.5 py-[7px] rounded-md cursor-pointer',
-                active ? 'bg-bg-hover text-text-primary' : 'bg-transparent text-text-secondary',
-              )}
-            >
-              <span className={cn('flex items-center flex-shrink-0', active ? 'opacity-100' : 'opacity-60')}>
-                {m.icon(16)}
-              </span>
-              <span className={cn('flex-1 text-sm', active ? 'font-semibold' : 'font-normal')}>{t(m.labelKey)}</span>
-              <span className="text-text-tertiary opacity-50">{Icons.chevronRight(14)}</span>
-            </div>
-          )
-        })}
+      <div className="pt-2 px-2 flex flex-col gap-0.5">
+        {navItems.map((m) => (
+          <NavItem
+            key={m.id}
+            testId={`nav-${m.id}`}
+            icon={m.icon}
+            label={t(m.labelKey)}
+            active={activeNav === m.id}
+            onClick={() => onSelectNav?.(m.id)}
+          />
+        ))}
       </div>
 
       <Divider style={{ margin: '6px 12px' }} />
@@ -215,8 +206,8 @@ export function LeftSidebar({
       {/* Session list label */}
       <div className="px-2">
         <div className="flex items-center justify-between px-1.5 pt-1 pb-1.5">
-          <span className="text-xs font-semibold text-text-tertiary uppercase tracking-[0.5px]">{t('sidebar.sessions')}</span>
-          <span className="text-[10px] text-text-tertiary">{sessions.length}</span>
+          <span className="text-xs font-semibold text-text-secondary uppercase tracking-[0.5px]">{t('sidebar.sessions')}</span>
+          <span className="text-2xs text-text-tertiary">{sessions.length}</span>
         </div>
       </div>
 
@@ -272,7 +263,7 @@ export function LeftSidebar({
             >
               {Icons.bell(16)}
               {pendingCount > 0 && (
-                <span className="absolute -top-0.5 -right-0.5 min-w-[15px] h-[15px] px-1 rounded-full bg-status-warning text-white text-[9px] font-bold flex items-center justify-center leading-none">
+                <span className="absolute -top-0.5 -right-0.5 min-w-[15px] h-[15px] px-1 rounded-full bg-status-warning text-white text-2xs font-bold flex items-center justify-center leading-none">
                   {pendingCount}
                 </span>
               )}

--- a/desktop/apps/electron/src/renderer/components/amphi/MessageThinking.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/MessageThinking.tsx
@@ -34,7 +34,7 @@ export function MessageThinking({ thinking, streaming = false }: MessageThinking
     <div>
       <div className="mb-1.5 flex items-center gap-1.5 text-text-secondary">
         {Icons.lightbulb(13)}
-        <span className="text-[11px] font-semibold tracking-[0.3px]">{t('message.thinking')}</span>
+        <span className="text-xs font-semibold tracking-[0.3px]">{t('message.thinking')}</span>
       </div>
       <StickyScroll
         active={streaming}

--- a/desktop/apps/electron/src/renderer/components/amphi/MessageToolCall.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/MessageToolCall.tsx
@@ -72,7 +72,7 @@ export function MessageToolCall({ call }: MessageToolCallProps) {
 function ToolSection({ label, body, error }: { label: string; body: string; error?: boolean }) {
   return (
     <div className="min-w-0">
-      <div className="text-[0.7rem] uppercase tracking-wide text-text-tertiary mb-1">{label}</div>
+      <div className="text-xs uppercase tracking-wide text-text-tertiary mb-1">{label}</div>
       <pre
         className={cn(
           // max-h + overflow-auto: tool inputs/results can be very long (reading a whole file, big JSON),

--- a/desktop/apps/electron/src/renderer/components/amphi/Modals.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/Modals.tsx
@@ -75,6 +75,7 @@ import type { ShowcaseWorkflow } from '@/lib/showcaseClient'
 import { rlog } from '@/lib/logger'
 import { EmbeddedShowcasePage } from './EmbeddedShowcasePage'
 import { Icons } from './Icons'
+import { NavItem } from './NavItem'
 import { Tooltip } from './Tooltip'
 import { Modal } from './Modal'
 import { ModalBackdrop } from './ModalBackdrop'
@@ -184,25 +185,18 @@ export function SettingsModal({
             <span className="text-lg font-bold text-text-primary">{t('modals.settings.title')}</span>
           </div>
           <div className="flex-1 px-2 flex flex-col gap-0.5">
-            {tabs.map((tab) => {
-              const active = activeTabId === tab.id
-              return (
-                <div
-                  key={tab.id}
-                  data-testid={`tab-${tab.label}`}
-                  onClick={() => handleTabSwitch(tab.id)}
-                  className={cn(
-                    'flex items-center gap-2.5 px-3 py-2.5 rounded-md cursor-pointer',
-                    active
-                      ? 'bg-bg-hover text-text-primary'
-                      : 'text-text-secondary hover:text-text-primary',
-                  )}
-                >
-                  <span className={cn('flex', active ? 'opacity-100' : 'opacity-60')}>{tab.icon(16)}</span>
-                  <span className={cn('text-sm', active && 'font-semibold')}>{tab.label}</span>
-                </div>
-              )
-            })}
+            {tabs.map((tab) => (
+              <NavItem
+                key={tab.id}
+                testId={`tab-${tab.label}`}
+                icon={tab.icon}
+                label={tab.label}
+                active={activeTabId === tab.id}
+                onClick={() => {
+                  void handleTabSwitch(tab.id)
+                }}
+              />
+            ))}
           </div>
         </div>
 
@@ -512,7 +506,7 @@ function OfficialShield() {
   const { t } = useTranslation()
   return (
     <Tooltip content={t('modals.model.official')}>
-      <span className="flex text-brand-blue">
+      <span className="flex text-text-accent">
       <svg width="13" height="13" viewBox="0 0 16 16" fill="none">
         <path
           d="M8 1.5l5 2v4c0 3-2.2 5.2-5 6.5-2.8-1.3-5-3.5-5-6.5v-4l5-2z"
@@ -617,7 +611,7 @@ function ModelAddStep1({
                     <span
                       className={cn(
                         'text-sm font-semibold',
-                        selected ? 'text-brand-blue' : 'text-text-primary',
+                        selected ? 'text-text-accent' : 'text-text-primary',
                       )}
                     >
                       {getProviderCatalogDisplayName(p, t)}
@@ -633,7 +627,7 @@ function ModelAddStep1({
                   </div>
                 </div>
                 {hasOAuth && (
-                  <span className="text-[10px] text-text-tertiary whitespace-nowrap">
+                  <span className="text-2xs text-text-tertiary whitespace-nowrap">
                     {t('modals.model.step1.supportsSubscription')}
                   </span>
                 )}
@@ -646,7 +640,7 @@ function ModelAddStep1({
       {/* Custom protocols — Phase 2: the backend no longer requires provider_id to be in the catalog, so
           these two cards are clickable and lead to a form with an empty slug + empty base_url + empty models for the user to fill in. */}
       <SectionLabel>{t('modals.model.step1.customProtocol')}</SectionLabel>
-      <div className="text-[11px] text-text-tertiary mb-2">
+      <div className="text-xs text-text-tertiary mb-2">
         {t('modals.model.step1.customProtocolDesc')}
       </div>
       <div className="grid grid-cols-2 gap-2.5">
@@ -686,7 +680,7 @@ function ModelAddStep1({
                 <span
                   className={cn(
                     'text-sm font-semibold',
-                    selected ? 'text-brand-blue' : 'text-text-primary',
+                    selected ? 'text-text-accent' : 'text-text-primary',
                   )}
                 >
                   {p.name}
@@ -718,7 +712,7 @@ function ModelAddStep1({
 /** Small grey uppercase heading, used for the sections of Step1 / Step2. A uniform spec from the design. */
 function SectionLabel({ children }: { children: React.ReactNode }) {
   return (
-    <div className="text-[11px] font-semibold text-text-tertiary uppercase tracking-[0.3px] mb-2">
+    <div className="text-xs font-semibold text-text-tertiary uppercase tracking-[0.3px] mb-2">
       {children}
     </div>
   )
@@ -995,7 +989,7 @@ function CodexOAuthBody({
         <button
           type="button"
           onClick={handleAuthorize}
-          className="text-[11px] text-text-tertiary hover:text-text-secondary cursor-pointer self-start"
+          className="text-xs text-text-tertiary hover:text-text-secondary cursor-pointer self-start"
         >
           {t('modals.model.oauth.useDifferentAccount')}
         </button>
@@ -1441,7 +1435,7 @@ function ChannelCredentialForm({
           <label className="text-xs font-semibold text-text-secondary block mb-1.5">Base URL</label>
           {/* Preview row: the normalised host + the SDK's own suffix, rendered only when non-empty. */}
           {normalizedBaseUrl && (
-            <div className="text-[11px] text-text-tertiary mb-1.5 break-all">
+            <div className="text-xs text-text-tertiary mb-1.5 break-all">
               {t('modals.model.form.preview')}
               <span className="font-mono text-text-secondary">
                 {normalizedBaseUrl}
@@ -1482,7 +1476,7 @@ function ChannelCredentialForm({
       {/* Test-result feedback row — right above the footer, with a fixed height to avoid layout jumps.
           Positionally it hugs the "test connection" button so the user's eye lands on the result right after clicking. */}
       <div
-        className="mt-4 text-[11px] leading-[1.5] min-h-[16px] text-right"
+        className="mt-4 text-xs leading-[1.5] min-h-[16px] text-right"
         data-testid="test-result"
       >
         {testState.kind === 'pristine' && (
@@ -1568,7 +1562,7 @@ function ProtocolRadio({
         <div
           className={cn(
             'text-sm font-semibold',
-            selected ? 'text-brand-blue' : 'text-text-primary',
+            selected ? 'text-text-accent' : 'text-text-primary',
           )}
         >
           {title}
@@ -2059,7 +2053,7 @@ function SettingsGatewayTab() {
   }
 
   return (
-    <div className="p-5">
+    <div>
       <div className="text-sm text-text-secondary mb-4">
         {t('modals.gateway.description', { product: APP_PRODUCT_NAME })}
       </div>
@@ -2409,7 +2403,7 @@ function SettingsAppearanceTab() {
             >
               <div>
                 <div className="text-sm font-medium text-text-primary">{opt.label}</div>
-                <div className="text-xs text-text-secondary mt-0.5">{opt.desc}</div>
+                <div className="text-sm text-text-secondary mt-0.5">{opt.desc}</div>
               </div>
               {active && <Badge color="brand">{t('common.inUse')}</Badge>}
             </div>
@@ -2539,7 +2533,7 @@ function SettingsZoomRow() {
             type="button"
             disabled={level === 0}
             onClick={() => setLevel(0)}
-            className="ml-1 rounded-md px-2 py-1 text-xs font-medium text-brand-blue disabled:cursor-not-allowed disabled:opacity-40"
+            className="ml-1 rounded-md px-2 py-1 text-xs font-medium text-text-accent disabled:cursor-not-allowed disabled:opacity-40"
           >
             {t('settings.appearance.zoom.reset')}
           </button>
@@ -2723,7 +2717,7 @@ export function EditFieldModal({ field, title, hasChange = false, onClose }: Edi
                 {field === EditFieldKind.Task && t('modals.editField.rematchDomain')}
               </div>
               <div className="mt-2.5 text-xs font-mono leading-[1.8]">
-                <div className="text-status-error line-through opacity-70">- {data.original.split('\n')[0]}</div>
+                <div className="text-status-error line-through">- {data.original.split('\n')[0]}</div>
                 <div className="text-status-success">+ {data.edited.split('\n')[0]}</div>
               </div>
             </div>

--- a/desktop/apps/electron/src/renderer/components/amphi/MountRow.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/MountRow.tsx
@@ -26,6 +26,7 @@ import {
   type WatchedLevel,
 } from '@/atoms/mounts'
 import { Icons } from './Icons'
+import { RowActionMenu } from './RowActionMenu'
 import { Tooltip } from './Tooltip'
 import { FileTreeView, type TreeRowMenu } from './FileTreeView'
 
@@ -42,15 +43,6 @@ function mountMeta(m: MountSummary, tree: DirListResult | undefined, t: TFunctio
   if (m.kind === 'folder') return tree?.ok ? t('asset.mount.itemCount', { n: tree.nodes.length }) : ''
   return formatSize(m.size_bytes ?? 0)
 }
-
-/* hover is --bg-active, one step stronger than the --bg-hover used by list
-   rows: a dropdown is a point-and-click decision, so the row under the
-   cursor has to be unmistakable. The container is --bg-elevated, not
-   --bg-input — in the light theme bg-input (#F2F3F7) is *darker* than
-   bg-hover (#F5F6F9), so hovering used to lighten the row instead of
-   darkening it, at 1.03:1. That is why the highlight was invisible. */
-const MENU_ITEM_CLS =
-  'w-full text-left px-2.5 py-1.5 text-xs text-text-secondary hover:text-text-primary hover:bg-bg-active'
 
 export interface MountRowProps {
   mount: MountSummary
@@ -225,55 +217,28 @@ export function MountRow({
           {Icons.dots(14)}
         </button>
         {menuOpen && (
-          <>
-            <div
-              className="fixed inset-0 z-40"
-              onClick={(e) => {
-                e.stopPropagation()
-                onMenuToggle()
-              }}
-            />
-            <div className="absolute right-1 top-full -mt-1 z-50 min-w-[168px] rounded-md border border-border-default bg-bg-elevated shadow-md py-1">
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.stopPropagation()
-                  onCopyPath()
-                }}
-                className={MENU_ITEM_CLS}
-              >
-                {t('asset.common.copyPath')}
-              </button>
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.stopPropagation()
-                  onOpenInFileManager()
-                }}
-                className={MENU_ITEM_CLS}
-              >
-                {t('asset.common.revealInFileManager')}
-              </button>
-              {onRemove && (
-                <>
-                  <div className="my-1 h-px bg-border-subtle" />
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      onRemove()
-                    }}
-                    className="w-full text-left px-2.5 py-1.5 text-xs text-status-error hover:bg-bg-hover"
-                  >
-                    {t('asset.mount.remove')}
-                    <span className="block text-2xs text-text-tertiary">
-                      {t('asset.mount.removeHint')}
-                    </span>
-                  </button>
-                </>
-              )}
-            </div>
-          </>
+          <RowActionMenu
+            onDismiss={onMenuToggle}
+            items={[
+              { label: t('asset.common.copyPath'), onSelect: onCopyPath },
+              { label: t('asset.common.revealInFileManager'), onSelect: onOpenInFileManager },
+              ...(onRemove
+                ? [{
+                  label: (
+                    <>
+                      {t('asset.mount.remove')}
+                      <span className="block text-2xs text-text-tertiary">
+                        {t('asset.mount.removeHint')}
+                      </span>
+                    </>
+                  ),
+                  onSelect: onRemove,
+                  tone: 'danger' as const,
+                  separated: true,
+                }]
+                : []),
+            ]}
+          />
         )}
         <button
           type="button"

--- a/desktop/apps/electron/src/renderer/components/amphi/MountRow.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/MountRow.tsx
@@ -200,7 +200,7 @@ export function MountRow({
             {m.name}
           </span>
         </Tooltip>
-        <span className="text-[10px] text-text-tertiary flex-shrink-0">{mountMeta(m, tree, t)}</span>
+        <span className="text-2xs text-text-tertiary flex-shrink-0">{mountMeta(m, tree, t)}</span>
         <button
           type="button"
           onClick={(e) => {
@@ -260,7 +260,7 @@ export function MountRow({
                     className="w-full text-left px-2.5 py-1.5 text-xs text-status-error hover:bg-bg-hover"
                   >
                     {t('asset.mount.remove')}
-                    <span className="block text-[10px] text-text-tertiary">
+                    <span className="block text-2xs text-text-tertiary">
                       {t('asset.mount.removeHint')}
                     </span>
                   </button>
@@ -278,7 +278,7 @@ export function MountRow({
             onMentionRoot()
           }}
           aria-label={t('asset.common.addToChat', { name: m.name })}
-          className="w-4 text-center text-[11px] font-semibold text-brand-blue flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity"
+          className="w-4 text-center text-xs font-semibold text-text-accent flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity"
         >
           @
         </button>
@@ -317,7 +317,7 @@ export interface MountSubtreeProps {
   menu: TreeRowMenu
 }
 
-const SUBTREE_MSG_CLS = 'ml-[13px] pl-[3px] px-2 py-[5px] text-[10px]'
+const SUBTREE_MSG_CLS = 'ml-[13px] pl-[3px] px-2 py-[5px] text-2xs'
 
 /** Why a folder level couldn't be read. `denied` is the only one the user can
  *  act on, so it carries the fix instead of a generic failure line: on macOS a
@@ -351,7 +351,7 @@ function MountSubtree({ tree, expanded, onToggle, onMention, onOpen, absPathOf, 
   return (
     <div className="ml-[13px] pl-[3px] border-l border-border-subtle">
       {tree.nodes.length === 0 ? (
-        <div className="px-2 py-[5px] text-[10px] text-text-tertiary">{t('asset.common.emptyFolder')}</div>
+        <div className="px-2 py-[5px] text-2xs text-text-tertiary">{t('asset.common.emptyFolder')}</div>
       ) : (
         <FileTreeView
           nodes={tree.nodes}

--- a/desktop/apps/electron/src/renderer/components/amphi/MountRow.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/MountRow.tsx
@@ -43,8 +43,14 @@ function mountMeta(m: MountSummary, tree: DirListResult | undefined, t: TFunctio
   return formatSize(m.size_bytes ?? 0)
 }
 
+/* hover is --bg-active, one step stronger than the --bg-hover used by list
+   rows: a dropdown is a point-and-click decision, so the row under the
+   cursor has to be unmistakable. The container is --bg-elevated, not
+   --bg-input — in the light theme bg-input (#F2F3F7) is *darker* than
+   bg-hover (#F5F6F9), so hovering used to lighten the row instead of
+   darkening it, at 1.03:1. That is why the highlight was invisible. */
 const MENU_ITEM_CLS =
-  'w-full text-left px-2.5 py-1.5 text-xs text-text-secondary hover:text-text-primary hover:bg-bg-hover'
+  'w-full text-left px-2.5 py-1.5 text-xs text-text-secondary hover:text-text-primary hover:bg-bg-active'
 
 export interface MountRowProps {
   mount: MountSummary
@@ -227,7 +233,7 @@ export function MountRow({
                 onMenuToggle()
               }}
             />
-            <div className="absolute right-1 top-full -mt-1 z-50 min-w-[168px] rounded-md border border-border-default bg-bg-input shadow-md py-1">
+            <div className="absolute right-1 top-full -mt-1 z-50 min-w-[168px] rounded-md border border-border-default bg-bg-elevated shadow-md py-1">
               <button
                 type="button"
                 onClick={(e) => {

--- a/desktop/apps/electron/src/renderer/components/amphi/NavItem.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/NavItem.tsx
@@ -1,0 +1,60 @@
+/**
+ * One row of a vertical navigation list — icon, label, selected state. Shared by
+ * the left sidebar's top-level nav and the settings dialog's tab rail; the two
+ * were hand-maintained copies of each other and drifted apart twice.
+ *
+ * It exists to hold three rules, every one of which was a real regression:
+ *
+ * - Selection is the background plus the weight. The label never fades — a nav
+ *   row is a primary entry point and reads at full strength either way. Dimming
+ *   the unselected rows is what made this list "hard to read" in the first place.
+ * - The selected background is --bg-selected, the one token every selected
+ *   surface in the app shares (session rows, mention menu, mode pill, the tool
+ *   rail, FilterTabs). Do not substitute --bg-hover or --bg-active here: both
+ *   were tried, the first vanished (1.08:1 in light) and the second read as
+ *   heavy. Retune the token, not the call site.
+ * - The icon runs large and light (18px at --text-tertiary), never small and
+ *   dark. Icons only need 3:1, and a thin glyph in a 7:1 grey reads as sharp
+ *   beside 13px text. Never an opacity: it multiplies against whatever sits
+ *   behind the element and escapes the contrast scale entirely.
+ *
+ * Deliberately NOT used for the session rows, the mention menu or the mode pill.
+ * Their highlight means "the keyboard cursor is here", not "this is the current
+ * section" — same pixels, different concept, and merging them would be the wrong
+ * abstraction.
+ */
+import type { ReactNode } from 'react'
+import { cn } from '@/lib/cn'
+
+/** Fixed so the size cannot drift per call site — see the icon rule above. */
+const ICON_SIZE = 18
+
+export function NavItem({
+  icon,
+  label,
+  active,
+  onClick,
+  testId,
+}: {
+  icon: (size?: number) => ReactNode
+  label: string
+  active: boolean
+  onClick: () => void
+  testId: string
+}) {
+  return (
+    <div
+      data-testid={testId}
+      onClick={onClick}
+      className={cn(
+        'flex items-center gap-2.5 px-3 py-2.5 rounded-md cursor-pointer text-text-primary',
+        active ? 'bg-bg-selected' : 'hover:bg-bg-hover',
+      )}
+    >
+      <span className={cn('flex items-center flex-shrink-0', active ? 'text-text-primary' : 'text-text-tertiary')}>
+        {icon(ICON_SIZE)}
+      </span>
+      <span className={cn('flex-1 text-sm', active ? 'font-semibold' : 'font-normal')}>{label}</span>
+    </div>
+  )
+}

--- a/desktop/apps/electron/src/renderer/components/amphi/Pipeline.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/Pipeline.tsx
@@ -443,7 +443,7 @@ export function Pipeline({ messages: legacyMessages, session, enableMessageActio
             {(hiddenCount > 0 || serverHasMore) && (
               <div
                 ref={topSentinelRef}
-                className="px-2 py-[5px] text-center text-[10px] text-text-tertiary"
+                className="px-2 py-[5px] text-center text-2xs text-text-tertiary"
               >
                 {hiddenCount > 0
                   ? t('session.pipeline.loadEarlierWithCount', { n: hiddenCount })
@@ -958,7 +958,7 @@ function MessageCompletionBar({
   }
   return (
     <div
-      className="flex w-fit select-none flex-wrap items-center gap-x-1.5 gap-y-0.5 text-[11px] leading-5 text-text-tertiary tabular-nums"
+      className="flex w-fit select-none flex-wrap items-center gap-x-1.5 gap-y-0.5 text-xs leading-5 text-text-tertiary tabular-nums"
       aria-label={t('session.pipeline.generationInfoAria')}
     >
       {metrics.map((metric, index) => (
@@ -1010,9 +1010,9 @@ function AgentActivityIndicator({
           <span />
         </span>
       ) : (
-        <span className="flex shrink-0 text-brand-blue" aria-hidden="true">{Icons.chat(13)}</span>
+        <span className="flex shrink-0 text-text-accent" aria-hidden="true">{Icons.chat(13)}</span>
       )}
-      <span className="shrink-0 font-medium text-brand-blue">{label}</span>
+      <span className="shrink-0 font-medium text-text-accent">{label}</span>
       <ActiveElapsedTime startedAt={startedAt} />
     </div>
   )
@@ -1078,7 +1078,7 @@ function ModelRetryIndicator({
   const { t } = useTranslation()
   return (
     <div
-      className="inline-flex items-center gap-2 rounded-md bg-accent-blue-subtle px-2.5 py-1.5 text-xs text-brand-blue"
+      className="inline-flex items-center gap-2 rounded-md bg-accent-blue-subtle px-2.5 py-1.5 text-xs text-text-accent"
       role="status"
       aria-label={t('session.pipeline.reconnectingAria', { attempt: retry.attempt, max: retry.maxRetries })}
     >

--- a/desktop/apps/electron/src/renderer/components/amphi/Primitives.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/Primitives.tsx
@@ -156,7 +156,7 @@ const badgeStyles = cva(
         error: 'bg-status-error-bg text-status-error',
         warning: 'bg-status-warning-bg text-status-warning',
         info: 'bg-status-info-bg text-status-info',
-        brand: 'bg-accent-blue-subtle text-brand-blue',
+        brand: 'bg-accent-blue-subtle text-text-accent',
       },
     },
     defaultVariants: { color: 'default' },

--- a/desktop/apps/electron/src/renderer/components/amphi/ProcessTimeline.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/ProcessTimeline.tsx
@@ -126,7 +126,7 @@ export function ProcessTimeline({ blocks, streaming = false, defaultOpen = false
           {Icons.chevronRight(13)}
         </span>
         <span className="whitespace-nowrap text-xs font-medium text-text-secondary">{t('session.timeline.title')}</span>
-        <span className="whitespace-nowrap text-[11px] text-text-tertiary">
+        <span className="whitespace-nowrap text-xs text-text-tertiary">
           {t('session.timeline.summary.calls', { n: countToolCalls(blocks) })} · {t('session.timeline.summary.messages', { n: countMessages(blocks) })}
           {workflowSteps > 0 ? ` · ${t('session.timeline.summary.steps', { n: workflowSteps })}` : null}
           {confirmations > 0 ? ` · ${t('session.timeline.summary.confirmations', { n: confirmations })}` : null}
@@ -376,7 +376,7 @@ function CompletedInteractionRow({ block, sessionId }: { block: CompletedInterac
         </span>
         <span className="shrink-0 font-medium text-text-secondary">{label}</span>
         {detail && <span className="min-w-0 flex-1 truncate text-text-tertiary">{detail}</span>}
-        <span className="ml-auto flex shrink-0 items-center gap-1 text-[11px] text-text-tertiary group-hover:text-text-secondary">
+        <span className="ml-auto flex shrink-0 items-center gap-1 text-xs text-text-tertiary group-hover:text-text-secondary">
           {open ? t('session.interaction.hideRecord') : t('session.interaction.showRecord')}
           <span className={cn('transition-transform duration-200', open && 'rotate-90')}>
             {Icons.chevronRight(11)}

--- a/desktop/apps/electron/src/renderer/components/amphi/RefreshButton.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/RefreshButton.tsx
@@ -1,0 +1,50 @@
+/**
+ * The "refresh" action in a center page's header, with the spin that makes it
+ * legible.
+ *
+ * The problem it solves: a local daemon usually answers in tens of milliseconds,
+ * so clearing the pending flag the moment the promise settles let the icon turn
+ * a few degrees and stop. That reads as a twitch, not as a refresh — worse than
+ * no feedback, because something moved and said nothing. Racing the work against
+ * MIN_SPIN_MS guarantees at least one full revolution; slower requests still
+ * spin for as long as they actually take, since Promise.all waits for both.
+ *
+ * Kept as the refresh arrow rather than a neutral spinner: a turning refresh
+ * glyph states which operation is running, where a bare ring only says "busy".
+ */
+import { useState } from 'react'
+import { cn } from '@/lib/cn'
+import { Btn } from './Primitives'
+import { Icons } from './Icons'
+
+/** One period of Tailwind's `animate-spin`, so the icon always lands where it started. */
+const MIN_SPIN_MS = 1000
+
+export function RefreshButton({
+  onRefresh,
+  label,
+  testId,
+}: {
+  onRefresh: () => Promise<unknown>
+  label: string
+  testId?: string
+}) {
+  const [spinning, setSpinning] = useState(false)
+
+  const handleClick = async () => {
+    if (spinning) return
+    setSpinning(true)
+    await Promise.all([
+      onRefresh(),
+      new Promise((resolve) => setTimeout(resolve, MIN_SPIN_MS)),
+    ])
+    setSpinning(false)
+  }
+
+  return (
+    <Btn variant="default" size="md" data-testid={testId} onClick={() => void handleClick()}>
+      <span className={cn('flex', spinning && 'animate-spin')}>{Icons.refresh(14)}</span>
+      {label}
+    </Btn>
+  )
+}

--- a/desktop/apps/electron/src/renderer/components/amphi/ReportIssueDialog.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/ReportIssueDialog.tsx
@@ -438,7 +438,7 @@ function ReportIssueDialogBody({ request }: { request: IssueReportRequestSnapsho
               <div className="text-xs font-semibold text-text-primary">
                 {t('issueReport.fileMode.exportedTitle')}
               </div>
-              <div className="mt-1 break-all font-mono text-[11px] leading-relaxed text-text-tertiary">
+              <div className="mt-1 break-all font-mono text-xs leading-relaxed text-text-tertiary">
                 {exportedPath}
               </div>
               <button
@@ -607,7 +607,7 @@ function ReportIssueDialogBody({ request }: { request: IssueReportRequestSnapsho
                 </div>
               )}
 
-              <div className="mt-3 flex items-start gap-1.5 text-[11px] leading-relaxed text-text-tertiary">
+              <div className="mt-3 flex items-start gap-1.5 text-xs leading-relaxed text-text-tertiary">
                 <ShieldCheck size={12} strokeWidth={1.8} className="mt-0.5 shrink-0" aria-hidden="true" />
                 {t(fileMode
                   ? 'issueReport.advanced.filePrivacyNotice'

--- a/desktop/apps/electron/src/renderer/components/amphi/RightPanel.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/RightPanel.tsx
@@ -275,7 +275,7 @@ export function RightPanel({
             )}
           >
             {c.label}
-            {c.count !== undefined && <span className="ml-1 opacity-60">{c.count}</span>}
+            {c.count !== undefined && <span className="ml-1">{c.count}</span>}
           </button>
         ))}
       </div>
@@ -372,7 +372,7 @@ export function BuildingCard({ fields = {} }: { fields?: BuildingFields }) {
               >
                 {f.label}
               </span>
-              {filled && f.editable && <span className="text-brand-blue">{Icons.edit(12)}</span>}
+              {filled && f.editable && <span className="text-text-accent">{Icons.edit(12)}</span>}
               {filled && !f.editable && <span className="text-text-tertiary">{Icons.eye(12)}</span>}
             </div>
           )
@@ -397,7 +397,7 @@ export function CompletedCard({
       <div className="px-3.5 py-3">
         <div className="flex items-center justify-between mb-2">
           <div className="flex items-center gap-2">
-            <div className="w-7 h-7 rounded-md bg-accent-purple-subtle flex items-center justify-center text-brand-purple">
+            <div className="w-7 h-7 rounded-md bg-accent-purple-subtle flex items-center justify-center text-text-accent-purple">
               {Icons.workflow(14)}
             </div>
             <div>
@@ -414,7 +414,7 @@ export function CompletedCard({
                   e.stopPropagation()
                   onPreview?.()
                 }}
-                className="flex items-center justify-center w-6 h-6 rounded-sm text-text-tertiary hover:bg-bg-hover hover:text-brand-blue"
+                className="flex items-center justify-center w-6 h-6 rounded-sm text-text-tertiary hover:bg-bg-hover hover:text-text-accent"
               >
                 {Icons.eye(14)}
               </button>
@@ -463,14 +463,14 @@ export function WorkflowRunResultCard({
       <div className="px-3.5 py-3">
         <div className="flex items-start justify-between gap-2">
           <div className="flex min-w-0 items-center gap-2">
-            <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-accent-blue-subtle text-brand-blue">
+            <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-accent-blue-subtle text-text-accent">
               {Icons.file(14)}
             </div>
             <div className="min-w-0">
               <div className="truncate text-sm font-semibold text-text-primary">
                 {run.workflow_name}
               </div>
-              <div className="mt-0.5 text-[11px] text-text-tertiary">
+              <div className="mt-0.5 text-xs text-text-tertiary">
                 {formatWorkflowRunShortTimestamp(run.finished_at ?? run.created_at, i18n.language)}
               </div>
             </div>
@@ -482,7 +482,7 @@ export function WorkflowRunResultCard({
                 event.stopPropagation()
                 onPreview?.()
               }}
-              className="flex h-6 w-6 shrink-0 items-center justify-center rounded-sm text-text-tertiary hover:bg-bg-hover hover:text-brand-blue"
+              className="flex h-6 w-6 shrink-0 items-center justify-center rounded-sm text-text-tertiary hover:bg-bg-hover hover:text-text-accent"
             >
               {Icons.eye(14)}
             </button>

--- a/desktop/apps/electron/src/renderer/components/amphi/RowActionMenu.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/RowActionMenu.tsx
@@ -1,0 +1,78 @@
+/**
+ * The ⋯ dropdown hanging off a list row — session files, mount roots, asset
+ * search hits. Three byte-identical copies existed; the highlight bug that
+ * prompted this extraction was present in all three at once, which is the
+ * argument for having one.
+ *
+ * Two colour decisions live here and should not be "unified" away:
+ *
+ * - The container is --bg-elevated, NOT --bg-input. In the light theme
+ *   bg-input (#F2F3F7) is *darker* than bg-hover (#F5F6F9), so a hover fill on
+ *   an input-coloured panel lightens the row instead of darkening it — 1.03:1,
+ *   invisible. Elevated puts the fill on the correct side in both themes.
+ * - Hover is --bg-active, a step stronger than the --bg-hover that list rows
+ *   use. A dropdown is a point-and-click decision: the row under the cursor
+ *   has to be unmistakable, where a list row only needs to feel alive.
+ *
+ * What it deliberately does NOT own: closing. `onDismiss` fires only for the
+ * outside-click scrim; whether picking an item also closes the menu is left to
+ * each caller, because the callbacks reach different owners (FileTreeView's
+ * arrive from MountRow, which gets them from SessionAssets) and some of those
+ * are toggles that would reopen the menu if fired twice.
+ */
+import type { ReactNode } from 'react'
+import { cn } from '@/lib/cn'
+
+export interface RowActionMenuItem {
+  label: ReactNode
+  onSelect: () => void
+  /** Destructive actions read in the error colour. */
+  tone?: 'danger'
+  /** Draws a divider above this item, to set destructive actions apart. */
+  separated?: boolean
+}
+
+export function RowActionMenu({
+  items,
+  onDismiss,
+}: {
+  items: RowActionMenuItem[]
+  onDismiss: () => void
+}) {
+  return (
+    <>
+      {/* Outside click closes. stopPropagation keeps it from bubbling to the row
+          underneath and triggering that row's own click (e.g. "open file"). */}
+      <div
+        className="fixed inset-0 z-40"
+        onClick={(event) => {
+          event.stopPropagation()
+          onDismiss()
+        }}
+      />
+      <div className="absolute right-1 top-full -mt-1 z-50 min-w-[168px] rounded-md border border-border-default bg-bg-elevated shadow-md py-1">
+        {items.map((item, index) => (
+          // key is the index: label is a ReactNode, and the item list is static for a given row.
+          <div key={index}>
+            {item.separated ? <div className="my-1 h-px bg-border-subtle" /> : null}
+            <button
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation()
+                item.onSelect()
+              }}
+              className={cn(
+                'w-full text-left px-2.5 py-1.5 text-xs hover:bg-bg-active',
+                item.tone === 'danger'
+                  ? 'text-status-error'
+                  : 'text-text-secondary hover:text-text-primary',
+              )}
+            >
+              {item.label}
+            </button>
+          </div>
+        ))}
+      </div>
+    </>
+  )
+}

--- a/desktop/apps/electron/src/renderer/components/amphi/SearchBox.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/SearchBox.tsx
@@ -1,0 +1,38 @@
+/**
+ * The search field in a center page's header. One width, one markup shape.
+ *
+ * It is a <label>, not a <div>: wrapping the icon and the input means clicking
+ * anywhere in the box focuses the field. Skills used a <div> and quietly lost
+ * that — the icon was dead to the pointer.
+ */
+import { cn } from '@/lib/cn'
+import { Icons } from './Icons'
+
+export function SearchBox({
+  value,
+  onChange,
+  placeholder,
+  className,
+}: {
+  value: string
+  onChange: (value: string) => void
+  placeholder: string
+  className?: string
+}) {
+  return (
+    <label
+      className={cn(
+        'flex items-center gap-1.5 px-3.5 py-2 rounded-md bg-bg-input border border-border-subtle w-[220px]',
+        className,
+      )}
+    >
+      {Icons.search(14)}
+      <input
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        className="w-full bg-transparent text-sm text-text-primary outline-none placeholder:text-text-tertiary"
+      />
+    </label>
+  )
+}

--- a/desktop/apps/electron/src/renderer/components/amphi/SearchHighlight.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/SearchHighlight.tsx
@@ -43,7 +43,7 @@ export function Highlighted({ text, ranges }: HighlightedProps) {
   ranges.forEach(([s, e], i) => {
     if (s > cursor) parts.push(text.slice(cursor, s))
     parts.push(
-      <mark key={i} className="bg-accent-blue-subtle text-brand-blue rounded-[3px] px-px">
+      <mark key={i} className="bg-accent-blue-subtle text-text-accent rounded-[3px] px-px">
         {text.slice(s, e)}
       </mark>,
     )

--- a/desktop/apps/electron/src/renderer/components/amphi/SessionAssets.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/SessionAssets.tsx
@@ -182,7 +182,7 @@ export function SessionAssetsPanel({
             type="button"
             onClick={() => setAddOpen((o) => !o)}
             disabled={!sessionId}
-            className="inline-flex items-center gap-0.5 text-xs text-brand-blue hover:opacity-80 disabled:opacity-40"
+            className="inline-flex items-center gap-0.5 text-xs text-text-accent hover:opacity-80 disabled:opacity-40"
             aria-expanded={addOpen}
           >
             {Icons.plus(12)}

--- a/desktop/apps/electron/src/renderer/components/amphi/SessionAssetsSearch.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/SessionAssetsSearch.tsx
@@ -26,6 +26,7 @@ import type { MountSummary } from '@/lib/amphiClient'
 import { requestMentionInsertAtom } from '@/atoms/mounts'
 import { requestFileOpenAtom } from '@/atoms/fileOpen'
 import { Icons } from './Icons'
+import { RowActionMenu } from './RowActionMenu'
 import { Tooltip } from './Tooltip'
 import { Highlighted, hitCrumbRanges, hitSizeLabel, noMatchText } from './SearchHighlight'
 
@@ -189,52 +190,30 @@ interface HitRowMenuProps {
 }
 
 /** ⋯ dropdown on a hit row: copy path / reveal in file manager (no "remove" — see the file header).
- *  Structurally a word-for-word counterpart of `FileTreeView :: TreeRowMenuDropdown`, so both look alike. */
+ *  Chrome and colours come from `RowActionMenu`; this used to be a hand-kept copy
+ *  of `FileTreeView :: TreeRowMenuDropdown` and the two drifted together. */
 function HitRowMenu({ abs, onCopyPath, onReveal, onClose }: HitRowMenuProps) {
   const { t } = useTranslation()
-  /* hover is --bg-active, one step stronger than the --bg-hover used by list
-     rows: a dropdown is a point-and-click decision, so the row under the
-     cursor has to be unmistakable. The container is --bg-elevated, not
-     --bg-input — in the light theme bg-input (#F2F3F7) is *darker* than
-     bg-hover (#F5F6F9), so hovering used to lighten the row instead of
-     darkening it, at 1.03:1. That is why the highlight was invisible. */
-  const itemCls =
-    'w-full text-left px-2.5 py-1.5 text-xs text-text-secondary hover:text-text-primary hover:bg-bg-active'
   return (
-    <>
-      {/* Close on outside click. stopPropagation keeps it from bubbling to the row and triggering "open file". */}
-      <div
-        className="fixed inset-0 z-40"
-        onClick={(e) => {
-          e.stopPropagation()
-          onClose()
-        }}
-      />
-      <div className="absolute right-1 top-full -mt-1 z-50 min-w-[168px] rounded-md border border-border-default bg-bg-elevated shadow-md py-1">
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation()
+    <RowActionMenu
+      onDismiss={onClose}
+      items={[
+        {
+          label: t('asset.common.copyPath'),
+          onSelect: () => {
             onClose()
             onCopyPath(abs)
-          }}
-          className={itemCls}
-        >
-          {t('asset.common.copyPath')}
-        </button>
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation()
+          },
+        },
+        {
+          label: t('asset.common.revealInFileManager'),
+          onSelect: () => {
             onClose()
             onReveal(abs)
-          }}
-          className={itemCls}
-        >
-          {t('asset.common.revealInFileManager')}
-        </button>
-      </div>
-    </>
+          },
+        },
+      ]}
+    />
   )
 }
 

--- a/desktop/apps/electron/src/renderer/components/amphi/SessionAssetsSearch.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/SessionAssetsSearch.tsx
@@ -192,8 +192,14 @@ interface HitRowMenuProps {
  *  Structurally a word-for-word counterpart of `FileTreeView :: TreeRowMenuDropdown`, so both look alike. */
 function HitRowMenu({ abs, onCopyPath, onReveal, onClose }: HitRowMenuProps) {
   const { t } = useTranslation()
+  /* hover is --bg-active, one step stronger than the --bg-hover used by list
+     rows: a dropdown is a point-and-click decision, so the row under the
+     cursor has to be unmistakable. The container is --bg-elevated, not
+     --bg-input — in the light theme bg-input (#F2F3F7) is *darker* than
+     bg-hover (#F5F6F9), so hovering used to lighten the row instead of
+     darkening it, at 1.03:1. That is why the highlight was invisible. */
   const itemCls =
-    'w-full text-left px-2.5 py-1.5 text-xs text-text-secondary hover:text-text-primary hover:bg-bg-hover'
+    'w-full text-left px-2.5 py-1.5 text-xs text-text-secondary hover:text-text-primary hover:bg-bg-active'
   return (
     <>
       {/* Close on outside click. stopPropagation keeps it from bubbling to the row and triggering "open file". */}
@@ -204,7 +210,7 @@ function HitRowMenu({ abs, onCopyPath, onReveal, onClose }: HitRowMenuProps) {
           onClose()
         }}
       />
-      <div className="absolute right-1 top-full -mt-1 z-50 min-w-[168px] rounded-md border border-border-default bg-bg-input shadow-md py-1">
+      <div className="absolute right-1 top-full -mt-1 z-50 min-w-[168px] rounded-md border border-border-default bg-bg-elevated shadow-md py-1">
         <button
           type="button"
           onClick={(e) => {

--- a/desktop/apps/electron/src/renderer/components/amphi/SessionAssetsSearch.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/SessionAssetsSearch.tsx
@@ -120,13 +120,13 @@ export function SessionAssetsSearch({
                   <Highlighted text={h.name} ranges={h.nameRanges} />
                 </div>
                 {h.crumb.length > 0 && (
-                  <div className="text-[10px] text-text-tertiary truncate">
+                  <div className="text-2xs text-text-tertiary truncate">
                     <Highlighted text={h.crumb.join(' / ')} ranges={hitCrumbRanges(h)} />
                   </div>
                 )}
               </div>
             </Tooltip>
-            <span className="text-[10px] text-text-tertiary flex-shrink-0">{hitSizeLabel(h)}</span>
+            <span className="text-2xs text-text-tertiary flex-shrink-0">{hitSizeLabel(h)}</span>
             {abs && (
               <button
                 type="button"
@@ -169,7 +169,7 @@ export function SessionAssetsSearch({
                 })
               }}
               aria-label={t('asset.common.addToChat', { name: h.name })}
-              className="w-4 text-center text-[11px] font-semibold text-brand-blue flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity"
+              className="w-4 text-center text-xs font-semibold text-text-accent flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity"
             >
               @
             </button>
@@ -249,7 +249,7 @@ function SearchResultFooter({ hitCount, total, partial }: SearchResultFooterProp
   const capped = total > hitCount
   if (!partial && !capped) return null
   return (
-    <div className="px-2 pt-2 flex flex-col gap-0.5 text-[10px]">
+    <div className="px-2 pt-2 flex flex-col gap-0.5 text-2xs">
       {capped && (
         <span className="text-text-tertiary">
           {t('asset.search.capped', { total, shown: hitCount })}

--- a/desktop/apps/electron/src/renderer/components/amphi/SessionRow.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/SessionRow.tsx
@@ -159,7 +159,11 @@ export function SessionRow({
       onClick={onSelect}
       className={cn(
         'group flex items-center gap-2 px-2 py-[9px] rounded-md cursor-pointer relative',
-        active ? 'bg-bg-selected' : 'bg-transparent',
+        /* Same pair as NavItem above the divider — the sidebar is one list, so a
+           session row answers the pointer the way a nav row does. Only the
+           three-dot button used to react on hover, which made the row itself
+           read as static text rather than something clickable. */
+        active ? 'bg-bg-selected' : 'bg-transparent hover:bg-bg-hover',
       )}
     >
       {depth > 0 && (

--- a/desktop/apps/electron/src/renderer/components/amphi/SessionRow.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/SessionRow.tsx
@@ -159,7 +159,7 @@ export function SessionRow({
       onClick={onSelect}
       className={cn(
         'group flex items-center gap-2 px-2 py-[9px] rounded-md cursor-pointer relative',
-        active ? 'bg-bg-hover' : 'bg-transparent',
+        active ? 'bg-bg-selected' : 'bg-transparent',
       )}
     >
       {depth > 0 && (
@@ -193,7 +193,7 @@ export function SessionRow({
         >
           {session.title}
         </div>
-        {session.stage && <div className="text-xs text-brand-blue mt-0.5">{session.stage}</div>}
+        {session.stage && <div className="text-xs text-text-accent mt-0.5">{session.stage}</div>}
       </div>
       {childCount > 0 && (
         <button
@@ -203,7 +203,7 @@ export function SessionRow({
             event.stopPropagation()
             onToggleChildren?.()
           }}
-          className="flex shrink-0 items-center gap-0.5 text-[10px] text-text-tertiary hover:text-text-secondary"
+          className="flex shrink-0 items-center gap-0.5 text-2xs text-text-tertiary hover:text-text-secondary"
         >
           {!expanded && backgroundChildStatus && (
             <AgentStatusIndicator {...backgroundChildStatus} />

--- a/desktop/apps/electron/src/renderer/components/amphi/SettingsAboutTab.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/SettingsAboutTab.tsx
@@ -45,6 +45,7 @@ import {
 import { rlog } from '@/lib/logger'
 import wechatQrUrl from '@/assets/wechat-group-qr.png'
 import { Btn, Card } from './Primitives'
+import { SettingsTabLayout } from './SettingsTabLayout'
 
 /** What the update row is currently saying. */
 type UpdateRowState =
@@ -140,7 +141,7 @@ export function SettingsAboutTab({ onRequestClose }: SettingsAboutTabProps) {
   }
 
   return (
-    <div className="p-5 flex flex-col gap-3">
+    <SettingsTabLayout>
       <Card className="p-0 divide-y divide-border-subtle">
         {/* One version, not two. `scripts/release-manifest.ts` refuses to build
             when the desktop and backend versions differ, so a separate "core
@@ -256,7 +257,7 @@ export function SettingsAboutTab({ onRequestClose }: SettingsAboutTabProps) {
       <div className="text-xs text-text-tertiary px-1">
         © {COPYRIGHT_YEAR} {COPYRIGHT_HOLDER}
       </div>
-    </div>
+    </SettingsTabLayout>
   )
 }
 
@@ -273,7 +274,7 @@ function AboutRow({ label, description, children }: AboutRowProps) {
       <div className="min-w-0">
         <div className="text-sm text-text-primary">{label}</div>
         {description && (
-          <div className="text-xs text-text-secondary mt-0.5 leading-relaxed">{description}</div>
+          <div className="text-sm text-text-secondary mt-0.5 leading-relaxed">{description}</div>
         )}
       </div>
       {children && <div className="flex-shrink-0">{children}</div>}
@@ -349,7 +350,7 @@ function LinkRow({ testId, label, text, href, copyValue }: LinkRowProps) {
           type="button"
           data-testid={`about-link-${testId}`}
           onClick={open}
-          className="inline-flex cursor-pointer items-center gap-1.5 text-xs font-medium text-brand-blue hover:underline focus-visible:underline focus-visible:outline-none"
+          className="inline-flex cursor-pointer items-center gap-1.5 text-sm font-medium text-text-accent hover:underline focus-visible:underline focus-visible:outline-none"
         >
           {text}
           {copyValue === undefined && <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />}
@@ -403,7 +404,7 @@ function WechatRow() {
           data-testid="about-wechat-toggle"
           aria-expanded={open}
           onClick={() => setOpen((prev) => !prev)}
-          className="inline-flex flex-shrink-0 cursor-pointer items-center gap-1.5 text-xs font-medium text-brand-blue hover:underline focus-visible:underline focus-visible:outline-none"
+          className="inline-flex flex-shrink-0 cursor-pointer items-center gap-1.5 text-sm font-medium text-text-accent hover:underline focus-visible:underline focus-visible:outline-none"
         >
           {open ? t('modals.about.contactWechatHide') : t('modals.about.contactWechatShow')}
           <ChevronDown

--- a/desktop/apps/electron/src/renderer/components/amphi/SettingsPrivacyTab.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/SettingsPrivacyTab.tsx
@@ -2,6 +2,7 @@ import { useAtomValue } from 'jotai'
 import { CircleCheck, ExternalLink, LockKeyhole, ShieldCheck } from 'lucide-react'
 import { type ReactNode, useId } from 'react'
 import { useTranslation } from 'react-i18next'
+import { SettingsTabLayout } from './SettingsTabLayout'
 import { APP_PRIVACY_NOTICE_URL, APP_PRODUCT_NAME } from '@shared/app-meta'
 import { settingsAtom } from '@/atoms/settings'
 import { useUpdateSettings } from '@/hooks/useSettingsBridge'
@@ -32,9 +33,9 @@ export function SettingsPrivacyTab() {
   }
 
   return (
-    <div className="flex flex-col gap-4">
+    <SettingsTabLayout>
       <section>
-        <h2 className="text-base font-semibold text-text-primary">
+        <h2 className="text-sm font-semibold text-text-primary">
           {t('settings.privacy.telemetry.sectionTitle', { product: APP_PRODUCT_NAME })}
         </h2>
         <p id={purposeId} className="mt-1 text-sm leading-[1.6] text-text-secondary">
@@ -63,7 +64,7 @@ export function SettingsPrivacyTab() {
                 </span>
                 <span
                   aria-live="polite"
-                  className={optedIn ? 'text-xs font-semibold text-brand-blue' : 'text-xs text-text-tertiary'}
+                  className={optedIn ? 'text-xs font-semibold text-text-accent' : 'text-xs text-text-tertiary'}
                 >
                   {t(optedIn
                     ? 'settings.privacy.telemetry.statusOn'
@@ -84,7 +85,7 @@ export function SettingsPrivacyTab() {
       </section>
 
       <section className="flex items-start gap-3 px-1 py-1">
-        <ShieldCheck className="mt-0.5 h-5 w-5 shrink-0 text-brand-blue" aria-hidden="true" />
+        <ShieldCheck className="mt-0.5 h-5 w-5 shrink-0 text-text-accent" aria-hidden="true" />
         <div>
           <h2 className="text-sm font-semibold text-text-primary">
             {t('settings.privacy.localFirst.title')}
@@ -102,7 +103,7 @@ export function SettingsPrivacyTab() {
           </h2>
         </div>
         <PrivacySummaryRow
-          icon={<CircleCheck className="h-4 w-4 text-brand-blue" />}
+          icon={<CircleCheck className="h-4 w-4 text-text-accent" />}
           title={t('settings.privacy.telemetry.sharedTitle')}
           description={t('settings.privacy.telemetry.sharedSummary')}
         />
@@ -112,7 +113,7 @@ export function SettingsPrivacyTab() {
           description={t('settings.privacy.telemetry.excludedSummary')}
         />
         <div className="border-t border-border-subtle bg-bg-hover px-4 py-3">
-          <p className="text-xs leading-[1.6] text-text-secondary">
+          <p className="text-sm leading-[1.6] text-text-secondary">
             {t('settings.privacy.use.description')}
           </p>
         </div>
@@ -124,13 +125,13 @@ export function SettingsPrivacyTab() {
           type="button"
           data-testid="privacy-notice-link"
           onClick={openPrivacyNotice}
-          className="inline-flex cursor-pointer items-center gap-1.5 text-xs font-medium text-brand-blue hover:underline focus-visible:underline focus-visible:outline-none"
+          className="inline-flex cursor-pointer items-center gap-1.5 text-sm font-medium text-text-accent hover:underline focus-visible:underline focus-visible:outline-none"
         >
           {t('settings.privacy.notice.label')}
           <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
         </button>
       </div>
-    </div>
+    </SettingsTabLayout>
   )
 }
 
@@ -145,11 +146,11 @@ function PrivacySummaryRow({
 }) {
   return (
     <div className="grid grid-cols-[112px_minmax(0,1fr)] gap-3 border-t border-border-subtle px-4 py-3">
-      <div className="flex items-center gap-2 text-xs font-semibold text-text-primary">
+      <div className="flex items-center gap-2 text-sm font-semibold text-text-primary">
         <span aria-hidden="true">{icon}</span>
         <h3>{title}</h3>
       </div>
-      <p className="text-xs leading-[1.6] text-text-secondary">{description}</p>
+      <p className="text-sm leading-[1.6] text-text-secondary">{description}</p>
     </div>
   )
 }

--- a/desktop/apps/electron/src/renderer/components/amphi/SettingsTabLayout.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/SettingsTabLayout.tsx
@@ -1,0 +1,20 @@
+/**
+ * Root container for one settings tab's content.
+ *
+ * The dialog around it already fixes the frame (`px-6 py-5` header, then a
+ * `px-6 pb-6` scroll area), so a tab only owns the rhythm between its own
+ * sections. That was the part that had drifted: gap-4 here, gap-3 there,
+ * hand-written mb-3 / mb-4 somewhere else — and About wrapped everything in an
+ * extra `p-5`, which stacked on the dialog's own padding and indented that one
+ * tab 20px further than its neighbours. Switching tabs moved the content.
+ *
+ * Only the container is shared. The tabs' insides stay their own: a model form,
+ * a gateway status readout and a contact list have nothing structural in common,
+ * and forcing them through one shape would be an abstraction that has to be
+ * fought rather than used.
+ */
+import type { ReactNode } from 'react'
+
+export function SettingsTabLayout({ children }: { children: ReactNode }) {
+  return <div className="flex flex-col gap-4">{children}</div>
+}

--- a/desktop/apps/electron/src/renderer/components/amphi/SkillConflictRow.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/SkillConflictRow.tsx
@@ -65,37 +65,37 @@ function ConflictVersionPanel({
   return (
     <div className="flex-1 min-w-0 flex flex-col rounded-md overflow-hidden border border-border-subtle bg-bg-elevated">
       <div className="flex items-center gap-1.5 px-2.5 py-[5px] bg-bg-hover text-text-tertiary">
-        <span className="text-[10px] font-bold tracking-[0.02em]">{label}</span>
-        <span className="text-[10px] font-medium opacity-80">· {sub}</span>
+        <span className="text-2xs font-bold tracking-[0.02em]">{label}</span>
+        <span className="text-2xs font-medium opacity-80">· {sub}</span>
       </div>
       <div className="flex flex-col gap-2 flex-1 px-[11px] py-[9px]">
         <div className="flex items-center gap-1.5">
           <span className={cn('flex shrink-0', newer ? 'text-status-success' : 'text-text-tertiary')}>
             {Icons.clock(13)}
           </span>
-          <span className="text-[11px] font-mono text-text-secondary">{formatUpdatedAt(time)}</span>
+          <span className="text-xs font-mono text-text-secondary">{formatUpdatedAt(time)}</span>
           {newer && (
-            <span className="text-[9.5px] font-bold text-status-success bg-status-success-bg px-1.5 py-0.5 rounded-full">
+            <span className="text-2xs font-bold text-status-success bg-status-success-bg px-1.5 py-0.5 rounded-full">
               {t('skill.conflict.newer')}
             </span>
           )}
         </div>
         <div
           ref={descRef}
-          className={cn('text-[11px] leading-[1.55] text-text-secondary', !expanded && 'line-clamp-4')}
+          className={cn('text-xs leading-[1.55] text-text-secondary', !expanded && 'line-clamp-4')}
         >
           {desc ?? '—'}
         </div>
         <div className="flex items-center gap-2 mt-auto">
           {descChanged && (
-            <span className="inline-flex items-center gap-1 text-[9.5px] font-semibold text-brand-blue">
+            <span className="inline-flex items-center gap-1 text-2xs font-semibold text-text-accent">
               {Icons.edit(10)} {t('skill.conflict.descChanged')}
             </span>
           )}
           {clamped && (
             <button
               type="button"
-              className="ml-auto text-[10px] font-semibold text-brand-blue"
+              className="ml-auto text-2xs font-semibold text-text-accent"
               onClick={(e) => {
                 e.stopPropagation()
                 onToggleDesc()
@@ -162,9 +162,9 @@ export function ConflictResolveRow({ name, incoming, existing, accept, onPick }:
           expanded={expanded}
           onToggleDesc={toggleDesc}
         />
-        <div className="shrink-0 w-12 flex flex-col items-center justify-center gap-1 self-center text-brand-blue">
+        <div className="shrink-0 w-12 flex flex-col items-center justify-center gap-1 self-center text-text-accent">
           {Icons.chevronRight(22)}
-          <span className="text-[9px] font-bold whitespace-nowrap">{t('skill.conflict.overwrite')}</span>
+          <span className="text-2xs font-bold whitespace-nowrap">{t('skill.conflict.overwrite')}</span>
         </div>
         <ConflictVersionPanel
           label={t('skill.conflict.existing')}

--- a/desktop/apps/electron/src/renderer/components/amphi/SkillImportModal.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/SkillImportModal.tsx
@@ -196,7 +196,7 @@ export function SkillImportModal({ onClose }: { onClose?: () => void }) {
       {error && <div className="px-6 text-xs text-status-error">{error}</div>}
 
       {step === Step.Review && newerSkipped > 0 && (
-        <div className="px-6 pt-2 flex items-center gap-2 text-[11px] text-text-secondary">
+        <div className="px-6 pt-2 flex items-center gap-2 text-xs text-text-secondary">
           <span className="flex shrink-0 text-text-tertiary">{Icons.clock(13)}</span>
           <Trans
             i18nKey="skill.import.modal.newerSkipped"
@@ -205,7 +205,7 @@ export function SkillImportModal({ onClose }: { onClose?: () => void }) {
           />
           <button
             type="button"
-            className="font-semibold text-brand-blue"
+            className="font-semibold text-text-accent"
             onClick={() => batchConflicts(true)}
           >
             {t('skill.import.review.replaceAll')}

--- a/desktop/apps/electron/src/renderer/components/amphi/SkillImportPick.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/SkillImportPick.tsx
@@ -76,7 +76,7 @@ function RemoteSourceHint({ source }: { source: SkillRemoteSource | null }) {
     return (
       <div className="flex items-center gap-1.5 mb-[18px]">
         <span className="text-status-success">{Icons.check(13)}</span>
-        <span className="text-[11px] text-text-secondary">
+        <span className="text-xs text-text-secondary">
           <Trans i18nKey="skill.import.pick.recognized" values={{ source: label }} components={{ b: <strong className="text-text-primary" /> }} />
         </span>
       </div>
@@ -89,7 +89,7 @@ function RemoteSourceHint({ source }: { source: SkillRemoteSource | null }) {
   return (
     <div className="flex items-center gap-1.5 mb-[18px]">
       <span className="text-status-warning">{Icons.xCircle(13)}</span>
-      <span className="text-[11px] text-text-secondary">{message}</span>
+      <span className="text-xs text-text-secondary">{message}</span>
     </div>
   )
 }
@@ -128,7 +128,7 @@ export function ImportPickStep({
 
       {method === ImportMethod.Local ? (
         <div className="border-[1.5px] border-dashed border-border-strong rounded-lg px-6 py-9 text-center bg-bg-hover">
-          <div className="w-12 h-12 rounded-md bg-accent-blue-subtle text-brand-blue flex items-center justify-center mx-auto mb-3.5">
+          <div className="w-12 h-12 rounded-md bg-accent-blue-subtle text-text-accent flex items-center justify-center mx-auto mb-3.5">
             {Icons.folder(24)}
           </div>
           <div className="text-md font-semibold text-text-primary">{t('skill.import.pick.local.title')}</div>
@@ -183,22 +183,22 @@ export function ImportPickStep({
                 <div className="flex-1 min-w-0">
                   <div className="text-sm font-semibold text-text-primary">
                     {s.name}{' '}
-                    <span className="text-[11px] font-normal text-text-tertiary">· {s.subKey ? t(s.subKey) : s.sub}</span>
+                    <span className="text-xs font-normal text-text-tertiary">· {s.subKey ? t(s.subKey) : s.sub}</span>
                     {!s.ready && (
-                      <span className="ml-1.5 text-[10px] font-semibold text-text-tertiary bg-bg-elevated border border-border-default px-1.5 py-px rounded-full">
+                      <span className="ml-1.5 text-2xs font-semibold text-text-tertiary bg-bg-elevated border border-border-default px-1.5 py-px rounded-full">
                         {t('skill.import.pick.comingSoon')}
                       </span>
                     )}
                   </div>
-                  <div className="text-[11px] text-text-tertiary font-mono mt-0.5 truncate">{s.eg}</div>
+                  <div className="text-xs text-text-tertiary font-mono mt-0.5 truncate">{s.eg}</div>
                 </div>
               </div>
             ))}
           </div>
 
           <div className="flex gap-2 mt-4 px-3 py-2.5 rounded-md bg-accent-blue-subtle">
-            <span className="text-brand-blue shrink-0 mt-px">{Icons.workflow(13)}</span>
-            <span className="text-[11px] text-text-secondary leading-[1.5]">
+            <span className="text-text-accent shrink-0 mt-px">{Icons.workflow(13)}</span>
+            <span className="text-xs text-text-secondary leading-[1.5]">
               <Trans i18nKey="skill.import.pick.remoteHint" components={{ b: <strong className="text-text-primary" /> }} />
             </span>
           </div>

--- a/desktop/apps/electron/src/renderer/components/amphi/SkillImportSteps.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/SkillImportSteps.tsx
@@ -41,7 +41,7 @@ function SourceBar({
       <div className="flex items-center gap-2 px-3 py-2 rounded-md bg-bg-hover border border-border-subtle mb-3.5">
         {Icons.link(14)}
         <span className="text-xs text-text-secondary font-mono flex-1 truncate">{path}</span>
-        <span className="text-[10px] font-semibold text-brand-blue bg-accent-blue-subtle px-2 py-0.5 rounded-full shrink-0">
+        <span className="text-2xs font-semibold text-text-accent bg-accent-blue-subtle px-2 py-0.5 rounded-full shrink-0">
           {remoteBadge}
         </span>
       </div>
@@ -101,14 +101,14 @@ function NewRow({
           <>
             <div
               ref={descRef}
-              className={cn('text-[11px] text-text-secondary mt-0.5', !expanded && 'line-clamp-3')}
+              className={cn('text-xs text-text-secondary mt-0.5', !expanded && 'line-clamp-3')}
             >
               {item.scanned.description}
             </div>
             {clamped && (
               <button
                 type="button"
-                className="mt-1 text-[10px] font-semibold text-brand-blue"
+                className="mt-1 text-2xs font-semibold text-text-accent"
                 onClick={(e) => {
                   e.stopPropagation()
                   setExpanded((x) => !x)
@@ -188,14 +188,14 @@ export function ImportReviewStep({
                 {t('skill.import.review.conflictHint')}
               </span>
             </span>
-            <div className="flex items-center gap-1.5 text-[11px]">
+            <div className="flex items-center gap-1.5 text-xs">
               <button
                 type="button"
                 className={cn(
                   'inline-flex items-center gap-1 font-semibold px-2.5 py-1 rounded-sm border',
                   allReplace
                     ? 'border-brand-blue bg-brand-blue text-white'
-                    : 'border-transparent text-brand-blue',
+                    : 'border-transparent text-text-accent',
                 )}
                 onClick={() => onBatch(true)}
               >
@@ -207,7 +207,7 @@ export function ImportReviewStep({
                 className={cn(
                   'font-semibold px-2.5 py-1 rounded-sm border',
                   allKeep
-                    ? 'border-border-strong bg-bg-active text-text-primary'
+                    ? 'border-border-strong bg-bg-selected text-text-primary'
                     : 'border-transparent text-text-secondary',
                 )}
                 onClick={() => onBatch(false)}
@@ -281,7 +281,7 @@ export function ImportResultStep({ summary }: { summary: ImportSummary }) {
             <span className="text-status-error mt-0.5">{Icons.x(12)}</span>
             <div className="min-w-0">
               <span className="font-mono text-text-primary">{s.name}</span>
-              <div className="text-[11px] text-text-tertiary truncate">{s.reason}</div>
+              <div className="text-xs text-text-tertiary truncate">{s.reason}</div>
             </div>
           </div>
         ))}

--- a/desktop/apps/electron/src/renderer/components/amphi/StructuredInput.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/StructuredInput.tsx
@@ -67,7 +67,7 @@ export function StructuredInput({ blocks, className }: StructuredInputProps) {
                 <Quote size={14} strokeWidth={1.5} />
               </span>
               <span className="min-w-0">
-                <span className="mb-0.5 block text-[11px] font-medium text-text-secondary">{source}</span>
+                <span className="mb-0.5 block text-xs font-medium text-text-secondary">{source}</span>
                 <span className="line-clamp-3 block whitespace-pre-wrap break-words text-xs leading-relaxed text-text-tertiary">
                   {quote.text}
                 </span>

--- a/desktop/apps/electron/src/renderer/components/amphi/SubagentCard.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/SubagentCard.tsx
@@ -30,14 +30,14 @@ export function SubagentCard({ block }: SubagentCardProps) {
       })}
       className="group relative flex w-full items-center gap-3 rounded-md border border-border-default bg-bg-surface px-3 py-2.5 text-left transition-colors hover:border-brand-blue hover:bg-bg-hover"
     >
-      <span className="flex size-8 shrink-0 items-center justify-center rounded-md bg-accent-blue-subtle text-brand-blue">
+      <span className="flex size-8 shrink-0 items-center justify-center rounded-md bg-accent-blue-subtle text-text-accent">
         <Bot size={17} strokeWidth={1.7} />
       </span>
       <span className="min-w-0 flex-1">
         <span className="flex items-center gap-2">
           <span className="text-xs font-semibold text-text-primary">{t('subagent.cardTitle')}</span>
           <span className={cn(
-            'inline-flex items-center gap-1 text-[11px]',
+            'inline-flex items-center gap-1 text-xs',
             lifecycle.tone === 'attention' && 'text-status-warning',
             lifecycle.tone === 'error' && 'text-status-error',
             lifecycle.tone === 'success' && 'text-status-success',

--- a/desktop/apps/electron/src/renderer/components/amphi/SubagentGroup.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/SubagentGroup.tsx
@@ -48,9 +48,9 @@ export function SubagentGroup({ subagents }: SubagentGroupProps) {
         type="button"
         aria-expanded={open}
         onClick={() => setOpen((value) => !value)}
-        className="flex w-full items-center gap-2 py-1.5 text-left text-[11px] text-text-tertiary hover:text-text-secondary"
+        className="flex w-full items-center gap-2 py-1.5 text-left text-xs text-text-tertiary hover:text-text-secondary"
       >
-        <Bot size={13} className="shrink-0 text-brand-blue" />
+        <Bot size={13} className="shrink-0 text-text-accent" />
         <span className="font-medium text-text-secondary">{t('subagent.group.summary', { n: children.length })}</span>
         <span className="min-w-0 flex-1 truncate">{summaries.join(' · ')}</span>
         <ChevronDown size={12} className={cn('shrink-0 transition-transform', !open && '-rotate-90')} />
@@ -85,7 +85,7 @@ export function SubagentGroup({ subagents }: SubagentGroupProps) {
                 <span className="min-w-0 flex-1 truncate text-xs text-text-secondary">
                   {child.goal || t('subagent.group.untitled')}
                 </span>
-                <span className="shrink-0 text-[11px] text-text-tertiary">
+                <span className="shrink-0 text-xs text-text-tertiary">
                   {lifecycle.shortLabel}
                 </span>
               </button>

--- a/desktop/apps/electron/src/renderer/components/amphi/TaskConfirmCard.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/TaskConfirmCard.tsx
@@ -56,7 +56,7 @@ export function TaskConfirmCard({
     <div className={floating ? 'w-full' : 'max-w-xl rounded-lg border border-border-subtle bg-bg-elevated p-3.5 shadow-sm'}>
       <div className="flex items-center justify-between gap-3">
         <div className="flex min-w-0 items-center gap-2.5">
-          <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-accent-blue-subtle text-brand-blue">
+          <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-accent-blue-subtle text-text-accent">
             {Icons.file(16)}
           </span>
           <div className="min-w-0">
@@ -78,7 +78,7 @@ export function TaskConfirmCard({
           <button
             type="button"
             onClick={() => openPreview()}
-            className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border-subtle px-2.5 text-xs font-semibold text-brand-blue hover:bg-bg-hover"
+            className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border-subtle px-2.5 text-xs font-semibold text-text-accent hover:bg-bg-hover"
           >
             {Icons.eye(14)} {t('workflow.task.preview')}
           </button>

--- a/desktop/apps/electron/src/renderer/components/amphi/TimelineStageSection.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/TimelineStageSection.tsx
@@ -71,7 +71,7 @@ export function TimelineStageSection({
           <span className="shrink-0 font-medium text-text-secondary">{eyebrow}</span>
           <span className="truncate font-medium text-text-primary">{title}</span>
         </span>
-        <span className="shrink-0 text-[11px] text-text-tertiary group-hover:text-text-secondary">
+        <span className="shrink-0 text-xs text-text-tertiary group-hover:text-text-secondary">
           {open ? t('timeline.collapse') : t('timeline.expand')}
         </span>
       </button>

--- a/desktop/apps/electron/src/renderer/components/amphi/ToolCallRow.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/ToolCallRow.tsx
@@ -103,20 +103,20 @@ export function ToolCallRow({ call }: ToolCallRowProps) {
         className={cn(
           'flex w-full items-center gap-[7px] rounded-md py-[3px] transition-colors',
           isError ? 'text-status-error' : 'text-text-tertiary hover:text-text-secondary',
-          isBrowserRunning && 'bg-accent-blue-subtle text-brand-blue',
+          isBrowserRunning && 'bg-accent-blue-subtle text-text-accent',
         )}
         data-browser-tool-state={isBrowserRunning ? 'running' : undefined}
       >
         <span className={cn(
           'flex shrink-0',
-          isBrowserRunning && 'text-brand-blue',
+          isBrowserRunning && 'text-text-accent',
         )}>
           {toolIcon(kind, name, isError)}
         </span>
         <span
           className={cn('flex min-w-0 items-baseline gap-1 text-xs', longSubject ? 'flex-1' : 'shrink-0')}
         >
-          <span className={cn('shrink-0 text-text-tertiary', isBrowserRunning && 'text-brand-blue')}>
+          <span className={cn('shrink-0 text-text-tertiary', isBrowserRunning && 'text-text-accent')}>
             {label.verb}
           </span>
           <SubjectText label={label} />
@@ -124,7 +124,7 @@ export function ToolCallRow({ call }: ToolCallRowProps) {
               part of the subject, e.g. "view file Y of skill X". With nine rows of the same skill reading different files,
               putting them apart would require scanning the whole width to pair them up. */}
           {meta.detail && (
-            <span className="min-w-0 truncate text-[11px] text-text-tertiary">
+            <span className="min-w-0 truncate text-xs text-text-tertiary">
               <span className="px-0.5">·</span>
               {meta.detail}
             </span>
@@ -132,15 +132,15 @@ export function ToolCallRow({ call }: ToolCallRowProps) {
           {/* Put the badge inside the items-baseline group so it aligns to the file name's text baseline (otherwise an 11px
               badge floats high relative to a 12px file name inside an items-center row). */}
           {meta.badge && (
-            <span className="shrink-0 font-mono text-[11px] font-semibold text-status-success">
+            <span className="shrink-0 font-mono text-xs font-semibold text-status-success">
               {meta.badge}
             </span>
           )}
         </span>
-        {meta.note && <span className="shrink-0 text-[11px] text-text-tertiary">{meta.note}</span>}
+        {meta.note && <span className="shrink-0 text-xs text-text-tertiary">{meta.note}</span>}
         {!longSubject && <span className="flex-1" />}
         {durationMs > 0 && (
-          <span className="shrink-0 font-mono text-[11px] text-text-tertiary">
+          <span className="shrink-0 font-mono text-xs text-text-tertiary">
             {formatDuration(durationMs)}
           </span>
         )}
@@ -152,7 +152,7 @@ export function ToolCallRow({ call }: ToolCallRowProps) {
         >
           {Icons.chevronRight(11)}
         </span>
-        {kind === 'write' && !open && <span className="shrink-0 text-[11px] text-brand-blue">{t('session.tool.preview')}</span>}
+        {kind === 'write' && !open && <span className="shrink-0 text-xs text-text-accent">{t('session.tool.preview')}</span>}
       </button>
       {kind === 'bash' && call.subagents?.length ? (
         <SubagentGroup subagents={call.subagents} />

--- a/desktop/apps/electron/src/renderer/components/amphi/ToolViews.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/ToolViews.tsx
@@ -50,7 +50,7 @@ function stringify(value: unknown): string {
 function RawText({ text }: { text: string }) {
   const { t } = useTranslation()
   return (
-    <pre className="m-0 max-h-[280px] min-w-0 overflow-auto whitespace-pre-wrap break-words rounded-md border border-border-subtle bg-bg-hover px-3 py-2.5 text-[11px] font-mono leading-[1.6] text-text-secondary">
+    <pre className="m-0 max-h-[280px] min-w-0 overflow-auto whitespace-pre-wrap break-words rounded-md border border-border-subtle bg-bg-hover px-3 py-2.5 text-xs font-mono leading-[1.6] text-text-secondary">
       {text || t('session.tool.noOutput')}
     </pre>
   )
@@ -65,7 +65,7 @@ function OverflowNoticeView({ notice }: { notice: OverflowNotice }) {
         <span className="flex shrink-0 text-text-tertiary">{Icons.file(13)}</span>
         {t('session.tool.overflow.title')}
       </div>
-      <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-[11px] leading-[1.6]">
+      <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-xs leading-[1.6]">
         <dt className="text-text-tertiary">{t('session.tool.overflow.size')}</dt>
         <dd className="m-0 font-mono text-text-secondary">
           {t('session.tool.overflow.bytes', {
@@ -97,7 +97,7 @@ function ExtLink({ url }: { url: string }) {
           .openExternal(url)
           .catch((e: unknown) => rlog.warn('[tool] openExternal failed', e))
       }}
-      className="cursor-pointer break-all text-left text-xs text-brand-blue hover:underline"
+      className="cursor-pointer break-all text-left text-xs text-text-accent hover:underline"
     >
       {url}
     </button>
@@ -301,7 +301,7 @@ function ParamsSection({ input, hasError }: { input: unknown; hasError: boolean 
       <button
         type="button"
         onClick={() => setOverride(!open)}
-        className="flex items-center gap-1 text-[10px] font-semibold uppercase tracking-[0.4px] text-text-tertiary transition-colors hover:text-text-secondary"
+        className="flex items-center gap-1 text-2xs font-semibold uppercase tracking-[0.4px] text-text-tertiary transition-colors hover:text-text-secondary"
       >
         <span className={cn('flex transition-transform duration-300 ease-out', open && 'rotate-90')}>
           {Icons.chevronRight(9)}
@@ -337,7 +337,7 @@ function JsonBlock({ body, error }: { body: string; error?: boolean }) {
   return (
     <pre
       className={cn(
-        'mb-0 mt-1.5 max-h-[148px] min-w-0 overflow-auto whitespace-pre-wrap break-words rounded-md border border-border-subtle bg-bg-hover px-3 py-2.5 text-[11px] font-mono leading-[1.65]',
+        'mb-0 mt-1.5 max-h-[148px] min-w-0 overflow-auto whitespace-pre-wrap break-words rounded-md border border-border-subtle bg-bg-hover px-3 py-2.5 text-xs font-mono leading-[1.65]',
         error ? 'text-status-error' : 'text-text-secondary',
       )}
     >
@@ -349,7 +349,7 @@ function JsonBlock({ body, error }: { body: string; error?: boolean }) {
 function Section({ label, body, error }: { label: string; body: string; error?: boolean }) {
   return (
     <div className="min-w-0">
-      <div className="text-[10px] font-semibold uppercase tracking-[0.4px] text-text-tertiary">
+      <div className="text-2xs font-semibold uppercase tracking-[0.4px] text-text-tertiary">
         {label}
       </div>
       <JsonBlock body={body} error={error} />

--- a/desktop/apps/electron/src/renderer/components/amphi/WindowedList.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/WindowedList.tsx
@@ -54,7 +54,7 @@ export function WindowedList<T>({
     <div className={className}>
       {items.slice(0, visibleCount).map((item, index) => children(item, index))}
       {hasMore && (
-        <div ref={sentinelRef} className="px-2 py-[5px] text-[10px] text-text-tertiary">
+        <div ref={sentinelRef} className="px-2 py-[5px] text-2xs text-text-tertiary">
           {t('windowedList.loadingMore', { count: items.length })}
         </div>
       )}

--- a/desktop/apps/electron/src/renderer/components/amphi/WorkflowConfirmCard.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/WorkflowConfirmCard.tsx
@@ -149,7 +149,7 @@ export function WorkflowConfirmCard({ block, floating = false }: { block: Workfl
           </span>
           <div className="min-w-0 flex-1">
             <h3 className="text-sm font-semibold text-text-primary">{successTitle}</h3>
-            <p className="mt-0.5 text-[13px] leading-5 text-text-secondary">{successDescription}</p>
+            <p className="mt-0.5 text-sm leading-5 text-text-secondary">{successDescription}</p>
             {block.summary ? (
               <MarkdownMessage
                 content={block.summary}
@@ -158,7 +158,7 @@ export function WorkflowConfirmCard({ block, floating = false }: { block: Workfl
               />
             ) : null}
             <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1">
-              <span className="inline-flex items-center gap-1 text-[11px] font-medium text-status-success">
+              <span className="inline-flex items-center gap-1 text-xs font-medium text-status-success">
                 {Icons.workflow(12)} {t('workflow.confirm.reusable')}
               </span>
               {block.workflowId ? (
@@ -178,7 +178,7 @@ export function WorkflowConfirmCard({ block, floating = false }: { block: Workfl
                   <button
                     type="button"
                     onClick={runWorkflow}
-                    className="inline-flex h-7 items-center gap-1.5 rounded-md px-2 text-xs font-semibold text-brand-blue hover:bg-bg-hover"
+                    className="inline-flex h-7 items-center gap-1.5 rounded-md px-2 text-xs font-semibold text-text-accent hover:bg-bg-hover"
                   >
                     {Icons.play(11)} {t('workflow.confirm.runNow')}
                   </button>

--- a/desktop/apps/electron/src/renderer/components/amphi/WorkflowDetailModal.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/WorkflowDetailModal.tsx
@@ -100,7 +100,7 @@ export function WorkflowDetailModal({
       contentStyle={{ overflow: 'hidden' }}
       customHeader={
         <div className="flex shrink-0 items-center gap-3 border-b border-border-subtle px-5 py-4">
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-accent-blue-subtle text-brand-blue">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-accent-blue-subtle text-text-accent">
             {Icons.workflow(20)}
           </div>
           <div className="min-w-0 flex-1">
@@ -467,17 +467,17 @@ function WorkflowNavItem({
       onClick={() => onSelect(entry.id)}
       className={cn(
         'mb-0.5 flex w-full min-w-0 items-center gap-2.5 rounded-md px-2 py-2 text-left max-md:mb-0 max-md:w-[158px] max-md:shrink-0',
-        selected ? 'bg-accent-blue-subtle text-brand-blue' : 'text-text-secondary hover:bg-bg-hover',
+        selected ? 'bg-accent-blue-subtle text-text-accent' : 'text-text-secondary hover:bg-bg-hover',
       )}
     >
       <span className={cn(
         'flex h-7 w-7 shrink-0 items-center justify-center rounded-md border bg-bg-surface',
-        selected ? 'border-brand-blue/20 text-brand-blue' : 'border-border-subtle text-text-tertiary',
+        selected ? 'border-brand-blue/20 text-text-accent' : 'border-border-subtle text-text-tertiary',
       )}>
         <Icon size={14} strokeWidth={1.7} />
       </span>
       <span className="min-w-0 flex-1">
-        <span className={cn('block truncate text-sm font-semibold', selected ? 'text-brand-blue' : 'text-text-primary')}>{entry.label}</span>
+        <span className={cn('block truncate text-sm font-semibold', selected ? 'text-text-accent' : 'text-text-primary')}>{entry.label}</span>
         <span className="mt-0.5 block truncate font-mono text-xs text-text-tertiary">{entry.path}</span>
       </span>
     </button>
@@ -563,7 +563,7 @@ function WorkflowDocumentReader({ entry }: { entry: WorkflowDocument }) {
                   aria-label={t('workflow.detail.openOutlineAria')}
                   aria-expanded={outlineOpen}
                   onClick={() => setOutlineOpen((open) => !open)}
-                  className="hidden h-7 w-7 items-center justify-center rounded-md hover:bg-bg-hover hover:text-brand-blue max-xl:flex"
+                  className="hidden h-7 w-7 items-center justify-center rounded-md hover:bg-bg-hover hover:text-text-accent max-xl:flex"
                 >
                   <ListTree size={15} strokeWidth={1.8} />
                 </button>
@@ -584,7 +584,7 @@ function WorkflowDocumentReader({ entry }: { entry: WorkflowDocument }) {
               <MarkdownMessage
                 content={entry.content}
                 className={cn(
-                  'text-[15px] leading-7 text-text-primary',
+                  'text-md leading-7 text-text-primary',
                   '[&_p]:my-3 [&_li]:my-1',
                   '[&_h1]:mb-7 [&_h1]:mt-0 [&_h1]:text-2xl [&_h1]:font-semibold [&_h1]:leading-[1.35]',
                   '[&_h2]:mb-3 [&_h2]:mt-9 [&_h2]:text-lg [&_h2]:font-semibold',
@@ -625,7 +625,7 @@ function WorkflowOutline({ headings, activeHeading, onSelect }: { headings: Outl
             onClick={() => onSelect(heading)}
             className={cn(
               'relative block w-full truncate rounded-sm py-1.5 pr-2 text-left text-xs leading-5',
-              active ? 'bg-accent-blue-subtle font-semibold text-brand-blue' : 'text-text-secondary hover:bg-bg-hover hover:text-text-primary',
+              active ? 'bg-accent-blue-subtle font-semibold text-text-accent' : 'text-text-secondary hover:bg-bg-hover hover:text-text-primary',
             )}
             style={{ paddingLeft: 10 + Math.min(heading.level - minimumLevel, 3) * 12 }}
           >

--- a/desktop/apps/electron/src/renderer/components/amphi/WorkflowResultCard.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/WorkflowResultCard.tsx
@@ -51,9 +51,9 @@ export function WorkflowResultCard({ block }: { block: WorkflowResultBlock }) {
         </span>
         <div className="min-w-0 flex-1">
           <h3 className="text-sm font-semibold text-text-primary">{title}</h3>
-          <p className="mt-0.5 text-[13px] leading-5 text-text-secondary">{description}</p>
+          <p className="mt-0.5 text-sm leading-5 text-text-secondary">{description}</p>
           <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1">
-            <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-text-tertiary">
+            <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs text-text-tertiary">
               <span className="font-medium text-text-secondary">{block.workflowName}</span>
               <span aria-hidden="true">·</span>
               <span>{formatWorkflowRunShortTimestamp(block.createdAt)}</span>

--- a/desktop/apps/electron/src/renderer/components/amphi/WorkflowRunDetailModal.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/WorkflowRunDetailModal.tsx
@@ -146,7 +146,7 @@ export function WorkflowRunDetailModal({
       contentStyle={{ overflow: 'hidden' }}
       customHeader={
         <div className="flex shrink-0 items-center gap-3 border-b border-border-subtle px-5 py-4">
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-accent-blue-subtle text-brand-blue">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-accent-blue-subtle text-text-accent">
             {Icons.workflow(20)}
           </div>
           <div className="min-w-0 flex-1">
@@ -428,14 +428,14 @@ function WorkflowRunReader({
                   className={cn(
                     'mb-1 flex w-full items-center gap-2 rounded-md px-2 py-2 text-left',
                     selectedFile?.path === file.path
-                      ? 'bg-accent-blue-subtle text-brand-blue'
+                      ? 'bg-accent-blue-subtle text-text-accent'
                       : 'text-text-secondary hover:bg-bg-hover',
                   )}
                 >
                   <FileOutput size={14} className="shrink-0" />
                   <span className="min-w-0 flex-1">
                     <span className="block truncate text-xs font-semibold">{file.name}</span>
-                    <span className="mt-0.5 block truncate font-mono text-[10px] text-text-tertiary">
+                    <span className="mt-0.5 block truncate font-mono text-2xs text-text-tertiary">
                       {file.path}
                     </span>
                   </span>
@@ -472,7 +472,7 @@ function WorkflowRunReader({
             </div>
           ) : null}
           {selectedFileContent?.truncated ? (
-            <div className="shrink-0 bg-accent-blue-subtle px-5 py-2 text-xs text-brand-blue">
+            <div className="shrink-0 bg-accent-blue-subtle px-5 py-2 text-xs text-text-accent">
               {t('workflow.runDetail.truncatedPreview', { count: (200_000).toLocaleString(i18n.language) })}
             </div>
           ) : null}
@@ -499,7 +499,7 @@ function WorkflowRunReader({
             {selectedFileContent?.truncated ? (
               <div
                 data-testid="workflow-run-truncated-footer"
-                className="mx-auto mt-6 max-w-[760px] rounded-md border border-border-subtle bg-accent-blue-subtle px-4 py-3 text-center text-xs leading-5 text-brand-blue"
+                className="mx-auto mt-6 max-w-[760px] rounded-md border border-border-subtle bg-accent-blue-subtle px-4 py-3 text-center text-xs leading-5 text-text-accent"
               >
                 {t('workflow.runDetail.truncatedPreviewFooter')}
               </div>
@@ -610,7 +610,7 @@ function WorkflowRunFilePreview({
     return (
       <MarkdownMessage
         content={content.content}
-        className="mx-auto max-w-[760px] text-[14px] leading-7"
+        className="mx-auto max-w-[760px] text-base leading-7"
       />
     )
   }
@@ -635,7 +635,7 @@ export function WorkflowRunStatus({
   else if (run.status === 'cancelled') label = t('workflow.runDetail.status.cancelled')
   else if (run.status === 'waiting') label = t('workflow.runDetail.status.waiting')
 
-  let tone = 'bg-accent-blue-subtle text-brand-blue'
+  let tone = 'bg-accent-blue-subtle text-text-accent'
   if (completed) tone = 'bg-status-success-bg text-status-success'
   else if (failed) tone = 'bg-status-error-bg text-status-error'
   else if (inactive) tone = 'bg-bg-hover text-text-tertiary'
@@ -643,7 +643,7 @@ export function WorkflowRunStatus({
     <span
       className={cn(
         'inline-flex shrink-0 items-center rounded-full px-2 py-0.5 font-semibold',
-        compact ? 'text-[10px]' : 'text-xs',
+        compact ? 'text-2xs' : 'text-xs',
         tone,
       )}
     >

--- a/desktop/apps/electron/src/renderer/components/app/AgentDockEntry.tsx
+++ b/desktop/apps/electron/src/renderer/components/app/AgentDockEntry.tsx
@@ -26,9 +26,9 @@ export function AgentDockEntry({
       aria-label={modeAvailable ? modeAriaLabel : t('session.resourcePanel.agent')}
       className={cn(
         'relative flex h-[53px] w-full flex-col items-center justify-center gap-1 rounded-[10px]',
-        'border border-transparent text-brand-purple transition-colors hover:bg-bg-hover',
+        'border border-transparent text-text-accent-purple transition-colors hover:bg-bg-hover',
         'disabled:cursor-default disabled:hover:bg-transparent',
-        active && 'bg-bg-active',
+        active && 'bg-bg-selected',
       )}
       data-testid="session-agent-launcher"
       disabled={!modeAvailable}
@@ -43,7 +43,7 @@ export function AgentDockEntry({
         />
       ) : null}
       <BridgicLogo size={18} />
-      <span className="max-w-[46px] truncate text-[10px] font-medium leading-none">
+      <span className="max-w-[46px] truncate text-2xs font-medium leading-none">
         {t('session.resourcePanel.agent')}
       </span>
     </button>

--- a/desktop/apps/electron/src/renderer/components/app/BrowserExpandControl.tsx
+++ b/desktop/apps/electron/src/renderer/components/app/BrowserExpandControl.tsx
@@ -62,7 +62,7 @@ export function BrowserExpandControl({
             type="button"
             data-testid="browser-overflow-reminder-action"
             onClick={() => onExpandedChange(true)}
-            className="rounded px-0.5 text-xs font-semibold text-brand-blue hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40"
+            className="rounded px-0.5 text-xs font-semibold text-text-accent hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40"
           >
             {reminderAction}
           </button>
@@ -96,7 +96,7 @@ export function BrowserExpandControl({
           onClick={() => onExpandedChange(!expanded)}
           className={cn(
             'flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-text-tertiary hover:bg-bg-hover hover:text-text-primary',
-            reminderId && 'bg-accent-blue-subtle text-brand-blue ring-1 ring-inset ring-brand-blue/20',
+            reminderId && 'bg-accent-blue-subtle text-text-accent ring-1 ring-inset ring-brand-blue/20',
           )}
         >
           <ExpandIcon expanded={expanded} size={15} />

--- a/desktop/apps/electron/src/renderer/components/app/CommentFeedbackPanel.tsx
+++ b/desktop/apps/electron/src/renderer/components/app/CommentFeedbackPanel.tsx
@@ -91,7 +91,7 @@ export function CommentFeedbackPanel() {
 
       {/* The divider clearly separates the two areas: "the comments collected" and "the send action". */}
       <div className="border-t border-border-subtle px-4 pt-3.5 pb-4">
-        <div className="text-md font-bold text-brand-purple mb-1">{t('commentFeedback.continueBuild')}</div>
+        <div className="text-md font-bold text-text-accent-purple mb-1">{t('commentFeedback.continueBuild')}</div>
         <div className="text-sm text-text-secondary mb-3">{t('commentFeedback.summary', { count: n })}</div>
 
         <button
@@ -146,7 +146,7 @@ function CommentItem({ comment, onRemove }: CommentItemProps) {
     <div className="group relative rounded-lg border border-border-subtle bg-bg-surface p-2.5 pr-8">
       {/* Selected source text — a reference, de-emphasized into a small grey box; expandable when very long. */}
       <div className="mb-2 rounded-md bg-bg-hover px-2 py-1.5">
-        <div className="mb-0.5 text-[10px] font-medium text-text-tertiary">{t('commentFeedback.selectedSource')}</div>
+        <div className="mb-0.5 text-2xs font-medium text-text-tertiary">{t('commentFeedback.selectedSource')}</div>
         <div
           ref={quoteRef}
           className={cn('text-xs italic leading-snug text-text-tertiary', !quoteExpanded && 'line-clamp-2')}
@@ -157,7 +157,7 @@ function CommentItem({ comment, onRemove }: CommentItemProps) {
           <button
             type="button"
             onClick={() => setQuoteExpanded((v) => !v)}
-            className="mt-1 text-[10px] font-semibold text-brand-purple hover:underline"
+            className="mt-1 text-2xs font-semibold text-text-accent-purple hover:underline"
           >
             {quoteExpanded ? t('commentFeedback.collapse') : t('commentFeedback.expandAll')}
           </button>
@@ -165,7 +165,7 @@ function CommentItem({ comment, onRemove }: CommentItemProps) {
       </div>
       {/* My comment — the main event; expandable when very long. */}
       <div>
-        <div className="mb-0.5 text-[10px] font-semibold text-brand-purple">{t('commentFeedback.myComment')}</div>
+        <div className="mb-0.5 text-2xs font-semibold text-text-accent-purple">{t('commentFeedback.myComment')}</div>
         <div
           ref={textRef}
           className={cn('text-sm font-medium leading-snug text-text-primary', !textExpanded && 'line-clamp-3')}
@@ -176,7 +176,7 @@ function CommentItem({ comment, onRemove }: CommentItemProps) {
           <button
             type="button"
             onClick={() => setTextExpanded((v) => !v)}
-            className="mt-1 text-[10px] font-semibold text-brand-purple hover:underline"
+            className="mt-1 text-2xs font-semibold text-text-accent-purple hover:underline"
           >
             {textExpanded ? t('commentFeedback.collapse') : t('commentFeedback.expandAll')}
           </button>

--- a/desktop/apps/electron/src/renderer/components/app/EmbeddedBrowserPanel.tsx
+++ b/desktop/apps/electron/src/renderer/components/app/EmbeddedBrowserPanel.tsx
@@ -218,7 +218,7 @@ function BrowserLaunchEmptyState({ sessionId }: { sessionId: string }) {
         style={{ height: SESSION_STATUS_BAR_HEIGHT_PX }}
         data-testid="browser-empty-header"
       >
-        <span className="flex text-brand-blue">{Icons.globe(16)}</span>
+        <span className="flex text-text-accent">{Icons.globe(16)}</span>
         <span className="text-sm font-semibold text-text-primary">
           {t('session.resourcePanel.browser')}
         </span>

--- a/desktop/apps/electron/src/renderer/components/app/FocusModeHeader.tsx
+++ b/desktop/apps/electron/src/renderer/components/app/FocusModeHeader.tsx
@@ -74,7 +74,7 @@ export function FocusStageRail({ stage, streaming, compact = false }: FocusStage
 /** Three-state colouring for the circles — the full rail has moved to the shared `StageRail`, this is left for the compact hover overlay. */
 function stageDotClass(done: boolean, active: boolean): string {
   if (done) return 'bg-brand-blue text-white'
-  if (active) return 'bg-bg-elevated text-brand-blue border-[1.5px] border-brand-blue'
+  if (active) return 'bg-bg-elevated text-text-accent border-[1.5px] border-brand-blue'
   return 'bg-stage-track text-text-tertiary'
 }
 
@@ -96,7 +96,7 @@ function compactBarClass(done: boolean, active: boolean): string {
 function StageDotMark({ done, active, index }: { done: boolean; active: boolean; index: number }) {
   if (done) return Icons.check(9)
   if (active) return <span className="w-1.5 h-1.5 rounded-full bg-brand-blue animate-pulse" />
-  return <span className="text-[9px] font-bold">{index + 1}</span>
+  return <span className="text-2xs font-bold">{index + 1}</span>
 }
 
 /** One row of the hover overlay: dot + stage name + status label + description. */
@@ -115,7 +115,7 @@ function CompactStageRow({
     <div className={cn('flex items-start gap-2.5 px-3 py-1.5 rounded-md', active && 'bg-accent-blue-subtle')}>
       <span
         className={cn(
-          'shrink-0 mt-px w-4 h-4 rounded-full flex items-center justify-center text-[9px] font-bold',
+          'shrink-0 mt-px w-4 h-4 rounded-full flex items-center justify-center text-2xs font-bold',
           stageDotClass(done, active),
         )}
       >
@@ -124,10 +124,10 @@ function CompactStageRow({
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-1.5">
           <span className={cn('text-xs', stageTextClass(done, active))}>{t(`focusMode.stages.${stage}`)}</span>
-          {done && <span className="text-[9px] text-brand-blue font-semibold">{t('focusMode.completed')}</span>}
-          {active && <span className="text-[9px] text-brand-blue font-semibold">{t('focusMode.inProgress')}</span>}
+          {done && <span className="text-2xs text-text-accent font-semibold">{t('focusMode.completed')}</span>}
+          {active && <span className="text-2xs text-text-accent font-semibold">{t('focusMode.inProgress')}</span>}
         </div>
-        <div className="text-[11px] text-text-tertiary leading-snug mt-px">{t(`focusMode.stageDescriptions.${stage}`)}</div>
+        <div className="text-xs text-text-tertiary leading-snug mt-px">{t(`focusMode.stageDescriptions.${stage}`)}</div>
       </div>
     </div>
   )
@@ -141,11 +141,11 @@ function CompactStageHover({ current, streaming }: { current: number; streaming:
     <div className="absolute top-[calc(100%+8px)] left-0 z-50 w-64 bg-bg-elevated border border-border-default rounded-lg shadow-md p-1.5 pt-3">
       <div className="flex items-center gap-1.5 px-3 pb-2 mb-1 border-b border-border-subtle">
         <span className="text-sm font-bold text-text-primary">{t('focusMode.progress')}</span>
-        <span className="text-[11px] text-text-tertiary font-mono">
+        <span className="text-xs text-text-tertiary font-mono">
           {Math.min(current + 1, total)}/{total}
         </span>
         {streaming && (
-          <span className="ml-auto flex items-center gap-1 text-[10px] font-semibold text-brand-blue">
+          <span className="ml-auto flex items-center gap-1 text-2xs font-semibold text-text-accent">
             <span className="w-1.5 h-1.5 rounded-full bg-brand-blue animate-pulse" /> {t('focusMode.inProgress')}
           </span>
         )}
@@ -200,10 +200,10 @@ function CompactStageRail({ current, streaming }: { current: number; streaming: 
             {shownLabel}
           </span>
           {streaming && <span className="w-1.5 h-1.5 rounded-full bg-brand-blue shrink-0 animate-pulse" />}
-          <span className="text-[11px] text-text-tertiary font-mono whitespace-nowrap shrink-0">
+          <span className="text-xs text-text-tertiary font-mono whitespace-nowrap shrink-0">
             {Math.min(current + 1, total)}/{total}
           </span>
-          <span className="flex text-text-tertiary shrink-0 opacity-70">{Icons.chevronDown(12)}</span>
+          <span className="flex text-text-tertiary shrink-0">{Icons.chevronDown(12)}</span>
         </div>
       </div>
       {hover && <CompactStageHover current={current} streaming={streaming} />}
@@ -276,7 +276,7 @@ function BuildTopStatusBar({
       isCompact={compact}
       title={t('focusMode.title')}
       badge={
-        <span className="shrink-0 whitespace-nowrap rounded-full bg-accent-blue-subtle px-2 py-0.5 text-[10px] font-semibold text-brand-blue">
+        <span className="shrink-0 whitespace-nowrap rounded-full bg-accent-blue-subtle px-2 py-0.5 text-2xs font-semibold text-text-accent">
           {shownStage}
         </span>
       }
@@ -288,7 +288,7 @@ function BuildTopStatusBar({
       }
       status={
         <span className={cn(
-          'items-center gap-1.5 text-[11px] font-medium text-text-secondary',
+          'items-center gap-1.5 text-xs font-medium text-text-secondary',
           compact ? 'hidden' : 'hidden sm:flex',
         )}>
           <span className={cn(

--- a/desktop/apps/electron/src/renderer/components/app/ScheduleWorkbenchPanel.tsx
+++ b/desktop/apps/electron/src/renderer/components/app/ScheduleWorkbenchPanel.tsx
@@ -192,7 +192,7 @@ function ScheduleWorkbenchCard({
         </span>
         <div className="min-w-0 flex-1">
           <div className="flex min-w-0 flex-wrap items-center gap-1.5">
-            <h3 className="min-w-0 break-words text-[13px] font-semibold leading-5 text-text-primary">
+            <h3 className="min-w-0 break-words text-sm font-semibold leading-5 text-text-primary">
               {schedule.name}
             </h3>
             <ScheduleStatusBadge status={status} />
@@ -208,7 +208,7 @@ function ScheduleWorkbenchCard({
         <span aria-hidden="true" className="shrink-0">{Icons.refresh(12)}</span>
         <span className="min-w-0 truncate text-text-secondary" title={cronText}>{cronText}</span>
       </div>
-      <div className="mt-1 grid min-w-0 grid-cols-1 gap-0.5 text-[11px] leading-4 text-text-tertiary min-[440px]:grid-cols-2 min-[440px]:gap-2">
+      <div className="mt-1 grid min-w-0 grid-cols-1 gap-0.5 text-xs leading-4 text-text-tertiary min-[440px]:grid-cols-2 min-[440px]:gap-2">
         <span className="min-w-0 truncate" title={schedule.lastRun}>
           {t('schedule.row.lastRun')}<span className="font-mono">{schedule.lastRun}</span>
         </span>
@@ -268,7 +268,7 @@ function ScheduleStatusBadge({ status }: { status: ScheduleStatus }) {
   }
   return (
     <span
-      className={cn('inline-flex shrink-0 items-center gap-1 rounded-full px-1.5 py-0.5 text-[10px] font-semibold', className)}
+      className={cn('inline-flex shrink-0 items-center gap-1 rounded-full px-1.5 py-0.5 text-2xs font-semibold', className)}
       data-schedule-status={status}
     >
       <span aria-hidden="true" className={cn('h-1.5 w-1.5 rounded-full', dotClassName)} />

--- a/desktop/apps/electron/src/renderer/components/app/SessionFilesPanel.tsx
+++ b/desktop/apps/electron/src/renderer/components/app/SessionFilesPanel.tsx
@@ -29,7 +29,7 @@ export function SessionFilesPanel() {
     <WorkbenchToolSurface testId="session-files-panel">
       <WorkbenchToolHeader
         icon={Icons.folder(15)}
-        iconClassName="bg-accent-blue-subtle text-brand-blue"
+        iconClassName="bg-accent-blue-subtle text-text-accent"
         testId="session-files-header"
         title={t('session.workbench.files.title', {
           defaultValue: t('session.resourcePanel.files'),

--- a/desktop/apps/electron/src/renderer/components/app/SessionStatusBar.tsx
+++ b/desktop/apps/electron/src/renderer/components/app/SessionStatusBar.tsx
@@ -132,7 +132,7 @@ export function SessionStatusBar({
             </div>
             {!isNarrow && (
               <Tooltip content={description} onlyWhenTruncated>
-                <div className="mt-0.5 truncate text-[11px] text-text-tertiary">{description}</div>
+                <div className="mt-0.5 truncate text-xs text-text-tertiary">{description}</div>
               </Tooltip>
             )}
           </div>

--- a/desktop/apps/electron/src/renderer/components/app/SessionSurfaceChrome.tsx
+++ b/desktop/apps/electron/src/renderer/components/app/SessionSurfaceChrome.tsx
@@ -139,8 +139,8 @@ export function SurfaceRailButton({
       className={cn(
         'relative flex h-[50px] w-full flex-col items-center justify-center gap-1 rounded-[10px]',
         'border border-transparent text-text-tertiary transition-colors hover:bg-bg-hover hover:text-text-secondary',
-        isActive && 'bg-bg-active text-text-primary',
-        isBusy && !showAttention && 'border-brand-blue/30 bg-accent-blue-subtle text-brand-blue',
+        isActive && 'bg-bg-selected text-text-primary',
+        isBusy && !showAttention && 'border-brand-blue/30 bg-accent-blue-subtle text-text-accent',
         showAttention && 'animate-surface-attention border-status-warning/40 bg-status-warning-bg text-status-warning hover:bg-status-warning-bg hover:text-status-warning motion-reduce:animate-none',
       )}
     >
@@ -157,12 +157,12 @@ export function SurfaceRailButton({
       ) : null}
       <span className={cn(
         'flex h-5 items-center justify-center',
-        isBusy && !showAttention && 'text-brand-blue',
+        isBusy && !showAttention && 'text-text-accent',
         isPulsing && 'animate-pulse motion-reduce:animate-none',
       )}>
         {icon}
       </span>
-      <span className="max-w-[46px] truncate text-[10px] font-medium leading-none">{label}</span>
+      <span className="max-w-[46px] truncate text-2xs font-medium leading-none">{label}</span>
     </button>
   )
 }

--- a/desktop/apps/electron/src/renderer/components/app/SpecPreviewPane.tsx
+++ b/desktop/apps/electron/src/renderer/components/app/SpecPreviewPane.tsx
@@ -238,7 +238,7 @@ export function SpecPreviewPane() {
     )
   } else if (pendingTaskConfirm) {
     statusBadge = (
-      <span className="rounded-full bg-accent-blue-subtle px-2 py-0.5 text-xs font-semibold text-brand-blue shrink-0">
+      <span className="rounded-full bg-accent-blue-subtle px-2 py-0.5 text-xs font-semibold text-text-accent shrink-0">
         {t('specPreview.badge.awaitingConfirmation')}
       </span>
     )
@@ -270,7 +270,7 @@ export function SpecPreviewPane() {
         <button
           type="button"
           onClick={beginEdit}
-          className="flex items-center justify-center w-7 h-7 rounded-md text-text-tertiary hover:bg-bg-hover hover:text-brand-blue"
+          className="flex items-center justify-center w-7 h-7 rounded-md text-text-tertiary hover:bg-bg-hover hover:text-text-accent"
         >
           {Icons.edit(14)}
         </button>
@@ -309,13 +309,13 @@ export function SpecPreviewPane() {
         className="flex shrink-0 items-center gap-2 border-b border-border-subtle px-4"
         style={{ height: SESSION_STATUS_BAR_HEIGHT_PX }}
       >
-        <span className="text-brand-blue flex shrink-0">{Icons.file(15)}</span>
+        <span className="text-text-accent flex shrink-0">{Icons.file(15)}</span>
         <span className="flex-1 min-w-0 truncate text-sm font-semibold text-text-primary">
           {editBaselinePreview ? t('specPreview.originalFileName') : t('specPreview.fileName')}
         </span>
         {statusBadge}
         {pendingCount > 0 ? (
-          <span className="px-2 py-0.5 rounded-full bg-accent-blue-subtle text-brand-blue text-xs font-semibold shrink-0">
+          <span className="px-2 py-0.5 rounded-full bg-accent-blue-subtle text-text-accent text-xs font-semibold shrink-0">
             {t('specPreview.pendingCount', { count: pendingCount })}
           </span>
         ) : null}
@@ -328,8 +328,8 @@ export function SpecPreviewPane() {
                 setReviewView('diff')
               }}
               className={cn(
-                'h-6 rounded px-2 text-[11px] font-semibold',
-                reviewView === 'diff' ? 'bg-bg-surface text-brand-blue shadow-sm' : 'text-text-tertiary',
+                'h-6 rounded px-2 text-xs font-semibold',
+                reviewView === 'diff' ? 'bg-bg-surface text-text-accent shadow-sm' : 'text-text-tertiary',
               )}
             >
               {t('specPreview.diff')}
@@ -341,8 +341,8 @@ export function SpecPreviewPane() {
                 setReviewView('document')
               }}
               className={cn(
-                'h-6 rounded px-2 text-[11px] font-semibold',
-                reviewView === 'document' ? 'bg-bg-surface text-brand-blue shadow-sm' : 'text-text-tertiary',
+                'h-6 rounded px-2 text-xs font-semibold',
+                reviewView === 'document' ? 'bg-bg-surface text-text-accent shadow-sm' : 'text-text-tertiary',
               )}
             >
               {t('specPreview.latest')}
@@ -355,7 +355,7 @@ export function SpecPreviewPane() {
       <div
         className={cn(
           'flex items-center gap-1.5 px-4 py-2 border-b border-border-subtle text-xs',
-          archived ? 'bg-status-success-bg text-status-success' : 'bg-accent-blue-subtle text-brand-blue',
+          archived ? 'bg-status-success-bg text-status-success' : 'bg-accent-blue-subtle text-text-accent',
         )}
       >
         {instruction}
@@ -563,7 +563,7 @@ function CommentComposer({ quote, text: draft, onChange, onAdd, onCancel }: Comm
   return (
     <div className="shrink-0 border-t border-border-default bg-bg-surface px-3.5 py-3 animate-enter">
       <div className="flex items-center gap-1.5 mb-2">
-        <span className="flex items-center gap-1 text-xs font-semibold text-brand-blue">
+        <span className="flex items-center gap-1 text-xs font-semibold text-text-accent">
           {Icons.chat(12)} {t('specPreview.commentSelection')}
         </span>
         <span className="flex-1" />
@@ -586,7 +586,7 @@ function CommentComposer({ quote, text: draft, onChange, onAdd, onCancel }: Comm
           <button
             type="button"
             onClick={() => setQuoteExpanded((v) => !v)}
-            className="mt-1 text-[10px] font-semibold text-brand-blue hover:underline"
+            className="mt-1 text-2xs font-semibold text-text-accent hover:underline"
           >
             {quoteExpanded ? t('specPreview.collapse') : t('specPreview.expandAll')}
           </button>

--- a/desktop/apps/electron/src/renderer/components/app/StageRail.tsx
+++ b/desktop/apps/electron/src/renderer/components/app/StageRail.tsx
@@ -40,7 +40,7 @@ export interface StageRailProps {
 /** Three-state colors for the numbered circle (done / active / pending). */
 function getStageDotClass(isDone: boolean, isActive: boolean): string {
   if (isDone) return 'bg-brand-blue text-white'
-  if (isActive) return 'bg-bg-elevated text-brand-blue border-[1.5px] border-brand-blue'
+  if (isActive) return 'bg-bg-elevated text-text-accent border-[1.5px] border-brand-blue'
   return 'bg-stage-track text-text-tertiary'
 }
 
@@ -77,7 +77,7 @@ export function StageRail({ items, current, isRunning = false }: StageRailProps)
               >
                 <span
                   className={cn(
-                    'flex h-4 w-4 items-center justify-center rounded-full text-[9px] font-bold transition-colors duration-300 ease-out',
+                    'flex h-4 w-4 items-center justify-center rounded-full text-2xs font-bold transition-colors duration-300 ease-out',
                     getStageDotClass(isDone, isActive),
                   )}
                 >

--- a/desktop/apps/electron/src/renderer/components/app/WorkbenchToolPrimitives.tsx
+++ b/desktop/apps/electron/src/renderer/components/app/WorkbenchToolPrimitives.tsx
@@ -150,7 +150,7 @@ export function WorkbenchScopeButtons<T extends string>({
           >
             {option.label}
             {option.count === undefined ? null : (
-              <span className="ml-1 opacity-60">{option.count}</span>
+              <span className="ml-1">{option.count}</span>
             )}
           </button>
         )

--- a/desktop/apps/electron/src/renderer/components/app/WorkflowResultsPanel.tsx
+++ b/desktop/apps/electron/src/renderer/components/app/WorkflowResultsPanel.tsx
@@ -260,10 +260,10 @@ function WorkflowResultRow({
           {statusIcon}
         </span>
         <div className="min-w-0 flex-1">
-          <h3 className="break-words text-[13px] font-semibold leading-5 text-text-primary">
+          <h3 className="break-words text-sm font-semibold leading-5 text-text-primary">
             {run.workflow_name}
           </h3>
-          <div className="mt-0.5 flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5 text-[11px] text-text-tertiary">
+          <div className="mt-0.5 flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5 text-xs text-text-tertiary">
             <span
               className={cn(
                 'font-medium',
@@ -286,7 +286,7 @@ function WorkflowResultRow({
         </p>
       ) : null}
       <div className="mt-2 flex min-w-0 flex-wrap items-center gap-1.5 border-t border-border-subtle pt-2">
-        <span className="min-w-0 flex-1 truncate font-mono text-[10px] text-text-tertiary" title={run.id}>
+        <span className="min-w-0 flex-1 truncate font-mono text-2xs text-text-tertiary" title={run.id}>
           {run.id}
         </span>
         {onReference ? (

--- a/desktop/apps/electron/src/renderer/components/app/WorkflowRunDetailsPane.tsx
+++ b/desktop/apps/electron/src/renderer/components/app/WorkflowRunDetailsPane.tsx
@@ -105,7 +105,7 @@ export function WorkflowRunDetailsPane() {
         className="flex shrink-0 items-center gap-2 border-b border-border-subtle px-4"
         style={{ height: SESSION_STATUS_BAR_HEIGHT_PX }}
       >
-        <span className="flex shrink-0 text-brand-blue">{Icons.workflow(16)}</span>
+        <span className="flex shrink-0 text-text-accent">{Icons.workflow(16)}</span>
         <span className="min-w-0 flex-1 truncate text-sm font-semibold text-text-primary">
           {t('workflowRunHeader.detailsTitle')}
         </span>
@@ -140,7 +140,7 @@ export function WorkflowRunDetailsPane() {
                   <div className="text-lg font-semibold tabular-nums text-text-primary">
                     {completedSteps}<span className="text-xs font-medium text-text-tertiary">/{totalSteps}</span>
                   </div>
-                  <div className="text-[10px] text-text-tertiary">
+                  <div className="text-2xs text-text-tertiary">
                     {t('workflowRunHeader.overallProgress')}
                   </div>
                 </div>
@@ -236,16 +236,16 @@ export function WorkflowRunDetailsPane() {
                 )}
               >
                 <span className={cn(
-                  'flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[10px] font-semibold',
+                  'flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-2xs font-semibold',
                   tab.complete && 'bg-status-success-bg text-status-success',
-                  tab.current && 'border border-brand-blue bg-accent-blue-subtle text-brand-blue',
+                  tab.current && 'border border-brand-blue bg-accent-blue-subtle text-text-accent',
                   !tab.complete && !tab.current && 'border border-border-default text-text-tertiary',
                 )}>
                   {tab.complete ? Icons.check(11) : tabIndex + 1}
                 </span>
                 <span className="min-w-0">
                   <span className="block truncate text-xs font-semibold">{tab.label}</span>
-                  <span className="block truncate text-[10px] text-text-tertiary">{progress}</span>
+                  <span className="block truncate text-2xs text-text-tertiary">{progress}</span>
                 </span>
               </button>
             )
@@ -297,9 +297,9 @@ export function WorkflowRunDetailsPane() {
                   )} />
                 )}
                 <span className={cn(
-                  'relative z-10 flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-[10px] font-semibold',
+                  'relative z-10 flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-2xs font-semibold',
                   done && 'bg-status-success-bg text-status-success ring-4 ring-bg-surface',
-                  active && 'border border-brand-blue bg-accent-blue-subtle text-brand-blue ring-4 ring-bg-surface',
+                  active && 'border border-brand-blue bg-accent-blue-subtle text-text-accent ring-4 ring-bg-surface',
                   failed && 'bg-status-error-bg text-status-error ring-4 ring-bg-surface',
                   !done && !active && !failed && 'border border-border-default bg-bg-surface text-text-tertiary ring-4 ring-bg-surface',
                 )}>
@@ -324,7 +324,7 @@ export function WorkflowRunDetailsPane() {
                       {title}
                     </span>
                     {active && (
-                      <span className={cn('shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium', statusTone)}>
+                      <span className={cn('shrink-0 rounded-full px-2 py-0.5 text-2xs font-medium', statusTone)}>
                         {status}
                       </span>
                     )}
@@ -332,7 +332,7 @@ export function WorkflowRunDetailsPane() {
                   <div
                     data-testid="workflow-run-step-detail"
                     className={cn(
-                      'mt-1 min-w-0 whitespace-pre-wrap [overflow-wrap:anywhere] text-[11px] leading-relaxed text-text-tertiary',
+                      'mt-1 min-w-0 whitespace-pre-wrap [overflow-wrap:anywhere] text-xs leading-relaxed text-text-tertiary',
                       failed && 'text-status-error',
                     )}
                   >
@@ -357,7 +357,7 @@ function RunMetric({ value, label }: { value: number; label: string }) {
   return (
     <div className="min-w-0 px-2 py-2.5 text-center">
       <div className="text-sm font-semibold tabular-nums text-text-primary">{value}</div>
-      <div className="truncate text-[10px] text-text-tertiary">{label}</div>
+      <div className="truncate text-2xs text-text-tertiary">{label}</div>
     </div>
   )
 }

--- a/desktop/apps/electron/src/renderer/components/app/WorkflowRunHeader.tsx
+++ b/desktop/apps/electron/src/renderer/components/app/WorkflowRunHeader.tsx
@@ -65,7 +65,7 @@ function WorkflowPhaseRail({
             />
           ))}
         </div>
-        <span className="min-w-0 truncate whitespace-nowrap text-[11px] font-medium text-text-secondary">
+        <span className="min-w-0 truncate whitespace-nowrap text-xs font-medium text-text-secondary">
           {currentLabel}{narrow ? ` · ${progress}` : ''}
         </span>
       </div>
@@ -152,7 +152,7 @@ export function WorkflowRunHeader({ sessionId }: { sessionId?: string }) {
       isNarrow={narrow}
       title={t('workflowRunHeader.title')}
       badge={
-        <span className="shrink-0 whitespace-nowrap rounded-full bg-accent-blue-subtle px-2 py-0.5 text-[10px] font-semibold text-brand-blue">
+        <span className="shrink-0 whitespace-nowrap rounded-full bg-accent-blue-subtle px-2 py-0.5 text-2xs font-semibold text-text-accent">
           {phaseLabel} · {phaseProgress}
         </span>
       }
@@ -171,7 +171,7 @@ export function WorkflowRunHeader({ sessionId }: { sessionId?: string }) {
       }
       status={
         <span className={cn(
-          'hidden items-center gap-1.5 text-[11px] font-medium text-text-secondary',
+          'hidden items-center gap-1.5 text-xs font-medium text-text-secondary',
           !compact && 'sm:flex',
         )}>
           <span className={cn(

--- a/desktop/apps/electron/src/renderer/components/app/__tests__/SessionResourcePanel.test.tsx
+++ b/desktop/apps/electron/src/renderer/components/app/__tests__/SessionResourcePanel.test.tsx
@@ -214,7 +214,7 @@ describe('SessionResourcePanel', () => {
     const filesStatus = files.querySelector<HTMLElement>(
       '[data-testid="session-workbench-files-status-indicator"]',
     )
-    expect(files.className).toContain('bg-bg-active')
+    expect(files.className).toContain('bg-bg-selected')
     expect(filesStatus?.dataset.state).toBe('active')
     expect(filesStatus?.className).toContain('-right-[3px]')
     expect(filesStatus?.className).toContain('h-5')
@@ -230,7 +230,7 @@ describe('SessionResourcePanel', () => {
     const workflows = host.querySelector<HTMLButtonElement>('[data-testid="session-workbench-workflows"]')!
     await act(async () => workflows.click())
     expect(store.get(sessionWorkbenchSurfaceAtom)).toBe(SessionWorkbenchSurface.Workflows)
-    expect(workflows.className).toContain('bg-bg-active')
+    expect(workflows.className).toContain('bg-bg-selected')
     expect(workflows.querySelector('[data-testid="session-workbench-workflows-status-indicator"]')?.getAttribute('data-state')).toBe('active')
     expect(files.querySelector('[data-testid="session-workbench-files-status-indicator"]')).toBeNull()
     expect(host.querySelector('[data-testid="session-workbench-workflows-content"]')?.getAttribute('aria-hidden')).toBe('false')
@@ -622,7 +622,7 @@ describe('SessionResourcePanel', () => {
     expect(host.querySelector('[data-testid="session-mode-surface"]')).not.toBeNull()
     expect(host.textContent).toContain('保留静态 Bridgic 标识')
     expect(launcher.textContent).toContain('Bridgic')
-    expect(launcher.className).toContain('bg-bg-active')
+    expect(launcher.className).toContain('bg-bg-selected')
     expect(launcher.querySelector('[data-testid="session-agent-status-indicator"]')?.getAttribute('data-state')).toBe('active')
     expect(launcher.querySelector('[data-testid="session-agent-status-indicator"]')?.className).toContain('bg-text-secondary/65')
     expect(launcher.querySelector('.left-0')).toBeNull()
@@ -891,7 +891,7 @@ describe('SessionResourcePanel', () => {
       await Promise.resolve()
     })
     expect(browserButton?.getAttribute('aria-selected')).toBe('true')
-    expect(browserButton?.className).toContain('bg-bg-active')
+    expect(browserButton?.className).toContain('bg-bg-selected')
     expect(browserButton?.querySelector('.left-0')).toBeNull()
     const activeIndicator = browserButton?.querySelector<HTMLElement>(
       '[data-testid="session-workbench-browser-status-indicator"]',
@@ -1182,7 +1182,7 @@ describe('SessionResourcePanel', () => {
         await Promise.resolve()
       })
       expect(browserButton.getAttribute('data-attention')).toBeNull()
-      expect(browserButton.className).toContain('bg-bg-active')
+      expect(browserButton.className).toContain('bg-bg-selected')
     } finally {
       await act(async () => root.unmount())
       jest.useRealTimers()

--- a/desktop/apps/electron/src/renderer/components/composer/ComposerQuoteCard.tsx
+++ b/desktop/apps/electron/src/renderer/components/composer/ComposerQuoteCard.tsx
@@ -20,7 +20,7 @@ export function ComposerQuoteCard({ quote, onRemove }: ComposerQuoteCardProps) {
         <Quote size={14} strokeWidth={1.5} />
       </span>
       <div className="min-w-0 flex-1">
-        <div className="mb-0.5 text-[11px] font-medium text-text-secondary">{source}</div>
+        <div className="mb-0.5 text-xs font-medium text-text-secondary">{source}</div>
         <div className="line-clamp-2 whitespace-pre-wrap break-words text-xs leading-relaxed text-text-tertiary">
           {quote.text}
         </div>

--- a/desktop/apps/electron/src/renderer/components/composer/InputToolbar.tsx
+++ b/desktop/apps/electron/src/renderer/components/composer/InputToolbar.tsx
@@ -110,7 +110,7 @@ export function InputToolbar(_props: InputToolbarProps) {
                           <FileOutput size={14} className="shrink-0 text-entity-workflow-run" />
                           <span className="min-w-0 flex-1">
                             <span className="block truncate text-xs font-semibold text-text-primary">{run.workflow_name}</span>
-                            <span className="mt-0.5 block truncate text-[10px] text-text-tertiary">
+                            <span className="mt-0.5 block truncate text-2xs text-text-tertiary">
                               {formatWorkflowRunTimestamp(run.created_at)}{input ? ` · ${input}` : ''}
                             </span>
                           </span>

--- a/desktop/apps/electron/src/renderer/components/composer/ModelPickerMenu.tsx
+++ b/desktop/apps/electron/src/renderer/components/composer/ModelPickerMenu.tsx
@@ -62,7 +62,7 @@ export function ModelPickerMenu() {
         <button
           type="button"
           onClick={() => setOpen(true)}
-          className="relative inline-flex items-center gap-1 px-2.5 py-1 rounded-md bg-bg-hover text-text-secondary text-xs font-medium hover:text-text-primary outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40"
+          className="relative inline-flex items-center gap-1 px-2.5 py-1 rounded-md bg-bg-hover text-text-primary text-sm font-medium hover:bg-bg-active outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40"
           aria-label={t('composer.model.switchAria')}
         >
           {Icons.robot(14)}
@@ -275,7 +275,7 @@ function ModelPickerBody({
 
 /** Centred empty-state hint (no models / no matches). */
 function EmptyHint({ text }: { text: string }) {
-  return <div className="px-3 py-12 text-xs text-text-tertiary text-center">{text}</div>
+  return <div className="px-3 py-12 text-sm text-text-tertiary text-center">{text}</div>
 }
 
 function Groups({
@@ -299,7 +299,7 @@ function Groups({
       {groups.map((g, gi) => (
         <div key={g.id}>
           {gi > 0 && <div className="mx-3 my-1 h-px bg-border-subtle" />}
-          <div className="px-4 pt-1.5 pb-1 text-[11px] font-semibold text-text-tertiary tracking-wide">
+          <div className="px-4 pt-1.5 pb-1 text-xs font-semibold text-text-tertiary tracking-wide">
             {g.displayName}
           </div>
           {g.rows.map((row) => {
@@ -349,7 +349,7 @@ function Row({
       )}
     >
       <span
-        className="w-[22px] h-[22px] rounded-[5px] flex items-center justify-center text-[11px] font-bold text-white flex-shrink-0"
+        className="w-[22px] h-[22px] rounded-[5px] flex items-center justify-center text-xs font-bold text-white flex-shrink-0"
         style={{ background: brand.brandColor }}
       >
         {brand.iconLetter}
@@ -363,7 +363,7 @@ function Row({
         {row.modelId}
       </span>
       {active && (
-        <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-accent-blue-subtle text-brand-blue flex-shrink-0">
+        <span className="text-2xs font-semibold px-1.5 py-0.5 rounded bg-accent-blue-subtle text-text-accent flex-shrink-0">
           {t('composer.model.current')}
         </span>
       )}

--- a/desktop/apps/electron/src/renderer/components/composer/NoModelPlaceholder.tsx
+++ b/desktop/apps/electron/src/renderer/components/composer/NoModelPlaceholder.tsx
@@ -92,7 +92,7 @@ export function NoModelPlaceholder({
     >
       <span>{t('composer.noModel.ctaPrefix')}</span>
       {/* The inline blue "configure model" — visual emphasis, with an underline on hover to signal explicitly that it is clickable. */}
-      <span className="ml-1 font-semibold text-brand-blue group-hover:underline underline-offset-2">
+      <span className="ml-1 font-semibold text-text-accent group-hover:underline underline-offset-2">
         {t('composer.noModel.configure')}
       </span>
     </button>

--- a/desktop/apps/electron/src/renderer/components/composer/menus/MentionMenu.tsx
+++ b/desktop/apps/electron/src/renderer/components/composer/menus/MentionMenu.tsx
@@ -123,17 +123,17 @@ function MentionMenuHeader({ state, q }: MentionMenuHeaderProps) {
     <div className="border-b border-border-subtle px-3 pb-2.5 pt-3">
       <div className="flex items-start justify-between gap-3">
         <div className="flex min-w-0 items-center gap-2.5">
-          <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-accent-blue-subtle text-brand-blue">
+          <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-accent-blue-subtle text-text-accent">
             {Icons.at(14)}
           </span>
           <div className="min-w-0">
-            <div className="text-xs font-semibold text-text-primary">{t('mention.title')}</div>
-            <div className="mt-0.5 truncate text-[10px] text-text-tertiary">
+            <div className="text-sm font-semibold text-text-primary">{t('mention.title')}</div>
+            <div className="mt-0.5 truncate text-xs text-text-tertiary">
               {q ? t('mention.searchingFor', { query: q }) : t('mention.subtitle')}
             </div>
           </div>
         </div>
-        <kbd className="shrink-0 rounded border border-border-subtle bg-bg-hover px-1.5 py-0.5 text-[9px] text-text-tertiary">
+        <kbd className="shrink-0 rounded border border-border-subtle bg-bg-hover px-1.5 py-0.5 text-2xs text-text-tertiary">
           Esc
         </kbd>
       </div>
@@ -146,17 +146,17 @@ function MentionMenuHeader({ state, q }: MentionMenuHeaderProps) {
             aria-selected={state.scope === scope}
             onClick={() => state.setScope(scope)}
             className={cn(
-              'flex h-7 min-w-0 items-center justify-center gap-1 rounded px-2 text-[10px] font-medium text-text-tertiary transition-colors',
+              'flex h-7 min-w-0 items-center justify-center gap-1 rounded px-2 text-xs font-medium text-text-tertiary transition-colors',
               state.scope === scope && 'bg-bg-elevated text-text-primary shadow-sm',
             )}
           >
             <span className="truncate">{t(SCOPE_LABEL_KEYS[scope])}</span>
-            <span className="shrink-0 tabular-nums text-[9px] text-text-tertiary">{scopeCount(state, scope)}</span>
+            <span className="shrink-0 tabular-nums text-xs text-text-tertiary">{scopeCount(state, scope)}</span>
           </button>
         ))}
       </div>
       {state.searchPartial && (state.scope === 'all' || state.scope === 'session-files') && (
-        <div className="mt-2 text-[10px] text-status-warning">{t('mention.partialWarning')}</div>
+        <div className="mt-2 text-xs text-status-warning">{t('mention.partialWarning')}</div>
       )}
     </div>
   )
@@ -193,7 +193,7 @@ function MenuBody({
     else if (state.scope === 'workflows') message = t('mention.empty.workflows')
     else if (state.scope === 'schedules') message = t('mention.empty.schedules')
     return (
-      <div className="px-2.5 py-6 text-center text-xs text-text-tertiary leading-[1.6]">
+      <div className="px-2.5 py-6 text-center text-sm text-text-tertiary leading-[1.6]">
         {message}
         {state.scope === 'session-files' && (
           <>
@@ -228,7 +228,7 @@ function MenuBody({
   return (
     <>
       {state.loading && (
-        <div className="px-2.5 py-1 text-[10px] text-text-tertiary">
+        <div className="px-2.5 py-1 text-xs text-text-tertiary">
           {state.mode === 'search' ? t('mention.loading.search') : t('mention.loading.browse')}
         </div>
       )}
@@ -301,7 +301,7 @@ function WorkflowRow({ row, selected, rowRef, onPick, onPreview }: WorkflowRowPr
       onClick={() => onPick(row)}
       className={cn(
         'group/workflow flex cursor-pointer items-center gap-2 rounded-md border-l-2 border-transparent px-2.5 py-2 hover:bg-bg-hover',
-        selected && 'border-brand-blue bg-bg-hover',
+        selected && 'border-brand-blue bg-bg-selected',
       )}
     >
       <span data-resource-kind="workflow" className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-entity-workflow-bg text-entity-workflow">
@@ -309,10 +309,10 @@ function WorkflowRow({ row, selected, rowRef, onPick, onPreview }: WorkflowRowPr
       </span>
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-1.5">
-          <div className="min-w-0 flex-1 truncate text-xs font-semibold text-text-primary">{workflow.name}</div>
-          <span className="shrink-0 rounded-full bg-entity-workflow-bg px-1.5 py-0.5 text-[9px] font-medium text-entity-workflow">{t('mention.badge.workflow')}</span>
+          <div className="min-w-0 flex-1 truncate text-sm font-semibold text-text-primary">{workflow.name}</div>
+          <span className="shrink-0 rounded-full bg-entity-workflow-bg px-1.5 py-0.5 text-2xs font-medium text-entity-workflow">{t('mention.badge.workflow')}</span>
         </div>
-        <div className="mt-0.5 truncate text-[10px] text-text-tertiary">
+        <div className="mt-0.5 truncate text-xs text-text-tertiary">
           {t('mention.workflow.editable')} · {workflow.desc || t('mention.workflow.defaultDesc')}
         </div>
       </div>
@@ -324,7 +324,7 @@ function WorkflowRow({ row, selected, rowRef, onPick, onPreview }: WorkflowRowPr
           onPreview(workflow)
         }}
         className={cn(
-          'flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-text-tertiary transition-colors hover:bg-bg-surface hover:text-brand-blue',
+          'flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-text-tertiary transition-colors hover:bg-bg-surface hover:text-text-accent',
           selected ? 'opacity-100' : 'opacity-0 group-hover/workflow:opacity-100',
         )}
       >
@@ -343,7 +343,7 @@ function ScheduleRow({ row, selected, rowRef, onPick }: RowProps<Extract<Mention
       onClick={() => onPick(row)}
       className={cn(
         'flex cursor-pointer items-center gap-2 rounded-md border-l-2 border-transparent px-2.5 py-2 hover:bg-bg-hover',
-        selected && 'border-brand-blue bg-bg-hover',
+        selected && 'border-brand-blue bg-bg-selected',
       )}
     >
       <span data-resource-kind="schedule" className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-entity-schedule-bg text-entity-schedule">
@@ -351,10 +351,10 @@ function ScheduleRow({ row, selected, rowRef, onPick }: RowProps<Extract<Mention
       </span>
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-1.5">
-          <div className="min-w-0 flex-1 truncate text-xs font-semibold text-text-primary">{schedule.name}</div>
-          <span className="shrink-0 rounded-full bg-entity-schedule-bg px-1.5 py-0.5 text-[9px] font-medium text-entity-schedule">{t('mention.badge.schedule')}</span>
+          <div className="min-w-0 flex-1 truncate text-sm font-semibold text-text-primary">{schedule.name}</div>
+          <span className="shrink-0 rounded-full bg-entity-schedule-bg px-1.5 py-0.5 text-2xs font-medium text-entity-schedule">{t('mention.badge.schedule')}</span>
         </div>
-        <div className="mt-0.5 truncate text-[10px] text-text-tertiary">
+        <div className="mt-0.5 truncate text-xs text-text-tertiary">
           {schedule.desc || t('mention.schedule.defaultDesc')}
         </div>
       </div>
@@ -376,13 +376,13 @@ function ScopeLinkRow({
       onClick={() => onPick(row)}
       className={cn(
         'flex cursor-pointer items-center gap-2 rounded-md px-2.5 py-2 text-entity-workflow-run hover:bg-bg-hover',
-        selected && 'bg-bg-hover',
+        selected && 'bg-bg-selected',
       )}
     >
       <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-entity-workflow-run-bg">
         {Icons.workflowResult(14)}
       </span>
-      <span className="min-w-0 flex-1 truncate text-xs font-medium">
+      <span className="min-w-0 flex-1 truncate text-sm font-medium">
         {t('mention.viewAllRuns', { total: row.total })}
       </span>
       <span className="shrink-0">{Icons.chevronRight(13)}</span>
@@ -394,7 +394,7 @@ function MentionSectionLabel({ label }: { label: string }) {
   return (
     <div
       data-mention-section={label}
-      className="px-2 pb-1 pt-1.5 text-[9px] font-semibold uppercase text-text-tertiary"
+      className="px-2 pb-1 pt-1.5 text-xs font-semibold uppercase text-text-tertiary"
     >
       {label}
     </div>
@@ -404,7 +404,7 @@ function MentionSectionLabel({ label }: { label: string }) {
 function MentionMenuFooter() {
   const { t } = useTranslation()
   return (
-    <div className="flex h-8 items-center gap-3 border-t border-border-subtle px-3 text-[9px] text-text-tertiary">
+    <div className="flex h-8 items-center gap-3 border-t border-border-subtle px-3 text-xs text-text-tertiary">
       <span><kbd>↑↓</kbd> {t('mention.footer.select')}</span>
       <span><kbd>←→</kbd> {t('mention.footer.switchScope')}</span>
       <span><kbd>Enter</kbd> {t('mention.footer.reference')}</span>
@@ -444,7 +444,7 @@ function WorkflowRunRow({ row, selected, rowRef, onPick, onPreview }: WorkflowRu
       onClick={() => onPick(row)}
       className={cn(
         'group/workflow-run flex cursor-pointer items-center gap-2 rounded-md border-l-2 border-transparent px-2.5 py-2 hover:bg-bg-hover',
-        selected && 'border-brand-blue bg-bg-hover',
+        selected && 'border-brand-blue bg-bg-selected',
       )}
     >
       <span data-resource-kind="workflow-run" className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-entity-workflow-run-bg text-entity-workflow-run">
@@ -452,16 +452,16 @@ function WorkflowRunRow({ row, selected, rowRef, onPick, onPreview }: WorkflowRu
       </span>
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-1.5">
-          <div className="min-w-0 flex-1 truncate text-xs font-semibold text-text-primary">{run.workflow_name}</div>
-          <span className="shrink-0 rounded-full bg-entity-workflow-run-bg px-1.5 py-0.5 text-[9px] font-medium text-entity-workflow-run">
+          <div className="min-w-0 flex-1 truncate text-sm font-semibold text-text-primary">{run.workflow_name}</div>
+          <span className="shrink-0 rounded-full bg-entity-workflow-run-bg px-1.5 py-0.5 text-2xs font-medium text-entity-workflow-run">
             {t('mention.badge.workflowRun')}
           </span>
         </div>
         <div className="mt-0.5 flex min-w-0 items-center gap-1.5">
-          <div className="min-w-0 flex-1 truncate text-[10px] text-text-tertiary">
+          <div className="min-w-0 flex-1 truncate text-xs text-text-tertiary">
             {formatWorkflowRunTimestamp(run.created_at)}{input ? ` · ${input}` : ''}
           </div>
-          <span className={cn('shrink-0 rounded-full px-1.5 py-0.5 text-[9px] font-medium', statusTone)}>{status}</span>
+          <span className={cn('shrink-0 rounded-full px-1.5 py-0.5 text-2xs font-medium', statusTone)}>{status}</span>
         </div>
       </div>
       <button
@@ -472,7 +472,7 @@ function WorkflowRunRow({ row, selected, rowRef, onPick, onPreview }: WorkflowRu
           onPreview(run)
         }}
         className={cn(
-          'flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-text-tertiary transition-colors hover:bg-bg-surface hover:text-brand-blue',
+          'flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-text-tertiary transition-colors hover:bg-bg-surface hover:text-text-accent',
           selected ? 'opacity-100' : 'opacity-0 group-hover/workflow-run:opacity-100',
         )}
       >
@@ -511,7 +511,7 @@ function TreeRow({
       onClick={handleClick}
       className={cn(
         'group/mention-tree flex items-center gap-1.5 px-2 py-[5px] rounded-md cursor-pointer hover:bg-bg-hover',
-        selected && 'bg-bg-hover',
+        selected && 'bg-bg-selected',
       )}
     >
       {/* Indent guides: one 13px left border segment per level, visually continuous across rows (same as the right-panel tree). */}
@@ -527,17 +527,17 @@ function TreeRow({
       <span className={cn('flex flex-shrink-0', extColor(row.name, row.nodeKind))}>
         {isFolder ? Icons.folder(15) : Icons.file(14)}
       </span>
-      <span className="flex-1 min-w-0 text-xs font-medium font-mono text-text-primary truncate">
+      <span className="flex-1 min-w-0 text-sm font-medium font-mono text-text-primary truncate">
         {row.name}
       </span>
       {row.loadingChildren && (
-        <span className="text-[10px] text-text-tertiary flex-shrink-0">{t('mention.tree.loading')}</span>
+        <span className="text-xs text-text-tertiary flex-shrink-0">{t('mention.tree.loading')}</span>
       )}
       {row.unreadable && (
-        <span className="text-[10px] text-text-tertiary flex-shrink-0">{t('mention.tree.unreadable')}</span>
+        <span className="text-xs text-text-tertiary flex-shrink-0">{t('mention.tree.unreadable')}</span>
       )}
       {row.sizeBytes !== null && (
-        <span className="text-[10px] text-text-tertiary flex-shrink-0">
+        <span className="text-xs text-text-tertiary flex-shrink-0">
           {formatSize(row.sizeBytes)}
         </span>
       )}
@@ -549,7 +549,7 @@ function TreeRow({
         }}
         aria-label={t('mention.tree.referenceAria', { name: row.name })}
         // Always rendered, shown/hidden via opacity (§LS1): folders can be referenced with the mouse too, not only via Enter.
-        className="w-4 text-center text-[11px] font-semibold text-brand-blue flex-shrink-0 opacity-0 group-hover/mention-tree:opacity-100 transition-opacity"
+        className="w-4 text-center text-xs font-semibold text-text-accent flex-shrink-0 opacity-0 group-hover/mention-tree:opacity-100 transition-opacity"
       >
         @
       </button>
@@ -565,11 +565,11 @@ function MoreRow({ row, selected, rowRef, onPick }: RowProps<Extract<MentionRow,
       onClick={() => onPick(row)}
       className={cn(
         'flex items-center gap-1.5 px-2 py-[5px] rounded-md cursor-pointer hover:bg-bg-hover',
-        selected && 'bg-bg-hover',
+        selected && 'bg-bg-selected',
       )}
     >
       <span className="w-3.5 flex-shrink-0" />
-      <span className="text-[10px] text-brand-blue">{t('mention.more', { remaining: row.remaining })}</span>
+      <span className="text-xs text-text-accent">{t('mention.more', { remaining: row.remaining })}</span>
     </div>
   )
 }
@@ -587,7 +587,7 @@ function SearchRow({
       onClick={() => onPick(row)}
       className={cn(
         'flex items-center gap-2 px-2.5 py-[7px] rounded-md cursor-pointer hover:bg-bg-hover',
-        selected && 'bg-bg-hover',
+        selected && 'bg-bg-selected',
       )}
     >
       <span className={cn('flex flex-shrink-0', extColor(h.name, h.kind))}>
@@ -598,7 +598,7 @@ function SearchRow({
           <Highlighted text={h.name} ranges={h.nameRanges} />
         </div>
         {h.crumb.length > 0 && (
-          <div className="flex items-center gap-1 mt-px text-[10px] text-text-tertiary truncate">
+          <div className="flex items-center gap-1 mt-px text-xs text-text-tertiary truncate">
             <span className="flex flex-shrink-0">{Icons.folder(10)}</span>
             <span className="truncate">
               <Highlighted text={h.crumb.join(' / ')} ranges={hitCrumbRanges(h)} />
@@ -606,7 +606,7 @@ function SearchRow({
           </div>
         )}
       </div>
-      <span className="text-[10px] text-text-tertiary flex-shrink-0">
+      <span className="text-xs text-text-tertiary flex-shrink-0">
         {hitSizeLabel(h)}
       </span>
     </div>

--- a/desktop/apps/electron/src/renderer/components/composer/menus/SlashMenu.tsx
+++ b/desktop/apps/electron/src/renderer/components/composer/menus/SlashMenu.tsx
@@ -63,7 +63,7 @@ export function SlashMenu({ rows, selectedIndex, style, onPick }: SlashMenuProps
       onMouseDown={(e) => e.preventDefault()}
     >
       {rows.length === 0 ? (
-        <div className="px-3 py-2 text-xs text-text-tertiary">{t('composer.slash.empty')}</div>
+        <div className="px-3 py-2 text-sm text-text-tertiary">{t('composer.slash.empty')}</div>
       ) : (
         rows.map((row, idx) => {
           const showGroup = !renderedGroups.has(row.group)
@@ -73,7 +73,7 @@ export function SlashMenu({ rows, selectedIndex, style, onPick }: SlashMenuProps
           return (
             <div key={`${row.kind}-${row.id}`}>
               {showGroup && (
-                <div className="flex items-center gap-1.5 px-3 pt-2 pb-1 text-[10px] text-text-tertiary">
+                <div className="flex items-center gap-1.5 px-3 pt-2 pb-1 text-xs text-text-tertiary">
                   {/* The entity-colored dot before the group heading (design handoff). */}
                   <span className={cn('w-1.5 h-1.5 rounded-full flex-shrink-0', color.dot)} />
                   <span>{t(slashGroupTranslationKey(row.group))}</span>
@@ -103,7 +103,7 @@ export function SlashMenu({ rows, selectedIndex, style, onPick }: SlashMenuProps
                   only clue that "there is more, type a keyword", so de-emphasizing it is the same as not having it.
                   Not a button and with no onClick — it does not enter the rows index and does not affect ↑↓ navigation (§1.28). */}
               {row.kind !== SlashRowKind.Command && row.overflow ? (
-                <div className={cn('px-3 pb-1.5 text-[11px] font-medium', color.text)}>
+                <div className={cn('px-3 pb-1.5 text-xs font-medium', color.text)}>
                   {t('composer.slash.overflow', { n: row.overflow })}
                 </div>
               ) : null}

--- a/desktop/apps/electron/src/renderer/components/composer/segments.ts
+++ b/desktop/apps/electron/src/renderer/components/composer/segments.ts
@@ -157,7 +157,7 @@ export function getMentionBadgeClass(group: string): string {
     case MentionGroup.WorkflowRun:
       return 'bg-entity-workflow-run-bg text-entity-workflow-run'
     default:
-      return 'bg-accent-purple-subtle text-brand-purple'
+      return 'bg-accent-purple-subtle text-text-accent-purple'
   }
 }
 

--- a/desktop/apps/electron/src/renderer/components/composer/widgets/SchedFreqWidget.tsx
+++ b/desktop/apps/electron/src/renderer/components/composer/widgets/SchedFreqWidget.tsx
@@ -333,7 +333,7 @@ export function SchedFreqWidget({ value, onChange }: WidgetViewProps) {
         onKeyDown={(e) => e.stopPropagation()}
         className={cn(
           'inline-flex items-center gap-1 align-baseline rounded-md border px-2 py-0.5 text-xs cursor-pointer',
-          'bg-accent-purple-subtle text-brand-purple border-brand-purple/30 hover:border-brand-purple',
+          'bg-accent-purple-subtle text-text-accent-purple border-brand-purple/30 hover:border-brand-purple',
         )}
       >
         {describe(cron)}
@@ -374,7 +374,7 @@ export function SchedFreqWidget({ value, onChange }: WidgetViewProps) {
             <PeriodFields st={st} set={set} />
             {/* Preview — human-readable only, never the raw cron. */}
             <div className="flex items-center gap-2.5 pt-3 border-t border-border-subtle">
-              <span className="text-[10px] font-semibold text-brand-blue bg-accent-blue-subtle px-2 py-0.5 rounded-full shrink-0">
+              <span className="text-2xs font-semibold text-text-accent bg-accent-blue-subtle px-2 py-0.5 rounded-full shrink-0">
                 {t('widget.schedFreq.preview')}
               </span>
               <span className="text-xs text-text-secondary">{describe(cron)}</span>

--- a/desktop/apps/electron/src/renderer/components/composer/widgets/SlotWidget.tsx
+++ b/desktop/apps/electron/src/renderer/components/composer/widgets/SlotWidget.tsx
@@ -37,7 +37,7 @@ export function makeSlotWidget(placeholderKey: string): FC<WidgetViewProps> {
           if (e.key === 'Enter') e.preventDefault()
           e.stopPropagation()
         }}
-        className="inline-block align-bottom resize-none overflow-hidden [field-sizing:content] max-w-full bg-accent-blue-subtle text-brand-blue rounded-sm px-1.5 py-0.5 text-xs outline-none border-0 placeholder:text-brand-blue/50"
+        className="inline-block align-bottom resize-none overflow-hidden [field-sizing:content] max-w-full bg-accent-blue-subtle text-text-accent rounded-sm px-1.5 py-0.5 text-xs outline-none border-0 placeholder:text-text-accent/50"
       />
     )
   }

--- a/desktop/apps/electron/src/renderer/components/human-request/FrameworkInteractionOverlay.tsx
+++ b/desktop/apps/electron/src/renderer/components/human-request/FrameworkInteractionOverlay.tsx
@@ -114,12 +114,12 @@ export function FrameworkInteractionOverlay() {
           className="flex h-10 w-full items-center gap-2 rounded-xl border border-border-default bg-bg-elevated px-3 shadow-lg animate-focus-enter"
           aria-label={t('humanRequest.expandAria')}
         >
-          <span className="flex shrink-0 text-brand-blue">{presentation.icon}</span>
+          <span className="flex shrink-0 text-text-accent">{presentation.icon}</span>
           <span className="shrink-0 text-xs font-semibold text-text-primary">{presentation.title}</span>
           <span className="min-w-0 flex-1 truncate text-left text-xs text-text-secondary">
             {presentation.summary}
           </span>
-          <span className="flex shrink-0 items-center gap-1 text-[11px] font-medium text-brand-blue">
+          <span className="flex shrink-0 items-center gap-1 text-xs font-medium text-text-accent">
             {t('humanRequest.expand')} {Icons.chevronDown(12)}
           </span>
         </button>
@@ -131,10 +131,10 @@ export function FrameworkInteractionOverlay() {
         )}
       >
         <header className="mb-3 flex items-center gap-2 border-b border-border-subtle pb-2.5">
-          <span className="flex text-brand-blue">{presentation.icon}</span>
+          <span className="flex text-text-accent">{presentation.icon}</span>
           <div className="min-w-0 flex-1">
             <div className="text-xs font-semibold text-text-primary">{presentation.title}</div>
-            <div className="mt-0.5 truncate text-[11px] text-text-secondary">{presentation.summary}</div>
+            <div className="mt-0.5 truncate text-xs text-text-secondary">{presentation.summary}</div>
           </div>
           <button
             type="button"

--- a/desktop/apps/electron/src/renderer/components/human-request/HumanRequestBanner.tsx
+++ b/desktop/apps/electron/src/renderer/components/human-request/HumanRequestBanner.tsx
@@ -70,7 +70,7 @@ function OptionMarker({ review, selected, index }: { review: boolean; selected: 
       <span
         aria-hidden="true"
         className={cn(
-          'mt-0.5 h-4 w-4 shrink-0 rounded border flex items-center justify-center text-[10px] font-bold',
+          'mt-0.5 h-4 w-4 shrink-0 rounded border flex items-center justify-center text-2xs font-bold',
           selected
             ? 'border-brand-blue bg-brand-blue text-white'
             : 'border-border-default bg-bg-surface',
@@ -294,10 +294,10 @@ export function HumanRequestChoice({ request, floating = false }: ChooseAskProps
         className="flex h-11 w-full items-center gap-2.5 rounded-xl border border-border-default bg-bg-elevated px-3.5 text-left shadow-lg animate-focus-enter hover:border-brand-blue/50"
         aria-label={t('humanRequest.expandAria')}
       >
-        <span className="flex shrink-0 text-brand-blue">{Icons.chat(15)}</span>
+        <span className="flex shrink-0 text-text-accent">{Icons.chat(15)}</span>
         <span className="shrink-0 text-xs font-semibold text-text-primary">{t('humanRequest.waitingTitle')}</span>
         <span className="min-w-0 flex-1 truncate text-xs text-text-secondary">{summary}</span>
-        <span className="flex shrink-0 items-center gap-1 text-[11px] font-medium text-brand-blue">
+        <span className="flex shrink-0 items-center gap-1 text-xs font-medium text-text-accent">
           {t('humanRequest.expand')} {Icons.chevronDown(12)}
         </span>
       </button>
@@ -324,7 +324,7 @@ export function HumanRequestChoice({ request, floating = false }: ChooseAskProps
             <div className="flex flex-wrap items-center gap-2">
               <div className="text-sm font-semibold text-text-primary">{t('humanRequest.acceptance.title')}</div>
               {acceptanceRuleCount > 1 && (
-                <span className="rounded-full bg-bg-hover px-2 py-0.5 text-[11px] text-text-secondary">
+                <span className="rounded-full bg-bg-hover px-2 py-0.5 text-xs text-text-secondary">
                   {t('humanRequest.acceptance.suggestionCount', { n: acceptanceRuleCount })}
                 </span>
               )}
@@ -346,7 +346,7 @@ export function HumanRequestChoice({ request, floating = false }: ChooseAskProps
       )}
       {floating && !acceptanceReview && (
         <div className="mb-3 flex items-center gap-2 border-b border-border-subtle pb-2.5">
-          <span className="flex text-brand-blue">{Icons.chat(14)}</span>
+          <span className="flex text-text-accent">{Icons.chat(14)}</span>
           <span className="text-xs font-semibold text-text-primary">{t('humanRequest.needAnswer')}</span>
           <button
             type="button"
@@ -393,13 +393,13 @@ export function HumanRequestChoice({ request, floating = false }: ChooseAskProps
                   )}
                 >
                   {q.header || t('humanRequest.questionN', { n: i + 1 })}
-                  {isAnswered(i, q) && <span className="ml-1 text-brand-blue">✓</span>}
+                  {isAnswered(i, q) && <span className="ml-1 text-text-accent">✓</span>}
                 </div>
               ))}
             </div>
           )}
           {acceptanceReview && acceptanceRuleCount > 1 && (
-            <div className="text-[11px] font-medium text-brand-blue">
+            <div className="text-xs font-medium text-text-accent">
               {t('humanRequest.acceptance.position', { current: activeIdx + 1, total: acceptanceRuleCount })}
             </div>
           )}
@@ -448,7 +448,7 @@ export function HumanRequestChoice({ request, floating = false }: ChooseAskProps
                 {opt.preview && (
                   <button
                     type="button"
-                    className="shrink-0 self-start text-xs text-brand-blue hover:underline"
+                    className="shrink-0 self-start text-xs text-text-accent hover:underline"
                     onClick={(event) => {
                       event.stopPropagation()
                       togglePreview(activeIdx, oi)
@@ -516,7 +516,7 @@ export function HumanRequestChoice({ request, floating = false }: ChooseAskProps
           {activeReviewList && active.multiSelect && (
             <button
               type="button"
-              className="text-xs text-brand-blue hover:underline"
+              className="text-xs text-text-accent hover:underline"
               onClick={() => selectAll(activeIdx, active)}
             >
               {t('humanRequest.selectAll')}
@@ -527,7 +527,7 @@ export function HumanRequestChoice({ request, floating = false }: ChooseAskProps
               type="button"
               className={cn(
                 'text-xs hover:underline',
-                emptySelections[activeIdx] ? 'text-brand-blue' : 'text-text-secondary',
+                emptySelections[activeIdx] ? 'text-text-accent' : 'text-text-secondary',
               )}
               onClick={() => chooseEmpty(activeIdx)}
             >
@@ -549,7 +549,7 @@ export function HumanRequestChoice({ request, floating = false }: ChooseAskProps
             >
               <span className="flex shrink-0 text-text-tertiary">{Icons.play(10)}</span>
               <span className="font-medium">{t('humanRequest.acceptance.executionOnly')}</span>
-              <span className="text-[11px] text-text-tertiary">{t('humanRequest.acceptance.executionOnlyHint')}</span>
+              <span className="text-xs text-text-tertiary">{t('humanRequest.acceptance.executionOnlyHint')}</span>
             </button>
           )}
         </div>

--- a/desktop/apps/electron/src/renderer/components/markdown/MarkdownMessage.tsx
+++ b/desktop/apps/electron/src/renderer/components/markdown/MarkdownMessage.tsx
@@ -263,7 +263,7 @@ export const MarkdownMessage = memo(function MarkdownMessage({
         '[&_ul]:my-2 [&_ul]:pl-5 [&_ul]:list-disc',
         '[&_ol]:my-2 [&_ol]:pl-5 [&_ol]:list-decimal',
         '[&_li]:my-0.5',
-        '[&_a]:text-brand-blue [&_a]:underline [&_a]:underline-offset-2 [&_a]:cursor-pointer',
+        '[&_a]:text-text-accent [&_a]:underline [&_a]:underline-offset-2 [&_a]:cursor-pointer',
         '[&_blockquote]:border-l-2 [&_blockquote]:border-border-default [&_blockquote]:pl-3 [&_blockquote]:text-text-secondary [&_blockquote]:my-2',
         '[&_hr]:my-3 [&_hr]:border-border-subtle',
         '[&_strong]:font-semibold',

--- a/desktop/apps/electron/src/renderer/components/permissions/ComposerModePill.tsx
+++ b/desktop/apps/electron/src/renderer/components/permissions/ComposerModePill.tsx
@@ -124,19 +124,19 @@ export function ComposerModePill() {
                 }}
                 className={cn(
                   'flex items-start gap-2.5 px-3 py-2.5 rounded-md cursor-pointer border border-transparent',
-                  on && 'bg-bg-hover',
+                  on && 'bg-bg-selected',
                 )}
               >
                 <span className={cn('mt-0.5 shrink-0', modeTint(m.id))}>{modeIcon(m.id)(16)}</span>
                 <div className="flex-1 min-w-0">
                   <div className="text-sm font-semibold text-text-primary">{t(m.labelKey)}</div>
-                  <div className="text-[11px] text-text-secondary mt-0.5 leading-snug">{t(m.descKey)}</div>
+                  <div className="text-xs text-text-secondary mt-0.5 leading-snug">{t(m.descKey)}</div>
                 </div>
-                {on && <span className="text-brand-blue mt-0.5 shrink-0">{PIcon.check(14)}</span>}
+                {on && <span className="text-text-accent mt-0.5 shrink-0">{PIcon.check(14)}</span>}
               </div>
             )
           })}
-          <div className="px-3 pt-2 pb-1 mt-1 border-t border-border-subtle text-[11px] text-text-tertiary">
+          <div className="px-3 pt-2 pb-1 mt-1 border-t border-border-subtle text-xs text-text-tertiary">
             {t('permission.pill.globalNote')}
           </div>
         </div>

--- a/desktop/apps/electron/src/renderer/components/permissions/PermissionApproval.tsx
+++ b/desktop/apps/electron/src/renderer/components/permissions/PermissionApproval.tsx
@@ -113,7 +113,7 @@ function ItemBody({ summary, cmd }: { summary?: string; cmd: string }) {
           <button
             type="button"
             onClick={() => setShowCmd((v) => !v)}
-            className="mt-1 text-[11px] font-medium text-brand-blue"
+            className="mt-1 text-xs font-medium text-text-accent"
           >
             {showCmd ? t('permission.command.collapse') : t('permission.command.expand')}
           </button>
@@ -139,7 +139,7 @@ function ClampText({ text }: { text: string }) {
     <div className="mt-0.5">
       <div
         ref={ref}
-        className={cn('text-[11px] leading-[1.5] text-text-secondary', !expanded && 'line-clamp-3')}
+        className={cn('text-xs leading-[1.5] text-text-secondary', !expanded && 'line-clamp-3')}
       >
         {text}
       </div>
@@ -147,7 +147,7 @@ function ClampText({ text }: { text: string }) {
         <button
           type="button"
           onClick={() => setExpanded((v) => !v)}
-          className="mt-0.5 text-[11px] font-medium text-brand-blue"
+          className="mt-0.5 text-xs font-medium text-text-accent"
         >
           {expanded ? t('permission.clamp.collapse') : t('permission.clamp.expand')}
         </button>
@@ -237,7 +237,7 @@ export function PermissionApproval({
     return (
       <div className="my-2.5 max-w-[640px] rounded-lg border border-status-warning bg-bg-elevated px-4 py-3">
         <div className="text-sm font-bold text-text-primary">{t('permission.empty.title')}</div>
-        <div className="mt-1 text-[11px] text-text-secondary">
+        <div className="mt-1 text-xs text-text-secondary">
           {t('permission.empty.desc')}
         </div>
       </div>
@@ -326,12 +326,12 @@ export function PermissionApproval({
           dangerous"). Orange still separates it clearly from the regular blue, which is enough to say "give
           this one a second look". */}
       <div className={cn('flex items-center gap-2.5 px-4 py-2.5', anyHigh ? 'bg-status-warning-bg' : 'bg-accent-blue-subtle')}>
-        <span className={anyHigh ? 'text-status-warning' : 'text-brand-blue'}>
+        <span className={anyHigh ? 'text-status-warning' : 'text-text-accent'}>
           {anyHigh ? PIcon.alert(16) : PIcon.shield(16)}
         </span>
         <div className="min-w-0 flex-1">
           <div className="text-sm font-bold text-text-primary">{headTitle(t, isSingle, items.length, anyHigh, decidedProp === true)}</div>
-          <div className="text-[11px] text-text-secondary mt-px">{headSubtitle(t, isSingle, anyHigh, decidedProp === true)}</div>
+          <div className="text-xs text-text-secondary mt-px">{headSubtitle(t, isSingle, anyHigh, decidedProp === true)}</div>
         </div>
       </div>
 
@@ -380,7 +380,7 @@ export function PermissionApproval({
         {isSingle && decided[0] === undefined && (
           <>
             <div className="mt-3">
-              <div className="text-[11px] font-semibold text-text-tertiary mb-1.5">{t('permission.instruction.label')}</div>
+              <div className="text-xs font-semibold text-text-tertiary mb-1.5">{t('permission.instruction.label')}</div>
               <input
                 value={instruction}
                 onChange={(e) => setInstruction(e.target.value)}
@@ -396,7 +396,7 @@ export function PermissionApproval({
                 {PIcon.ban(13)} {instruction.trim() ? t('permission.action.denyWithInstruction') : t('permission.action.deny')}
               </button>
               <span className="flex-1" />
-              {instruction.trim() && <span className="text-[10px] text-text-tertiary">{t('permission.instruction.onceOnly')}</span>}
+              {instruction.trim() && <span className="text-2xs text-text-tertiary">{t('permission.instruction.onceOnly')}</span>}
               <button
                 onClick={() => decide(0, true)}
                 className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-md bg-brand-blue text-white text-xs font-semibold"
@@ -410,10 +410,10 @@ export function PermissionApproval({
           <div className="mt-3 pb-3.5">
             <div className="flex items-center gap-2.5">
               <DecidedChip allow={decided[0]} />
-              <span className="text-[11px] text-text-tertiary">{decidedNote(t, decided[0], shownInstruction !== '')}</span>
+              <span className="text-xs text-text-tertiary">{decidedNote(t, decided[0], shownInstruction !== '')}</span>
             </div>
             {shownInstruction && (
-              <div className="mt-1.5 rounded-md border border-border-subtle bg-bg-input px-2.5 py-1.5 text-[11px] leading-[1.5] text-text-secondary break-words">
+              <div className="mt-1.5 rounded-md border border-border-subtle bg-bg-input px-2.5 py-1.5 text-xs leading-[1.5] text-text-secondary break-words">
                 <span className="text-text-tertiary">{t('permission.instruction.echoLabel')}</span>
                 {shownInstruction}
               </div>
@@ -427,13 +427,13 @@ export function PermissionApproval({
             {highPending > 0 && (
               <div className="flex gap-2 px-3 py-2 rounded-md bg-status-warning-bg mt-3">
                 <span className="text-status-warning shrink-0 mt-px">{PIcon.alert(12)}</span>
-                <span className="text-[11px] text-text-primary leading-relaxed">
+                <span className="text-xs text-text-primary leading-relaxed">
                   <b>{t('permission.highNotice.bold', { n: highPending })}</b>{t('permission.highNotice.rest')}
                 </span>
               </div>
             )}
             <div className="flex items-center gap-2.5 mt-3">
-              <span className="text-[11px] text-text-tertiary shrink-0">
+              <span className="text-xs text-text-tertiary shrink-0">
                 {allDecided ? (
                   <span className="text-status-success font-semibold">{t('permission.progress.allDone', { n: items.length })}</span>
                 ) : (

--- a/desktop/apps/electron/src/renderer/components/permissions/SettingsModeTab.tsx
+++ b/desktop/apps/electron/src/renderer/components/permissions/SettingsModeTab.tsx
@@ -16,6 +16,7 @@ import {
   setExecutionModeAtom,
 } from '@/atoms/permissions'
 import { cn } from '@/lib/cn'
+import { SettingsTabLayout } from '../amphi/SettingsTabLayout'
 import { MODE_META } from './modeMeta'
 import { modeIcon, modeTint } from './icons'
 
@@ -32,8 +33,8 @@ export function SettingsModeTab() {
   }, [load])
 
   return (
-    <div className="flex flex-col gap-3">
-      <div className="text-xs text-text-secondary leading-relaxed">
+    <SettingsTabLayout>
+      <div className="text-sm text-text-secondary leading-relaxed">
         {t('permission.settings.desc')}
       </div>
       <div className="flex flex-col gap-2">
@@ -44,18 +45,18 @@ export function SettingsModeTab() {
               <span className={cn('mt-0.5 shrink-0', modeTint(m.id))}>{modeIcon(m.id)(18)}</span>
               <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-2">
-                  <span className="text-sm font-bold text-text-primary">{t(m.labelKey)}</span>
+                  <span className="text-sm font-semibold text-text-primary">{t(m.labelKey)}</span>
                   {m.id === 'auto' && (
-                    <span className="text-[9px] font-bold text-brand-blue border border-brand-blue rounded-full px-1.5 py-px">
+                    <span className="text-2xs font-bold text-text-accent border border-brand-blue rounded-full px-1.5 py-px">
                       {t('permission.settings.defaultBadge')}
                     </span>
                   )}
                   <span className="flex-1" />
-                  <span className={cn('text-[11px]', m.id === 'full' ? 'text-status-warning' : 'text-text-tertiary')}>
+                  <span className={cn('text-xs', m.id === 'full' ? 'text-status-warning' : 'text-text-tertiary')}>
                     {t(m.freqKey)}
                   </span>
                 </div>
-                <div className="text-xs text-text-secondary mt-0.5 leading-snug">{t(m.descKey)}</div>
+                <div className="text-sm text-text-secondary mt-0.5 leading-snug">{t(m.descKey)}</div>
               </div>
               <span
                 className={cn(
@@ -69,6 +70,6 @@ export function SettingsModeTab() {
           )
         })}
       </div>
-    </div>
+    </SettingsTabLayout>
   )
 }

--- a/desktop/apps/electron/src/renderer/components/permissions/icons.tsx
+++ b/desktop/apps/electron/src/renderer/components/permissions/icons.tsx
@@ -150,11 +150,11 @@ export function deriveRisk(f: RiskFacts): Risk {
 /** Category icon + colors (capability → presentation). */
 export function categoryMeta(capability: string): { icon: (s?: number) => ReactNode; tint: string; bg: string } {
   if (capability === 'execute') return { icon: PIcon.terminal, tint: 'text-status-warning', bg: 'bg-status-warning-bg' }
-  if (capability === 'network') return { icon: PIcon.globe, tint: 'text-brand-blue', bg: 'bg-accent-blue-subtle' }
-  if (capability === 'mcp') return { icon: PIcon.robot, tint: 'text-brand-blue', bg: 'bg-accent-blue-subtle' }
+  if (capability === 'network') return { icon: PIcon.globe, tint: 'text-text-accent', bg: 'bg-accent-blue-subtle' }
+  if (capability === 'mcp') return { icon: PIcon.robot, tint: 'text-text-accent', bg: 'bg-accent-blue-subtle' }
   if (capability === 'read' || capability === 'edit' || capability === 'manage'
     || capability === 'manage_write' || capability === 'control') {
-    return { icon: PIcon.folder, tint: 'text-brand-purple', bg: 'bg-accent-purple-subtle' }
+    return { icon: PIcon.folder, tint: 'text-text-accent-purple', bg: 'bg-accent-purple-subtle' }
   }
   // Unknown capability (added by the backend, not yet mirrored on the frontend): use a neutral warning style, do not draw the most harmless-looking folder.
   return { icon: PIcon.alert, tint: 'text-status-warning', bg: 'bg-status-warning-bg' }
@@ -166,14 +166,14 @@ export function categoryMeta(capability: string): { icon: (s?: number) => ReactN
 const RISK_BADGE: Record<Risk, { labelKey: string; cls: string }> = {
   high: { labelKey: 'permission.risk.high', cls: 'text-status-error bg-status-error-bg' },
   med: { labelKey: 'permission.risk.med', cls: 'text-status-warning bg-status-warning-bg' },
-  low: { labelKey: 'permission.risk.low', cls: 'text-brand-blue bg-accent-blue-subtle' },
+  low: { labelKey: 'permission.risk.low', cls: 'text-text-accent bg-accent-blue-subtle' },
 }
 
 /** Tier badge (shows "what this step is", no danger narrative). */
 export function RiskBadge({ risk }: { risk: Risk }) {
   const { t } = useTranslation()
   const b = RISK_BADGE[risk]
-  return <span className={cn('text-[10px] font-semibold px-1.5 py-px rounded shrink-0', b.cls)}>{t(b.labelKey)}</span>
+  return <span className={cn('text-2xs font-semibold px-1.5 py-px rounded shrink-0', b.cls)}>{t(b.labelKey)}</span>
 }
 
 /** Decided-record chip (allowed / denied). */
@@ -181,13 +181,13 @@ export function DecidedChip({ allow }: { allow: boolean }) {
   const { t } = useTranslation()
   if (allow) {
     return (
-      <span className="inline-flex items-center gap-1 text-[11px] font-semibold text-status-success shrink-0">
+      <span className="inline-flex items-center gap-1 text-xs font-semibold text-status-success shrink-0">
         {PIcon.check(12)} {t('permission.decided.allowed')}
       </span>
     )
   }
   return (
-    <span className="inline-flex items-center gap-1 text-[11px] font-semibold text-status-error shrink-0">
+    <span className="inline-flex items-center gap-1 text-xs font-semibold text-status-error shrink-0">
       {PIcon.x(12)} {t('permission.decided.denied')}
     </span>
   )
@@ -204,5 +204,5 @@ export function modeIcon(id: ExecutionMode): (s?: number) => ReactNode {
 export function modeTint(id: ExecutionMode): string {
   if (id === 'full') return 'text-status-warning'  // warning (use with care) rather than danger red — full still keeps the system red lines and the credential-deletion block
   if (id === 'request') return 'text-status-info'
-  return 'text-brand-blue'
+  return 'text-text-accent'
 }

--- a/desktop/apps/electron/src/renderer/components/schedules/ApprovalCenter.tsx
+++ b/desktop/apps/electron/src/renderer/components/schedules/ApprovalCenter.tsx
@@ -66,7 +66,7 @@ export function ApprovalCenter() {
                   <div className="text-sm font-semibold text-text-primary">{s.name}</div>
                   <div className="text-xs text-text-secondary mt-0.5 truncate">{s.desc}</div>
                 </div>
-                <span className="text-[10px] text-status-warning font-semibold flex-shrink-0">
+                <span className="text-2xs text-status-warning font-semibold flex-shrink-0">
                   {t('schedule.approval.itemCount', { n: s.needsAction ?? 0 })}
                 </span>
                 <Btn

--- a/desktop/apps/electron/src/renderer/components/schedules/CenterSchedules.tsx
+++ b/desktop/apps/electron/src/renderer/components/schedules/CenterSchedules.tsx
@@ -8,11 +8,14 @@
 import { useEffect, useState } from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
 import { useTranslation } from 'react-i18next'
-import { cn } from '@/lib/cn'
 import { Btn, Icons, WindowedList } from '@/components/amphi'
 import { hydrateSchedulesAtom, schedulesAtom } from '@/atoms/schedules'
 import { openScheduleSessionAtom } from '@/atoms/schedule-session'
 import { ScheduleTemplateMode } from '@/lib/scheduleTemplate'
+import { CenterPageLayout } from '../amphi/CenterPageLayout'
+import { EmptyState } from '../amphi/EmptyState'
+import { RefreshButton } from '../amphi/RefreshButton'
+import { FilterTabs } from '../amphi/FilterTabs'
 import { ScheduleRow } from './ScheduleRow'
 
 const FILTER_KEYS = ['all', 'active', 'paused'] as const
@@ -25,7 +28,6 @@ export function CenterSchedules() {
   const openSession = useSetAtom(openScheduleSessionAtom)
   const hydrate = useSetAtom(hydrateSchedulesAtom)
   const [filter, setFilter] = useState<FilterKey>('all')
-  const [refreshing, setRefreshing] = useState(false)
 
   // Load the real schedule list on mount (external sync — not derived state).
   useEffect(() => {
@@ -45,76 +47,48 @@ export function CenterSchedules() {
   })
 
   const create = () => openSession({ mode: ScheduleTemplateMode.Create })
-  const refresh = async () => {
-    if (refreshing) return
-    setRefreshing(true)
-    await hydrate()
-    setRefreshing(false)
-  }
 
   return (
-    <div className="flex-1 flex flex-col overflow-hidden">
-      <div className="px-8 pt-5 flex items-start justify-between">
-        <div>
-          <h2 className="text-2xl font-bold text-text-primary m-0">{t('schedule.title')}</h2>
-          <p className="text-sm text-text-secondary mt-1">
-            {t('schedule.subtitle')}
-          </p>
-        </div>
-        <div className="flex gap-2">
-          <Btn variant="default" size="md" onClick={refresh}>
-            <span className={cn('flex', refreshing && 'animate-spin')}>{Icons.refresh(14)}</span> {t('schedule.action.refresh')}
-          </Btn>
+    <CenterPageLayout
+      title={t('schedule.title')}
+      subtitle={t('schedule.subtitle')}
+      actions={
+        <>
+          <RefreshButton onRefresh={hydrate} label={t('schedule.action.refresh')} />
           <Btn variant="primary" size="md" data-testid="schedule-create" onClick={create}>
             {Icons.plus(14)} {t('schedule.action.create')}
           </Btn>
-        </div>
-      </div>
-
-      {/* Filter tabs — §LS1: the font weight is fixed in the base class and the selected state only flips color/background. Going from weight 400→600 would
-          make CJK glyphs wider and push the tabs in the group, along with the count parentheses after them, sideways. */}
-      <div className="px-8 pt-4">
-        <div className="flex gap-1 p-1 rounded-md border border-border-subtle bg-bg-surface w-fit">
-          {FILTER_KEYS.map((key) => (
-            <button
-              key={key}
-              type="button"
-              data-testid={`schedule-filter-${key}`}
-              onClick={() => setFilter(key)}
-              className={cn(
-                'px-3.5 py-1 rounded-[5px] text-xs font-semibold',
-                filter === key
-                  ? 'bg-bg-elevated text-text-primary'
-                  : 'text-text-tertiary hover:text-text-secondary',
-              )}
-            >
-              {t(`schedule.filter.${key}`)}
-              <span className="ml-1 opacity-60">({counts[key]})</span>
-            </button>
-          ))}
-        </div>
-      </div>
-
-      <div className="flex-1 overflow-auto px-8 pt-[18px] pb-8">
-        {shown.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-20 text-center">
-            <div className="w-[52px] h-[52px] rounded-full border-[1.5px] border-dashed border-border-strong flex items-center justify-center text-text-tertiary mb-4">
-              {Icons.clock(22)}
-            </div>
-            <div className="text-lg font-semibold text-text-primary mb-1.5">{t('schedule.empty.title')}</div>
-            <div className="text-sm text-text-secondary mb-[18px] max-w-[340px]">
-              {t('schedule.empty.desc')}
-            </div>
+        </>
+      }
+      filters={
+        <FilterTabs
+          tabs={FILTER_KEYS.map((key) => ({
+            key,
+            label: t(`schedule.filter.${key}`),
+            count: counts[key],
+          }))}
+          value={filter}
+          onChange={setFilter}
+          testIdPrefix="schedule-filter-"
+        />
+      }
+    >
+      {shown.length === 0 ? (
+        <EmptyState
+          icon={Icons.clock}
+          title={t('schedule.empty.title')}
+          description={t('schedule.empty.desc')}
+          action={
             <Btn variant="primary" size="md" onClick={create}>
               {Icons.plus(14)} {t('schedule.action.create')}
             </Btn>
-          </div>
-        ) : (
-          <WindowedList items={shown} className="flex flex-col gap-2.5">
-            {(s) => <ScheduleRow key={s.id} s={s} />}
-          </WindowedList>
-        )}
-      </div>
-    </div>
+          }
+        />
+      ) : (
+        <WindowedList items={shown} className="flex flex-col gap-2.5">
+          {(s) => <ScheduleRow key={s.id} s={s} />}
+        </WindowedList>
+      )}
+    </CenterPageLayout>
   )
 }

--- a/desktop/apps/electron/src/renderer/components/schedules/RunAgentLayerNav.tsx
+++ b/desktop/apps/electron/src/renderer/components/schedules/RunAgentLayerNav.tsx
@@ -70,16 +70,16 @@ export function RunAgentLayerNav({ subagents, mainSessionId, selectedSessionId, 
   const { t } = useTranslation()
   return (
     <aside className="w-52 flex-shrink-0 overflow-y-auto border-r border-border-subtle px-2.5 py-3">
-      <div className="mb-1.5 px-2 text-[11px] font-medium text-text-tertiary">{t('schedule.nav.title')}</div>
+      <div className="mb-1.5 px-2 text-xs font-medium text-text-tertiary">{t('schedule.nav.title')}</div>
       <NavButton
-        icon={<Bot size={14} className="text-brand-blue" />}
+        icon={<Bot size={14} className="text-text-accent" />}
         label={t('schedule.nav.mainAgent')}
         selected={selectedSessionId === mainSessionId}
         onClick={() => onSelect(mainSessionId)}
       />
       {subagents.length > 0 && (
         <>
-          <div className="mb-1 mt-3 px-2 text-[11px] text-text-tertiary">
+          <div className="mb-1 mt-3 px-2 text-xs text-text-tertiary">
             {t('schedule.nav.subAgents', { n: subagents.length })}
           </div>
           <div className="space-y-0.5">

--- a/desktop/apps/electron/src/renderer/components/schedules/RunLogDrawer.tsx
+++ b/desktop/apps/electron/src/renderer/components/schedules/RunLogDrawer.tsx
@@ -86,7 +86,7 @@ function emptyRunText(t: ReturnType<typeof useTranslation>['t'], hydrated: boole
 function RunMeta({ label, value, accent, mono }: { label: string; value: string; accent?: string; mono?: boolean }) {
   return (
     <div className="min-w-0">
-      <div className="text-[10px] text-text-tertiary mb-0.5">{label}</div>
+      <div className="text-2xs text-text-tertiary mb-0.5">{label}</div>
       <Tooltip content={value} onlyWhenTruncated>
         <div className={cn('text-sm font-semibold truncate', accent ?? 'text-text-primary', mono && 'font-mono')}>
           {value}
@@ -291,7 +291,7 @@ export function RunLogDrawer({ scheduleId, run }: RunLogDrawerProps) {
           <div className="text-sm text-text-secondary mt-1">{name}</div>
           <div className="grid grid-cols-3 gap-3 mt-3.5">
             <RunMeta label={t('schedule.run.time')} value={run.time} mono />
-            <RunMeta label={t('schedule.run.trigger')} value={t('schedule.run.scheduledTrigger')} accent="text-brand-blue" />
+            <RunMeta label={t('schedule.run.trigger')} value={t('schedule.run.scheduledTrigger')} accent="text-text-accent" />
             <RunMeta label={t('schedule.run.sessionId')} value={viewSessionId} mono />
           </div>
         </div>

--- a/desktop/apps/electron/src/renderer/components/schedules/ScheduleDetail.tsx
+++ b/desktop/apps/electron/src/renderer/components/schedules/ScheduleDetail.tsx
@@ -75,7 +75,7 @@ export function ScheduleDetail({ s }: ScheduleDetailProps) {
         </button>
         <div className="flex items-start justify-between gap-4">
           <div className="flex items-center gap-3.5 min-w-0">
-            <div className="w-11 h-11 rounded-md flex-shrink-0 flex items-center justify-center bg-accent-purple-subtle text-brand-purple">
+            <div className="w-11 h-11 rounded-md flex-shrink-0 flex items-center justify-center bg-accent-purple-subtle text-text-accent-purple">
               {Icons.clock(20)}
             </div>
             <div className="min-w-0">
@@ -164,7 +164,7 @@ export function ScheduleDetail({ s }: ScheduleDetailProps) {
         <Card className="px-[18px] mb-7">
           <ConfigRow label={t('schedule.detail.config.trigger')}>
             <span>{describeCron(s.cron, t)}</span>
-            <span className="ml-2.5 text-[11px] text-text-tertiary font-mono bg-bg-hover px-2 py-0.5 rounded-md">
+            <span className="ml-2.5 text-xs text-text-tertiary font-mono bg-bg-hover px-2 py-0.5 rounded-md">
               {s.cron}
             </span>
           </ConfigRow>
@@ -177,7 +177,7 @@ export function ScheduleDetail({ s }: ScheduleDetailProps) {
                 s.skills.map((n) => (
                   <span
                     key={n}
-                    className="inline-flex items-center gap-1.5 text-xs font-mono text-brand-purple bg-accent-purple-subtle px-2.5 py-0.5 rounded-full"
+                    className="inline-flex items-center gap-1.5 text-xs font-mono text-text-accent-purple bg-accent-purple-subtle px-2.5 py-0.5 rounded-full"
                   >
                     {Icons.terminal(11)} {n}
                   </span>
@@ -190,7 +190,7 @@ export function ScheduleDetail({ s }: ScheduleDetailProps) {
           <ConfigRow label={t('schedule.detail.config.nextRun')}>
             <SchedTime
               value={s.nextRun}
-              className={cn(st === ScheduleStatus.Active ? 'text-brand-blue' : 'text-text-secondary')}
+              className={cn(st === ScheduleStatus.Active ? 'text-text-accent' : 'text-text-secondary')}
             />
           </ConfigRow>
           <ConfigRow label={t('schedule.detail.config.lastRun')}>

--- a/desktop/apps/electron/src/renderer/components/schedules/ScheduleRow.tsx
+++ b/desktop/apps/electron/src/renderer/components/schedules/ScheduleRow.tsx
@@ -55,7 +55,7 @@ export const ScheduleRow = memo(function ScheduleRow({ s }: ScheduleRowProps) {
       onClick={() => openDetail(s.id)}
       className="px-[18px] py-3.5 flex items-center gap-3.5 cursor-pointer hover:bg-bg-hover transition-colors"
     >
-      <div className="w-10 h-10 rounded-md flex-shrink-0 flex items-center justify-center bg-accent-purple-subtle text-brand-purple">
+      <div className="w-10 h-10 rounded-md flex-shrink-0 flex items-center justify-center bg-accent-purple-subtle text-text-accent-purple">
         {Icons.clock(18)}
       </div>
 
@@ -76,7 +76,7 @@ export const ScheduleRow = memo(function ScheduleRow({ s }: ScheduleRowProps) {
             {t('schedule.row.lastRun')}<SchedTime value={s.lastRun} />
           </span>
           <span
-            className={cn('text-xs', st === ScheduleStatus.Active ? 'text-brand-blue' : 'text-text-tertiary')}
+            className={cn('text-xs', st === ScheduleStatus.Active ? 'text-text-accent' : 'text-text-tertiary')}
           >
             {t('schedule.row.nextRun')}<SchedTime value={s.nextRun} />
           </span>

--- a/desktop/apps/electron/src/renderer/index.css
+++ b/desktop/apps/electron/src/renderer/index.css
@@ -15,7 +15,8 @@
    Keep this block in sync with `styles/tokens.css`.
    ───────────────────────────────────────────────────────────────────────── */
 @theme inline {
-  /* Typography — overrides Tailwind defaults (12/14/16) with our 11/12/13 scale */
+  /* Typography — overrides Tailwind defaults (12/14/16) with our 12/13/14 scale */
+  --text-2xs: var(--text-2xs);
   --text-xs: var(--text-xs);
   --text-sm: var(--text-sm);
   --text-base: var(--text-base);
@@ -41,6 +42,9 @@
   --color-bg-elevated: var(--bg-elevated);
   --color-bg-hover: var(--bg-hover);
   --color-bg-active: var(--bg-active);
+  /* The persistent "this one is selected" fill — see tokens.css. Use it for
+     selected state; --bg-hover / --bg-active stay for pointer feedback. */
+  --color-bg-selected: var(--bg-selected);
   --color-bg-input: var(--bg-input);
   --color-bg-modal: var(--bg-modal);
   --color-bg-tooltip: var(--bg-tooltip);
@@ -56,6 +60,10 @@
   --color-text-tertiary: var(--text-tertiary);
   --color-text-inverse: var(--text-inverse);
   --color-text-on-brand: var(--text-on-brand);
+  /* Text-only blue/purple. Use these for `text-*`; --color-brand-* stays for
+     fills and borders. */
+  --color-text-accent: var(--text-accent);
+  --color-text-accent-purple: var(--text-accent-purple);
 
   /* Status — paired color + tint background */
   --color-status-success: var(--status-success);

--- a/desktop/apps/electron/src/renderer/lib/__tests__/file-tree.test.ts
+++ b/desktop/apps/electron/src/renderer/lib/__tests__/file-tree.test.ts
@@ -121,6 +121,6 @@ describe('extColor', () => {
     expect(extColor('c.zip', 'file')).toBe('text-[#E0A33A]')
     expect(extColor('d.docx', 'file')).toBe('text-[#3B82C4]')
     expect(extColor('e.weird', 'file')).toBe('text-text-tertiary')
-    expect(extColor('any', 'folder')).toBe('text-brand-blue')
+    expect(extColor('any', 'folder')).toBe('text-text-accent')
   })
 })

--- a/desktop/apps/electron/src/renderer/lib/fileTree.ts
+++ b/desktop/apps/electron/src/renderer/lib/fileTree.ts
@@ -109,7 +109,7 @@ const EXT_COLOR: Record<string, string> = {
 
 /** Icon tint class: folders brand-blue, files by extension, default tertiary. */
 export function extColor(name: string, kind: 'file' | 'folder'): string {
-  if (kind === 'folder') return 'text-brand-blue'
+  if (kind === 'folder') return 'text-text-accent'
   const ext = (name.split('.').pop() ?? '').toLowerCase()
   return EXT_COLOR[ext] ?? 'text-text-tertiary'
 }

--- a/desktop/apps/electron/src/renderer/styles/tokens.css
+++ b/desktop/apps/electron/src/renderer/styles/tokens.css
@@ -16,10 +16,18 @@
   --font-sans: 'Plus Jakarta Sans', -apple-system, 'PingFang SC', 'Noto Sans SC', sans-serif;
   --font-mono: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
 
-  --text-xs: 11px;
-  --text-sm: 12px;
-  --text-base: 13px;
-  --text-md: 14px;
+  /* The bottom four steps were each 1px smaller than this (11/12/13/14) and
+     users reported the UI as hard to read — body copy in a chat window sat at
+     12px. The scale's floor is --text-2xs; nothing should be smaller, which is
+     why it exists at all: it replaces the text-[9px] / text-[10px] /
+     text-[11px] one-offs that used to bypass the scale.
+     lg and up are unchanged — headings were never the complaint, and leaving
+     them still keeps the layout risk on the four steps that had to move. */
+  --text-2xs: 11px;
+  --text-xs: 12px;
+  --text-sm: 13px;
+  --text-base: 14px;
+  --text-md: 15px;
   --text-lg: 16px;
   --text-xl: 18px;
   --text-2xl: 22px;
@@ -62,6 +70,14 @@
   --bg-elevated: #31312F;
   --bg-hover: #383836;
   --bg-active: #424240;
+  /* Selection has its own value because it is its own idea, not a shade of the
+     pointer states: it persists, it must not be mistaken for the row the cursor
+     happens to sit on, and it must not shout. Reusing --bg-hover made selection
+     invisible (1.22:1 here, 1.08:1 in light); reusing --bg-active read as heavy
+     once every selected surface in the app carried it. This sits at the midpoint
+     — 1.32:1 against --bg-surface. Change it here and all 14 selected surfaces
+     move together. */
+  --bg-selected: #3D3D3B;
   --bg-input: #2C2C2A;
   --bg-modal: #2A2A28;
   --bg-tooltip: #454543;
@@ -71,10 +87,22 @@
   --border-strong: #4E4E4C;
 
   --text-primary: #EDEBE7;
-  --text-secondary: #A8A5A0;
-  --text-tertiary: #918E89;
+  /* Contrast is measured against --bg-hover, not --bg-surface: a hovered list
+     row is a state the pointer rests in, so its text has to stay readable
+     there, and the hover background is the brightest one text sits on for any
+     length of time. On bg-surface that lands at 12.08 / 7.51 / 5.65 — the
+     three steps stay clearly apart. */
+  --text-secondary: #BEBBB6;
+  --text-tertiary: #A5A29D;
   --text-inverse: #242422;
   --text-on-brand: #FFFFFF;
+
+  /* Blue/purple used as TEXT. --brand-blue / --brand-purple stay untouched
+     because they are also fills (gradients, --stage-done, icon backgrounds),
+     where text contrast does not apply. Splitting the two roles is what lets
+     the light theme darken its text variant without dulling the brand. */
+  --text-accent: #0099FF;
+  --text-accent-purple: #B97BE2;
 
   --status-success: #34D399;
   --status-success-bg: rgba(52, 211, 153, 0.12);
@@ -95,7 +123,7 @@
   --entity-command-bg: rgba(0, 153, 255, 0.12);
   --entity-schedule: #F5A623;
   --entity-schedule-bg: rgba(245, 166, 35, 0.12);
-  --entity-skill: #B370E0;
+  --entity-skill: #B97BE2;
   --entity-skill-bg: rgba(179, 112, 224, 0.12);
   --entity-workflow: #2DD4BF;
   --entity-workflow-bg: rgba(45, 212, 191, 0.12);
@@ -124,6 +152,9 @@
   --bg-elevated: #FFFFFF;
   --bg-hover: #F5F6F9;
   --bg-active: #ECEDF2;
+  /* See the dark theme's note. Midway between hover and active: 1.13:1 against
+     white, where hover is 1.08 and active 1.17. */
+  --bg-selected: #F0F1F5;
   --bg-input: #F2F3F7;
   --bg-modal: #FFFFFF;
   --bg-tooltip: #1A1D28;
@@ -133,33 +164,44 @@
   --border-strong: #C5C7D0;
 
   --text-primary: #1A1D28;
-  --text-secondary: #6B7084;
-  --text-tertiary: #9CA0B0;
+  /* Measured against --bg-input, the darkest surface these sit on for any
+     length of time; on pure white that leaves 16.80 / 7.05 / 5.07. */
+  --text-secondary: #53586C;
+  --text-tertiary: #6A6E7E;
   --text-inverse: #FFFFFF;
   --text-on-brand: #FFFFFF;
 
-  --status-success: #059669;
+  /* See the dark theme's note. On white, --brand-blue is only 3.00:1 and
+     --brand-purple 3.33:1 — both fail body text, so the text role gets its
+     own darker value while the brand fills keep the original hue. */
+  --text-accent: #0079C9;
+  --text-accent-purple: #A14DD8;
+
+  --status-success: #04865E;
   --status-success-bg: rgba(5, 150, 105, 0.08);
   --status-error: #DC2626;
   --status-error-bg: rgba(220, 38, 38, 0.08);
-  --status-warning: #D97706;
+  --status-warning: #B06105;
   --status-warning-bg: rgba(217, 119, 6, 0.08);
   --status-info: #2563EB;
   --status-info-bg: rgba(37, 99, 235, 0.08);
-  --status-pending: #9CA0B0;
+  --status-pending: #6F748B;
   --status-pending-bg: rgba(156, 160, 176, 0.08);
 
   --accent-blue-subtle: rgba(0, 153, 255, 0.08);
   --accent-purple-subtle: rgba(179, 112, 224, 0.08);
 
-  /* Entity types — light theme (blue/purple stay brand; schedule/workflow darkened to keep contrast) */
-  --entity-command: #0099FF;
+  /* Entity types — light theme. Every one of these renders as a small label on
+     white, so all five are pinned at >=4.5:1; hue and saturation are the
+     originals, only lightness moved. The tint backgrounds keep the original
+     rgba (a fill has no contrast requirement). */
+  --entity-command: #0079C9;
   --entity-command-bg: rgba(0, 153, 255, 0.12);
-  --entity-schedule: #C9791A;
+  --entity-schedule: #A86516;
   --entity-schedule-bg: rgba(201, 121, 26, 0.10);
-  --entity-skill: #B370E0;
+  --entity-skill: #A14DD8;
   --entity-skill-bg: rgba(179, 112, 224, 0.12);
-  --entity-workflow: #0F9E8B;
+  --entity-workflow: #0D8474;
   --entity-workflow-bg: rgba(15, 158, 139, 0.10);
   --entity-workflow-run: #5E7199;
   --entity-workflow-run-bg: rgba(94, 113, 153, 0.10);


### PR DESCRIPTION
## Why

Users reported the UI as hard to read. Measurement backed it up rather than
contradicting it:

| | Light theme, on white | AA floor |
|---|---|---|
| `--text-tertiary` | **2.60:1** | 4.5:1 |
| `text-brand-blue` (used as text, 129 sites) | **3.00:1** | 4.5:1 |
| `--status-warning` / `--status-success` | 3.19 / 3.77 | 4.5:1 |

`--text-tertiary` was simultaneously the **most-used** text colour in the app
(375 call sites) and the one furthest below the line. On top of that the type
scale sat a step under Tailwind's defaults throughout — chat body copy at 12px
— and **185 hardcoded sizes** bypassed the scale entirely, the smallest at 9px.

## What changed

### Contrast

Every text, status and entity colour now clears 4.5:1 on the surfaces it
actually renders on. `tertiary` is measured against the worst *persistent*
background (`--bg-input` in light, `--bg-hover` in dark) rather than the ideal
one, so a hovered row no longer drops below the line. Hue and saturation are the
originals — only lightness moved, so the palette reads as the same colours,
just more solid.

`--brand-blue` / `--brand-purple` are deliberately untouched: they are also
fills (gradients, `--stage-done`, icon backgrounds) where text contrast does not
apply. Their text role moved to new `--text-accent` tokens. Splitting the two
roles is what let the light theme darken its text variant without dulling the
brand.

### Type scale

Bottom four steps raised (`xs` 11→12, `sm` 12→13, `base` 13→14, `md` 14→15);
headings untouched — they were never the complaint, and leaving them keeps the
layout risk on the steps that had to move. New `--text-2xs` (11px) is the floor.
All 185 hardcoded sizes fold into the scale; **no `text-[Npx]` remains
anywhere**.

### Token usage, not just token values

Correcting the values exposed the larger problem: the wrong *step* was being
used. Nav items and settings tabs dimmed their **unselected** labels to express
selection, and put icons under an `opacity` that escapes the contrast scale
entirely. Selection is now carried by background + weight; `opacity` is reserved
for genuinely inactive controls, which WCAG exempts.

### New `--bg-selected`

Selection had been borrowing `--bg-hover` (invisible — 1.08:1 in light), then
`--bg-active` (heavy once every selected surface carried it). It is its own
idea — it persists, it must not be mistaken for the row the pointer sits on, and
it must not shout — so it now has its own value at the midpoint. All 14 selected
surfaces point at it; retuning is one line.

### Seven shared components

Replacing hand-maintained copies that had drifted apart:

`NavItem` · `FilterTabs` · `CenterPageLayout` · `SearchBox` · `EmptyState` ·
`SettingsTabLayout` · `RefreshButton`

The four center pages disagreed on body top padding (20px / 16px / an 18px
one-off), header alignment, search box markup and empty-state shape. Each
component carries, in its header comment, the rule it enforces **and the
regression that motivated it**, so the next change has to argue with the reason
rather than rediscover it.

## Bugs fixed along the way

- **The assets refresh button looked dead.** The page-level loading line only
  renders when there is nothing to show — deliberately, so a refresh does not
  blank out content you are reading — which left a refresh with data already
  loaded changing nothing on screen. `RefreshButton` now spins for at least one
  full revolution (`MIN_SPIN_MS` = one `animate-spin` period, so the icon lands
  where it started).
- **Settings' About and Gateway tabs** wrapped content in a `p-5` that stacked
  on the dialog's own padding, indenting those two tabs 20px further than their
  siblings and shifting content while switching tabs.
- **Skills' search box was a `<div>`**, not a `<label>` — clicking the icon did
  not focus the field.

## Deliberately not done

- `variant="primary"`'s brand gradient is unchanged. It is used in 30 places
  (approvals, update prompts, schedules, confirm dialogs); restyling it is a
  brand decision, not part of a readability fix.
- Settings dialog stays a fixed `880×600`. Content-light tabs leave space below,
  but a self-sizing dialog would jump on every tab switch.
- The `Skills` page title is still a hardcoded string rather than an i18n key —
  flagged in a comment; adding a key means touching the locale catalogues.
- `Appearance` / `Model` / `Gateway` tabs do not use `SettingsTabLayout`: their
  bodies are `mb-*` element flows, not section lists, and a `gap-4` wrapper would
  double their spacing.

## Test plan

- [x] `bun run test` — 1358 pass, 6 skip, 0 fail
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run check:chinese`
- [x] `uv run pytest -q --timeout=300 --timeout-method=thread` — 1878 passed
- [x] Contrast regression: every text/status/entity token re-read from
      `tokens.css` and recomputed against each surface it renders on; all ≥4.5:1
- [ ] Visual pass, **light theme**: session list, tool cards, settings copy,
      empty states
- [ ] Visual pass, **dark theme**: same surfaces
- [ ] Switch between all four center pages — content baseline should not jump
- [ ] Switch through all six settings tabs — no horizontal indent shift
- [ ] Assets and Schedules refresh — icon completes a full turn, stops upright
- [ ] Confirm disabled buttons still read as disabled (their `opacity` was left
      alone on purpose)
