### PR TITLE
Self-heal degraded daemon logging when the log path recovers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,27 +5,21 @@ configuration. Where the two disagree, this file wins.
 
 ## Language
 
-**Commit messages and pull request descriptions MUST be written in English.**
-Nothing checks these, so they are on you.
+**Everything that lands in this repository MUST be written in English** —
+code, comments, docstrings, tests (case names included), docs, commit
+messages, and pull request descriptions. The single exception is the i18n
+catalogs (`desktop/packages/shared/src/i18n/locales/`): they ARE the
+translated copy. Display strings belong there, never inline.
 
-Comments are already gated: `bun run check:chinese` fails on any Chinese comment
-in `.ts`, `.tsx`, or `.py`, across both halves of the repo. Run it instead of
+Comments are gated: `bun run check:chinese` fails on any Chinese comment in
+`.ts`, `.tsx`, or `.py`, across both halves of the repo. Run it instead of
 eyeballing the diff.
 
-That check exempts three things. Two are Chinese on purpose — leave them:
-
-- **`docs/`.** Chinese technical writing, not product surface.
-- **The i18n catalogs.** `desktop/packages/shared/src/i18n/locales/` is the
-  translated copy itself. Display strings belong there, never inline.
-
-The third exemption is legacy, not license:
-
-- **Tests.** Test code MUST be written in English — comments, docstrings,
-  and case names alike, same as any other code. The check still skips
-  `__tests__/`, `tests/`, and `*.test.ts(x)` only because the existing
-  Chinese tests predate this rule; the exemption grandfathers them, it does
-  not permit new Chinese test code. Nothing enforces this yet, so it is on
-  you.
+The check still skips `__tests__/`, `tests/`, `*.test.ts(x)`, and `docs/`.
+That is legacy, not license: the Chinese content already there predates this
+rule and has not been migrated yet. New content in those places must be
+English like everything else — nothing enforces that yet, so it is on you.
+Commit messages and PR descriptions are likewise unchecked.
 
 Two things no check can see:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,13 +12,20 @@ Comments are already gated: `bun run check:chinese` fails on any Chinese comment
 in `.ts`, `.tsx`, or `.py`, across both halves of the repo. Run it instead of
 eyeballing the diff.
 
-That check exempts three things on purpose — leave them in Chinese:
+That check exempts three things. Two are Chinese on purpose — leave them:
 
-- **Tests.** `__tests__/`, `tests/`, and `*.test.ts(x)` keep Chinese assertions
-  and Chinese case names deliberately.
 - **`docs/`.** Chinese technical writing, not product surface.
 - **The i18n catalogs.** `desktop/packages/shared/src/i18n/locales/` is the
   translated copy itself. Display strings belong there, never inline.
+
+The third exemption is legacy, not license:
+
+- **Tests.** Test code MUST be written in English — comments, docstrings,
+  and case names alike, same as any other code. The check still skips
+  `__tests__/`, `tests/`, and `*.test.ts(x)` only because the existing
+  Chinese tests predate this rule; the exemption grandfathers them, it does
+  not permit new Chinese test code. Nothing enforces this yet, so it is on
+  you.
 
 Two things no check can see:
 

--- a/desktop/scripts/__tests__/check-payload-paths.test.ts
+++ b/desktop/scripts/__tests__/check-payload-paths.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'bun:test'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { longestPackagedPath } from '../check-payload-paths'
+
+describe('longestPackagedPath', () => {
+  it('文件型 extraResources 条目(LICENSE/NOTICE)不使 walk 崩溃,并计入测量', () => {
+    // electron-builder.yml 里 `from: resources/LICENSE` 指向文件而非目录;
+    // 此前 walk 对根节点直接 readdir,ENOTDIR 让整个 dist 构建在检查步骤崩掉。
+    const dir = mkdtempSync(join(tmpdir(), 'payload-'))
+    writeFileSync(join(dir, 'LICENSE'), 'x')
+    mkdirSync(join(dir, 'bin'))
+    writeFileSync(join(dir, 'bin', 'amphi'), 'x')
+
+    const { longest, skipped } = longestPackagedPath(dir)
+
+    expect(longest).not.toBeNull()
+    // 文件条目本身被计为一个文件,不算 "present but empty"。
+    expect(skipped.some((s) => s.startsWith('LICENSE'))).toBe(false)
+  })
+})

--- a/desktop/scripts/check-payload-paths.ts
+++ b/desktop/scripts/check-payload-paths.ts
@@ -138,7 +138,7 @@ export function longestPackagedPath(resourcesDir = RESOURCES_DIR): {
       continue
     }
     let files = 0
-    walk(root, (absolute) => {
+    const measure = (absolute: string): void => {
       files += 1
       // Windows separators, and prefixed with `resources/` because that is where
       // the tree lands relative to $INSTDIR.
@@ -146,7 +146,11 @@ export function longestPackagedPath(resourcesDir = RESOURCES_DIR): {
       if (longest === null || rel.length > longest.length) {
         longest = { length: rel.length, path: rel }
       }
-    })
+    }
+    // An extraResources entry may name a single file (LICENSE, NOTICE), and
+    // walk() readdirs its root — ENOTDIR on a file.
+    if (statSync(root).isDirectory()) walk(root, measure)
+    else measure(root)
     // An existing but empty subtree is a failed fetch that still created the
     // directory. Counting it as present would let the check report success over
     // a payload that is not actually there.

--- a/src/amphi_service/server/_logging.py
+++ b/src/amphi_service/server/_logging.py
@@ -22,9 +22,10 @@ import logging
 import os
 import platform
 import sys
+import time
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 from src import __version__
 
@@ -98,6 +99,92 @@ def configure_console_logging(
     return console
 
 
+class _SelfHealingConsoleHandler(logging.StreamHandler):
+    """Console fallback that keeps trying to move to the real log file.
+
+    The degraded path has no rotation: under a supervisor the "console" is
+    the crash-net file, and a daemon that stays degraded writes every record
+    into a file nothing trims while it runs. The usual causes (full disk, a
+    directory briefly locked by security software) are transient, so each
+    emitted record — rate-limited to one attempt per ``retry_seconds`` —
+    retries opening the rotating handler and hands over on success.
+
+    Emit-driven on purpose: the growth this guards against only happens
+    while records flow, so a silent daemon costs nothing and no timer thread
+    is needed. ``runtime.json`` is left alone — it advertised no ``log_file``
+    at startup and cannot be republished from here, but the desktop's
+    discovery chain picks the most recently written candidate, which after
+    the handover is ``server.log`` again.
+    """
+
+    def __init__(
+        self,
+        stream: Any,
+        *,
+        log_path: Path,
+        formatter: logging.Formatter,
+        max_bytes: int,
+        backup_count: int,
+        retry_seconds: float = 300.0,
+        monotonic: Callable[[], float] = time.monotonic,
+    ) -> None:
+        super().__init__(stream)
+        self.setFormatter(formatter)
+        self._log_path = log_path
+        self._max_bytes = max_bytes
+        self._backup_count = backup_count
+        self._retry_seconds = retry_seconds
+        self._monotonic = monotonic
+        # The open just failed at construction time; the clock starts now.
+        self._next_retry = monotonic() + retry_seconds
+        self._retired = False
+
+    def emit(self, record: logging.LogRecord) -> None:
+        if not self._retired:
+            self._maybe_heal()
+        if self._retired:
+            return
+        super().emit(record)
+
+    def _maybe_heal(self) -> None:
+        now = self._monotonic()
+        if now < self._next_retry:
+            return
+        self._next_retry = now + self._retry_seconds
+        try:
+            self._log_path.parent.mkdir(parents=True, exist_ok=True)
+            file_handler = RotatingFileHandler(
+                self._log_path,
+                maxBytes=self._max_bytes,
+                backupCount=self._backup_count,
+                encoding="utf-8",
+                errors="backslashreplace",
+            )
+        except OSError:
+            return
+        file_handler.setFormatter(self.formatter)
+        # Appended DURING callHandlers' iteration over this very list, which
+        # visits appended entries: the record that triggered the handover
+        # lands in the file, not on the floor.
+        logging.getLogger().addHandler(file_handler)
+        try:
+            is_tty = bool(self.stream.isatty())
+        except (AttributeError, OSError, ValueError):
+            is_tty = False
+        # Mirror the healthy topology: a dev terminal keeps its console (the
+        # success path attaches one alongside the file), the crash net goes
+        # quiet again. Retire BEFORE logging the recovery line so it cannot
+        # land here; NOT removed from the root logger, because removeHandler
+        # would mutate the list mid-iteration and skip the next handler.
+        self._retired = not is_tty
+        logger.info(
+            "[daemon-logging] recovered pid=%d version=%s, resuming at %s",
+            os.getpid(),
+            __version__,
+            self._log_path,
+        )
+
+
 def configure_daemon_logging(
     log_path: Path,
     *,
@@ -160,7 +247,16 @@ def configure_daemon_logging(
             "falling back to console logging",
             file=stream,
         )
-        add_console()
+        # Self-healing, not a plain console: see _SelfHealingConsoleHandler.
+        root.addHandler(
+            _SelfHealingConsoleHandler(
+                stream,
+                log_path=log_path,
+                formatter=formatter,
+                max_bytes=max_bytes,
+                backup_count=backup_count,
+            )
+        )
         return None
 
     file_handler.setFormatter(formatter)

--- a/tests/test_server_logging.py
+++ b/tests/test_server_logging.py
@@ -233,3 +233,105 @@ def test_crash_net_note_stays_silent_when_there_is_nothing_to_read(
     log_crash_net_size(empty)
 
     assert log_path.read_text(encoding="utf-8") == banner_only
+
+
+def _blocked(log_path: Path) -> None:
+    # 让 RotatingFileHandler 打不开:路径上是个目录 → OSError(IsADirectoryError)。
+    log_path.mkdir()
+
+
+def test_degraded_configure_installs_the_self_healing_fallback(
+    tmp_path: Path,
+) -> None:
+    log_path = tmp_path / "server.log"
+    _blocked(log_path)
+
+    handler = configure_daemon_logging(log_path, stderr=io.StringIO())
+
+    assert handler is None
+    fallbacks = [
+        h
+        for h in logging.getLogger().handlers
+        if isinstance(h, logging_module._SelfHealingConsoleHandler)
+    ]
+    assert len(fallbacks) == 1
+
+
+def test_degraded_logging_recovers_when_the_path_becomes_writable(
+    tmp_path: Path,
+) -> None:
+    """降级的常见诱因(磁盘满/目录被临时锁)是暂时的;此前一旦降级就永远
+    把全部日志写进无轮转的 crash net,直到下次重启。现在按 emit 限频重试,
+    路径恢复可写后自动切回 server.log。"""
+    log_path = tmp_path / "server.log"
+    _blocked(log_path)
+    console = io.StringIO()
+    now = {"t": 0.0}
+
+    fallback = logging_module._SelfHealingConsoleHandler(
+        console,
+        log_path=log_path,
+        formatter=logging.Formatter(logging_module.LOG_FORMAT),
+        max_bytes=logging_module.LOG_MAX_BYTES,
+        backup_count=logging_module.LOG_BACKUP_COUNT,
+        retry_seconds=300.0,
+        monotonic=lambda: now["t"],
+    )
+    root = logging.getLogger()
+    root.addHandler(fallback)
+    root.setLevel(logging.INFO)
+    probe = logging.getLogger("probe.selfheal")
+
+    # 阶段 1:路径仍不可写,重试窗口已到 → 尝试失败,继续走 console。
+    now["t"] = 301.0
+    probe.info("degraded-1")
+    assert "degraded-1" in console.getvalue()
+    assert not (tmp_path / "server.log").is_file()
+
+    # 阶段 2:路径恢复可写,但还在限频窗口内 → 不重试,仍走 console。
+    log_path.rmdir()
+    probe.info("degraded-2")
+    assert "degraded-2" in console.getvalue()
+    assert not log_path.is_file()
+
+    # 阶段 3:窗口过后第一条记录触发接管:本条起进文件,console 不再增长。
+    now["t"] = 602.0
+    probe.info("recovered-1")
+    console_after_heal = console.getvalue()
+    content = log_path.read_text(encoding="utf-8")
+    assert "recovered-1" in content
+    assert "[daemon-logging] recovered" in content
+    assert "recovered-1" not in console_after_heal
+
+    probe.info("recovered-2")
+    assert "recovered-2" in log_path.read_text(encoding="utf-8")
+    assert console.getvalue() == console_after_heal
+
+
+def test_degraded_recovery_keeps_a_tty_console(tmp_path: Path) -> None:
+    # 开发终端里降级后恢复:成功路径本来就是 file + TTY console 双写,
+    # 恢复后的拓扑必须一致 —— 终端不能突然安静下来。
+    log_path = tmp_path / "server.log"
+    _blocked(log_path)
+    console = _TtyStderr()
+    now = {"t": 0.0}
+
+    fallback = logging_module._SelfHealingConsoleHandler(
+        console,
+        log_path=log_path,
+        formatter=logging.Formatter(logging_module.LOG_FORMAT),
+        max_bytes=logging_module.LOG_MAX_BYTES,
+        backup_count=logging_module.LOG_BACKUP_COUNT,
+        retry_seconds=300.0,
+        monotonic=lambda: now["t"],
+    )
+    root = logging.getLogger()
+    root.addHandler(fallback)
+    root.setLevel(logging.INFO)
+
+    log_path.rmdir()
+    now["t"] = 301.0
+    logging.getLogger("probe.selfheal.tty").info("after-heal")
+
+    assert "after-heal" in log_path.read_text(encoding="utf-8")
+    assert "after-heal" in console.getvalue()


### PR DESCRIPTION
## Summary

Stacked on #8 (base is its branch; retarget to `main` once #8 merges).

When `server.log` cannot be opened the daemon degrades to console logging, and under a supervisor that console **is the crash-net file** (`daemon.stderr.log`) — which has no rotation and is only trimmed at the next explicit start. A daemon that stays degraded for days writes every record into a file nothing bounds while it runs.

This PR makes the degraded state transient when its cause is:

- The fallback console handler retries opening the rotating file handler, at most once per 5 minutes.
- Retry is **emit-driven** (no timer thread): the unbounded growth this guards against only happens while records flow, so a silent daemon costs nothing.
- On success it attaches the file handler mid-`callHandlers` (appended entries are visited, so the triggering record lands in the file), logs a recovery line carrying pid/version (the session banner this start never got), and mirrors the healthy topology — a dev terminal keeps its console, the crash net goes quiet again.
- `runtime.json` is deliberately not republished: the desktop's discovery chain picks the most recently written candidate, which after handover is `server.log` again.

## Test plan

- [x] New: degraded configure installs the self-healing fallback
- [x] New: recovery is rate-limited, hands over on the first record after the path becomes writable, and stops writing to the crash net
- [x] New: a TTY console keeps mirroring after recovery
- [x] `uv run pytest -q --timeout=300 --timeout-method=thread` — 1905 passed
- [x] `bun run check:chinese`