### PR TITLE
fix: Anthropic thinking replay 400 and thinking ladder for relay-served models

### DIFF
--- a/src/amphi_agent/_cognitive.py
+++ b/src/amphi_agent/_cognitive.py
@@ -971,9 +971,13 @@ class MainThink(CognitiveWorker):
             return f"- `{call['name']}` — " + "; ".join(facts)
 
         def reasoning_extras(record: Any, mode: Optional[str]) -> Dict[str, Any]:
-            """This round's captured reasoning as ``Message.extras`` for replay — a
-            thinking-mode round that emitted none still gets an empty fallback DeepSeek
-            requires; ``mode`` None (not a thinking model) → nothing added."""
+            """This round's captured reasoning as ``Message.extras`` for replay — an
+            OpenAI-wire thinking round that emitted none still gets the empty
+            ``reasoning_content`` DeepSeek requires; ``mode`` None (not a thinking
+            model) → nothing added. Anthropic rounds are never synthesized: adaptive
+            thinking may legitimately skip a round, and a thinking block without a
+            real signature is rejected (400 "each thinking block must contain
+            thinking")."""
             extras: Dict[str, Any] = {}
             thinking_blocks = _view(record, "thinking_blocks")
             reasoning_content = _view(record, "reasoning_content")
@@ -981,23 +985,19 @@ class MainThink(CognitiveWorker):
                 extras["thinking_blocks"] = thinking_blocks
             elif reasoning_content:
                 extras["reasoning_content"] = reasoning_content
-            elif mode == "anthropic":
-                extras["thinking_blocks"] = [{"type": "thinking", "thinking": "", "signature": ""}]
             elif mode == "openai":
                 extras["reasoning_content"] = ""
             return extras
 
-        # reasoning_mode: which wire this turn's thinking rides (from whatever round
-        # captured it), else None. DeepSeek requires the assistant turn's reasoning
-        # echoed on EVERY tool-call turn once thinking is active — including rounds
-        # that emitted none; None → not a thinking model, so no fallback is synthesized.
+        # reasoning_mode: "openai" once any round captured ``reasoning_content`` —
+        # DeepSeek (OpenAI wire) requires the assistant turn's reasoning echoed on
+        # EVERY tool-call turn once thinking is active, including rounds that emitted
+        # none; None → nothing is synthesized. Anthropic thinking blocks are only ever
+        # replayed as captured (see ``reasoning_extras``).
         reasoning_mode: Optional[str] = None
         for record in records:
             if _view(record, "reasoning_content"):
                 reasoning_mode = "openai"
-                break
-            if _view(record, "thinking_blocks"):
-                reasoning_mode = "anthropic"
                 break
 
         messages: List[Message] = []

--- a/src/amphi_agent/security/_reasoning.py
+++ b/src/amphi_agent/security/_reasoning.py
@@ -20,8 +20,9 @@ the comments). Two traps:
     only *hide* the chain of thought without saving generation time — always use the
     parameters that genuinely skip the thinking phase.
   * **The cannot-be-disabled class** (reasoning-only): deepseek-reasoner / o1-mini /
-    GLM-Z1 / Gemini-2.5-pro / Anthropic Fable5·Mythos5 — the only option is switching
-    models.
+    GLM-Z1 / Gemini-2.5-pro — the only option is switching models. Anthropic
+    Fable 5 / Mythos 5 (and Opus 5, where "disabled" leaks ``<thinking>`` into the
+    answer) can at least be lowered with ``output_config.effort: low``.
   * **base_url wins over the model name**: the same model (e.g. ``qwen3-coder``) is
     disabled differently on DashScope than on OpenRouter, so the actual endpoint domain
     is authoritative.
@@ -31,8 +32,9 @@ turn a timeout degradation into a 400 degradation).
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 # status semantics:
 #   disabled   — parameters injected, chain of thought off
@@ -75,6 +77,19 @@ def _model_of(llm: Any) -> str:
     return (m if isinstance(m, str) else _attr(llm, "model")).lower()
 
 
+# ``claude-<family>-5`` with nothing numeric right after the 5 (so ``claude-sonnet-4-5`` is 4.x).
+_CLAUDE_5 = re.compile(r"claude-([a-z]+)-5(?!\d)")
+
+
+def _claude_5_family(model: str) -> Optional[str]:
+    """``"sonnet"`` / ``"opus"`` / ``"fable"`` … for a Claude 5-series id, else None.
+    Fable / Mythos are matched by name alone (``claude-mythos-preview`` has no ``-5``)."""
+    if "fable" in model or "mythos" in model:
+        return "fable"
+    match = _CLAUDE_5.search(model)
+    return match.group(1) if match else None
+
+
 def reasoning_off(llm: Any) -> ReasoningOff:
     """Decide the disable-reasoning parameters for a single call from the llm's vendor
     (reads public attributes only, imports no provider class)."""
@@ -82,12 +97,22 @@ def reasoning_off(llm: Any) -> ReasoningOff:
     model = _model_of(llm)
     base = (_attr(llm, "api_base") or _attr(llm, "base_url")).lower()
 
-    # Anthropic: extended thinking is opt-in by default, and plain Messages carries no chain of
-    # thought anyway. Fable5/Mythos5 force reasoning and return 400 if sent disabled — so send
-    # nothing there either and keep the default.
-    # Source: platform.claude.com/docs/en/build-with-claude/extended-thinking
+    # Anthropic: up to the 4.x generations extended thinking is opt-in, so a plain Messages call
+    # carries no chain of thought — nothing to inject. The 5 series (Sonnet 5 / Opus 5 / Fable 5 /
+    # Mythos 5) thinks adaptively BY DEFAULT: Sonnet 5 accepts ``thinking:{type:disabled}`` and
+    # genuinely skips the phase; Opus 5 accepts it too but then leaks ``<thinking>`` tags into the
+    # visible answer (breaks the JSON verdict) — Anthropic's guidance is low effort instead; Fable
+    # 5 / Mythos 5 cannot disable at all (400) and only take ``output_config.effort``. A relay
+    # alias that hides the family gets nothing (the classifier's strip-and-retry covers a guess).
+    # Source: platform.claude.com/docs/en/build-with-claude/extended-thinking ;
+    #         platform.claude.com/docs/en/about-claude/models/migrating (Opus 5 disabled-thinking)
     if protocol == "anthropic":
-        return ReasoningOff({}, _NOT_NEEDED)
+        family = _claude_5_family(model)
+        if family is None:
+            return ReasoningOff({}, _NOT_NEEDED if "claude" in model else _UNKNOWN)
+        if family == "sonnet":
+            return ReasoningOff({"extra_body": {"thinking": {"type": "disabled"}}}, _DISABLED)
+        return ReasoningOff({"extra_body": {"output_config": {"effort": "low"}}}, _MINIMIZED)
 
     # Google Gemini: thinking goes through the SDK config (not a chat-completions parameter) and
     # is handled by the google adapter layer; 2.5-pro cannot turn it off.
@@ -183,15 +208,25 @@ def _doubao(model: str) -> ReasoningOff:
     return _thinking_disabled()
 
 
+# ``gpt-5.<n>`` — every point release from 5.1 on; plain ``gpt-5`` / ``gpt-5-mini`` don't match.
+_GPT5_POINT_RELEASE = re.compile(r"^gpt-5\.\d")
+
+
 def _openai(model: str) -> ReasoningOff:
-    # Top-level reasoning_effort. gpt-5.1+ → none (fully off); gpt-5 → minimal (its floor);
-    # o-series → low (its floor, cannot be disabled); o1-mini ignores the parameter.
-    # Source: learn.microsoft.com/.../openai/how-to/reasoning
+    # Top-level reasoning_effort. gpt-5.1 and every later point release (5.2 / 5.4 / 5.5 / 5.6 …)
+    # → none (fully off; "minimal" was removed with 5.1 and 400s "does not support 'minimal'");
+    # gpt-5 / gpt-5-mini / gpt-5-nano → minimal (their floor, "none" is rejected); o-series → low
+    # (its floor, cannot be disabled); o1-mini ignores the parameter. The ``*-chat*`` aliases are
+    # non-reasoning (or pinned to one effort) — nothing to inject.
+    # Source: learn.microsoft.com/.../openai/how-to/reasoning ; models.dev providers/openai
+    # (reasoning_options per model) ; verified live 2026-08-19 through a new-api relay.
+    if "chat" in model:
+        return ReasoningOff({}, _NOT_NEEDED)
     if model.startswith("o1-mini"):
         return ReasoningOff({}, _CANNOT)
     if model.startswith(("o1", "o3", "o4")):
         return ReasoningOff({"reasoning_effort": "low"}, _MINIMIZED)
-    if model.startswith(("gpt-5.1", "gpt-5.2")):
+    if _GPT5_POINT_RELEASE.match(model):
         return ReasoningOff({"reasoning_effort": "none"}, _DISABLED)
     if model.startswith("gpt-5"):
         return ReasoningOff({"reasoning_effort": "minimal"}, _MINIMIZED)

--- a/src/amphi_service/handler/_providers_handler.py
+++ b/src/amphi_service/handler/_providers_handler.py
@@ -321,8 +321,9 @@ class MeProviderTestHandler(BaseHandler):
                     configuration=AnthropicConfiguration(
                         model=body.model,
                         temperature=0.0,
-                        # 1 token cap — keeps the probe cheap. Anthropic
-                        # requires max_tokens; OpenAI accepts it.
+                        # 1 token cap — keeps the probe cheap. Anthropic requires
+                        # max_tokens, and the probe never enables thinking, so one
+                        # token always completes.
                         max_tokens=1,
                     ),
                 )
@@ -343,7 +344,11 @@ class MeProviderTestHandler(BaseHandler):
                     configuration=OpenAIConfiguration(
                         model=body.model,
                         temperature=0.0,
-                        max_tokens=1,
+                        # No token cap: reasoning models (gpt-5.x / o-series) spend
+                        # the budget on reasoning first, so a 1-token cap 400s with
+                        # "Could not finish the message ..." on every strict
+                        # upstream. A "ping" reply is short — no cap stays cheap.
+                        max_tokens=None,
                     ),
                 )
         except Exception as exc:  # noqa: BLE001 — surface ctor errors to UI

--- a/src/amphi_service/protocol/llms/_openai_params.py
+++ b/src/amphi_service/protocol/llms/_openai_params.py
@@ -11,13 +11,31 @@ REASONING_UNSUPPORTED = frozenset({
 
 _O_SERIES = re.compile(r"^(o1|o3|o4|codex-mini)(-|$)")
 
+# Request parameters a 400 may legitimately name as unsupported; anything else
+# mentioned in an error text is not something we can strip and retry.
+_HEALABLE_PARAMS = REASONING_UNSUPPORTED | frozenset({
+    "max_tokens", "max_completion_tokens", "stop", "tool_choice",
+    "parallel_tool_calls", "response_format", "reasoning_effort", "stream_options",
+})
+
+# Relay wording when the structured ``code``/``param`` fields are absent:
+#   LiteLLM  "gpt-5 models (...) don't support temperature=0.0. Only temperature=1 ..."
+#            "O-series models don't support temperature=0.0. ..."
+#   OpenAI   "Unsupported parameter: 'top_p' is not supported with this model."
+_UNSUPPORTED_TEXT = re.compile(
+    r"(?:don't|do not|does not) support [`']?(\w+)[`']?\s*="
+    r"|Unsupported parameter:? [`']?(\w+)[`']?"
+    r"|[`'](\w+)[`'] is not supported",
+    re.IGNORECASE,
+)
+
 
 def is_openai_endpoint(base_url: Optional[str]) -> bool:
     """True when the endpoint is official OpenAI (the default, or *.openai.com).
 
-    OpenAI-compat services such as DeepSeek/GLM/OpenRouter use their own host → False;
-    their parameter rules differ from the official ones, and the sanitizer stays entirely
-    out of their way.
+    OpenAI-compat services such as DeepSeek/GLM/OpenRouter use their own host → False.
+    The host only gates the ``max_tokens`` rename for *non-reasoning* models; the
+    reasoning-model rules are keyed on the model name (see ``sanitize_openai_params``).
     """
     if not (base_url or "").strip():
         return True  # empty → the openai SDK defaults to api.openai.com
@@ -49,25 +67,31 @@ def is_openai_reasoning_model(model: str) -> bool:
 
 
 def sanitize_openai_params(params: Dict[str, Any], *, base_url: Optional[str]) -> Dict[str, Any]:
-    """Apply endpoint-specific parameter rules for OpenAI-compatible APIs.
+    """Apply OpenAI parameter rules for OpenAI-compatible APIs.
 
-    Kimi Code currently accepts only ``temperature=1`` for its coding models.
-    Official OpenAI endpoints rename ``max_tokens`` and reject sampling
-    parameters on reasoning models. Other compatible endpoints pass through.
+    * Kimi Code currently accepts only ``temperature=1`` for its coding models.
+    * OpenAI reasoning models (o-series / gpt-5.x) reject ``temperature`` / ``top_p``
+      / penalties / logprobs and only take ``max_completion_tokens`` — a property of
+      the MODEL, so it applies on every host: official, new-api, LiteLLM … (a relay
+      that validates strictly, e.g. LiteLLM without ``drop_params``, 400s otherwise;
+      a lenient one silently drops the params — either way they must not be sent).
+    * On the official endpoint ``max_tokens`` is renamed for every model; other
+      compatible endpoints pass non-reasoning models through untouched.
     """
     if is_kimi_code_endpoint(base_url):
         out = dict(params)
         if "temperature" in out:
             out["temperature"] = 1
         return out
-    if not is_openai_endpoint(base_url):
+    reasoning = is_openai_reasoning_model(str(params.get("model") or ""))
+    if not reasoning and not is_openai_endpoint(base_url):
         return params
     out = dict(params)
     if "max_tokens" in out:
         # Rename only (the value is unchanged); max_completion_tokens is accepted by
-        # every OpenAI Chat model.
+        # every OpenAI Chat model and is the only form reasoning models take.
         out["max_completion_tokens"] = out.pop("max_tokens")
-    if is_openai_reasoning_model(str(out.get("model") or "")):
+    if reasoning:
         for key in REASONING_UNSUPPORTED:
             out.pop(key, None)
     return out
@@ -83,10 +107,20 @@ def unsupported_param_of(exc: Exception) -> Optional[str]:
     code = getattr(exc, "code", None)
     param = getattr(exc, "param", None)
     body = getattr(exc, "body", None)
+    message = ""
     if isinstance(body, dict):
         err = body.get("error") or {}
         code = code or err.get("code")
         param = param or err.get("param")
+        if isinstance(err.get("message"), str):
+            message = err["message"]
     if code == "unsupported_parameter" and isinstance(param, str) and param:
         return param
+    # Relays (LiteLLM) enforce the same rules but only name the parameter in the
+    # message text, with code "400" and param null — fall back to the wording.
+    match = _UNSUPPORTED_TEXT.search(message or str(exc))
+    if match:
+        name = next(g for g in match.groups() if g)
+        if name in _HEALABLE_PARAMS:
+            return name
     return None

--- a/src/amphi_service/protocol/llms/anthropic_llm.py
+++ b/src/amphi_service/protocol/llms/anthropic_llm.py
@@ -43,6 +43,37 @@ _SAMPLING_PARAMS: Tuple[str, ...] = ("temperature", "top_p", "top_k")
 # Strip-and-retry ceiling — the param set is tiny, so this never loops.
 _MAX_SELF_HEAL_RETRIES = 4
 
+# Thinking shapes ``stream_turn`` tries in order; the first one the endpoint
+# accepts is remembered per (base_url, model) in ``_THINKING_TIERS``. Tier 0 is
+# what current models want: adaptive thinking with summarized text — ``display``
+# arrived with Opus 4.7 and defaults to "omitted" on Opus 4.7+/Sonnet 5/Opus 5/
+# Fable 5, i.e. thinking blocks with EMPTY text, so the UI never sees reasoning
+# without it. Tier 1 drops ``display`` (Opus 4.6 / Sonnet 4.6); tier 2 is the
+# pre-4.6 ``enabled`` + ``budget_tokens`` shape (budget derived from max_tokens at
+# request time); tier 3 sends no thinking at all. Relays (new-api) expose
+# arbitrary model names, so the tier is learned from the endpoint's 400s rather
+# than guessed from the id. Thinking tiers never carry temperature / top_p /
+# top_k (Anthropic: "`temperature` may only be set to 1 when thinking is
+# enabled"). Only the streaming agent path walks this ladder — ``chat`` /
+# ``achat`` (probe, safety classifier) never inject thinking.
+_THINKING_LADDER: Tuple[Optional[Dict[str, Any]], ...] = (
+    {"type": "adaptive", "display": "summarized"},
+    {"type": "adaptive"},
+    {"type": "enabled"},
+    None,
+)
+_THINKING_TIERS: Dict[Tuple[str, str], int] = {}
+
+# Substrings a thinking-config 400 carries (``thinking.display: Extra inputs…``,
+# ``thinking.type: Input should be…``, ``budget_tokens`` removed, …).
+_THINKING_REJECTION_HINTS: Tuple[str, ...] = ("thinking", "budget_tokens", "display", "adaptive")
+
+# ``budget_tokens`` bounds for the ``enabled`` tier: the API floor is 1024 and the
+# budget must stay below max_tokens; half of max_tokens capped at 4096 leaves the
+# answer room on the default 8K ceiling.
+_MIN_BUDGET_TOKENS = 1024
+_MAX_BUDGET_TOKENS = 4096
+
 
 class AnthropicConfiguration(BaseModel):
     """Per-request defaults for an :class:`AnthropicLlm` instance.
@@ -223,7 +254,11 @@ class AnthropicLlm(BaseLlm):
             return "".join(stream.text_stream)
 
     async def achat(self, messages: List[Message], **kwargs: Any) -> Any:  # noqa: D401
-        params = self._build_parameters(messages, stream=False)
+        # ``extra_body`` is how the safety classifier turns reasoning off for one
+        # call (``reasoning_off``); forward it like the OpenAI adapters do.
+        params = self._build_parameters(
+            messages, extra_body=kwargs.get("extra_body"), stream=False
+        )
         response = await self._acreate(params)
         return _anthropic_response_to_text(response)
 
@@ -286,20 +321,42 @@ class AnthropicLlm(BaseLlm):
 
         key = self._reject_key()
         heal = 0
+        # A caller-supplied ``thinking`` (extra_body) is sent as-is; otherwise walk
+        # the thinking ladder from the tier this endpoint last accepted.
+        caller_thinking = bool(extra_body and "thinking" in extra_body)
+        tier = _THINKING_TIERS.get(key, 0)
+        max_tokens = int(params.get("max_tokens") or _DEFAULT_MAX_TOKENS)
 
         async def run_attempt(attempt_publish: Callable[..., None]) -> StreamResult:
-            nonlocal heal
+            nonlocal heal, tier
             while True:
+                attempt = (
+                    params if caller_thinking
+                    else _with_thinking(params, _thinking_for(tier, max_tokens))
+                )
                 try:
-                    return await self._run_stream(params, attempt_publish)
+                    result = await self._run_stream(attempt, attempt_publish)
                 except Exception as exc:  # noqa: BLE001 — parameter self-heal stays independent
                     param = _deprecated_param_of(exc)
-                    if param is not None and param in params and heal < _MAX_SELF_HEAL_RETRIES:
+                    if param is not None and param in attempt and heal < _MAX_SELF_HEAL_RETRIES:
                         params.pop(param, None)
                         _REJECTED_PARAMS.setdefault(key, set()).add(param)
                         heal += 1
                         continue
+                    if (
+                        not caller_thinking
+                        and tier < len(_THINKING_LADDER) - 1
+                        and _thinking_rejected(exc)
+                    ):
+                        tier += 1
+                        continue
                     raise
+                if not caller_thinking:
+                    # Learned from success only: an exhausted ladder that still
+                    # fails (e.g. a bad replayed block) must not silently cost the
+                    # next turn its thinking.
+                    _THINKING_TIERS[key] = tier
+                return result
 
         return await stream_with_transport_retry(run_attempt, publish)
 
@@ -461,6 +518,55 @@ def _deprecated_param_of(exc: Exception) -> Optional[str]:
         if param in text:
             return param
     return None
+
+
+def _thinking_rejected(exc: Exception) -> bool:
+    """True when a 4xx names the thinking config (``thinking.display``,
+    ``thinking.type``, ``budget_tokens`` …) — the cue to step down the ladder.
+
+    Transport statuses (429 / 5xx) never count; an error with no status at all (a
+    relay-mangled body) is judged on its text alone.
+    """
+    status = getattr(exc, "status_code", None)
+    if status is not None and status not in (400, 422):
+        return False
+    text = _error_text(exc).lower()
+    # "`temperature` may only be set to 1 when thinking is enabled" names thinking
+    # but complains about the sampling param — the tier itself is fine.
+    if any(param in text for param in _SAMPLING_PARAMS):
+        return False
+    return any(hint in text for hint in _THINKING_REJECTION_HINTS)
+
+
+def _thinking_for(tier: int, max_tokens: int) -> Optional[Dict[str, Any]]:
+    """The ``thinking`` request param for a ladder tier (None → send nothing).
+
+    The ``enabled`` tier needs ``budget_tokens`` ≥ 1024 and < max_tokens; when
+    max_tokens can't satisfy both, that tier degrades to no thinking.
+    """
+    shape = _THINKING_LADDER[tier]
+    if shape is None:
+        return None
+    if shape["type"] == "enabled":
+        budget = max(_MIN_BUDGET_TOKENS, min(_MAX_BUDGET_TOKENS, max_tokens // 2))
+        return {"type": "enabled", "budget_tokens": budget} if budget < max_tokens else None
+    return dict(shape)
+
+
+def _with_thinking(
+    params: Dict[str, Any], thinking: Optional[Dict[str, Any]]
+) -> Dict[str, Any]:
+    """A copy of ``params`` for one attempt: ``thinking`` set (and the sampling
+    params dropped — Anthropic rejects temperature / top_p / top_k modifications
+    while thinking is on) or, for the no-thinking tier, ``thinking`` absent and
+    the sampling params left as configured."""
+    out = {k: v for k, v in params.items() if k != "thinking"}
+    if thinking is None:
+        return out
+    for param in _SAMPLING_PARAMS:
+        out.pop(param, None)
+    out["thinking"] = thinking
+    return out
 
 
 _THINKING_BLOCK_TYPES = ("thinking", "redacted_thinking")

--- a/src/amphi_service/protocol/llms/openai_llm.py
+++ b/src/amphi_service/protocol/llms/openai_llm.py
@@ -165,10 +165,45 @@ class OpenAICompatLlm(OpenAILlm):
 
         Covers every exit: stream_turn (streaming) and the inherited chat/achat
         (probing/titling/compaction) all go through this assembly, so reasoning models'
-        parameter 400s are cured here in one place. Non-OpenAI endpoints pass through.
+        parameter 400s are cured here in one place. Reasoning-model rules are keyed
+        on the model name, so they hold behind relays too; other endpoints pass through.
         """
         params = super()._build_parameters(*args, **kwargs)
-        return sanitize_openai_params(params, base_url=getattr(self, "api_base", None))
+        params = sanitize_openai_params(params, base_url=getattr(self, "api_base", None))
+        # Drop what this endpoint already rejected (learned by ``_create_stream`` /
+        # ``achat``), so the probe and the safety classifier don't re-hit the 400.
+        for name in _REJECTED_PARAMS.get(self._reject_key(), ()):
+            params.pop(name, None)
+        return params
+
+    async def achat(self, messages: List[Message], **kwargs: Any) -> Any:
+        """bridgic's achat plus the unsupported-parameter self-heal.
+
+        Known reasoning models are sanitized up front; this covers the rest — a
+        model the name heuristic misses behind a strict relay (LiteLLM without
+        ``drop_params``) rejects e.g. ``temperature`` on every call, including the
+        provider probe and the safety classifier, which reach the model through
+        achat before any stream could learn the rejection. A
+        ``ModelUnrecoverableError`` wrapping such a 400 strips the named param,
+        caches it, and retries; anything else propagates unchanged.
+        """
+        key = self._reject_key()
+        heal_retries = 0
+        while True:
+            try:
+                return await super().achat(messages, **kwargs)
+            except Exception as exc:  # noqa: BLE001 — only the named-param 400 is healed
+                original = getattr(exc, "original_exception", None) or exc
+                param = unsupported_param_of(original)
+                if (
+                    param is not None
+                    and param not in _REJECTED_PARAMS.get(key, set())
+                    and heal_retries < _MAX_SELF_HEAL_RETRIES
+                ):
+                    _REJECTED_PARAMS.setdefault(key, set()).add(param)
+                    heal_retries += 1
+                    continue
+                raise
 
     async def stream_turn(
         self,

--- a/tests/test_anthropic_params.py
+++ b/tests/test_anthropic_params.py
@@ -13,6 +13,7 @@ from src.amphi_service.protocol.llms.anthropic_llm import (
     AnthropicConfiguration,
     AnthropicLlm,
     _REJECTED_PARAMS,
+    _THINKING_TIERS,
     _deprecated_param_of,
 )
 
@@ -116,6 +117,9 @@ async def test_stream_turn_self_heals_and_caches() -> None:
 
     llm = _llm()
     llm._run_stream = fake_run_stream  # type: ignore[method-assign]
+    # Thinking tiers never carry sampling params; pin the no-thinking tier so the
+    # stream path actually sends temperature and exercises the self-heal.
+    _THINKING_TIERS[llm._reject_key()] = 3
 
     result = await llm.stream_turn([], None, publish=lambda *a, **k: None)
 
@@ -124,3 +128,4 @@ async def test_stream_turn_self_heals_and_caches() -> None:
     assert "temperature" not in seen[1]
     assert "temperature" in _REJECTED_PARAMS.get(llm._reject_key(), set())
     _REJECTED_PARAMS.clear()
+    _THINKING_TIERS.clear()

--- a/tests/test_anthropic_thinking.py
+++ b/tests/test_anthropic_thinking.py
@@ -1,0 +1,328 @@
+"""Anthropic thinking self-heal ladder on the agent's streaming path.
+
+``stream_turn`` asks for ``thinking: {type: adaptive, display: summarized}`` so the
+UI gets readable reasoning on Sonnet 5 / Opus 5 / Fable 5 / Opus 4.7+ (whose
+default ``display`` is ``omitted`` → empty thinking text). Older models reject
+that shape, so on a thinking-related 400 the adapter steps down a ladder —
+adaptive without ``display`` → ``enabled`` + ``budget_tokens`` → no thinking at
+all — and remembers the tier that worked per (base_url, model). Relays (new-api)
+expose arbitrary model names, so this is learned from the endpoint, not guessed
+from the id. ``chat`` / ``achat`` (probe + safety classifier) never inject it.
+"""
+from types import SimpleNamespace
+
+from bridgic.core.model.types import Message, Role
+
+from src.amphi_service.protocol.llms._streaming import StreamResult
+from src.amphi_service.protocol.llms.anthropic_llm import (
+    _REJECTED_PARAMS,
+    _THINKING_TIERS,
+    AnthropicConfiguration,
+    AnthropicLlm,
+    _thinking_rejected,
+)
+
+_SUMMARIZED = {"type": "adaptive", "display": "summarized"}
+_ADAPTIVE = {"type": "adaptive"}
+
+
+class _Exc400(Exception):
+    """A 400 in the Anthropic SDK's error shape (``status_code`` + ``body``)."""
+
+    status_code = 400
+
+    def __init__(self, msg: str) -> None:
+        super().__init__(f"Error code: 400 - {{'error': {{'message': '{msg}'}}}}")
+        self.message = msg
+        self.body = {"error": {"type": "invalid_request_error", "message": msg}}
+
+
+_DISPLAY_REJECTED = "thinking.display: Extra inputs are not permitted"
+_ADAPTIVE_REJECTED = "thinking.type: Input should be 'enabled' or 'disabled'"
+_BUDGET_REJECTED = "thinking.budget_tokens: Extra inputs are not permitted"
+
+
+def _llm(model: str = "claude-sonnet-5") -> AnthropicLlm:
+    return AnthropicLlm(api_key="k", configuration=AnthropicConfiguration(model=model))
+
+
+def _reset() -> None:
+    _REJECTED_PARAMS.clear()
+    _THINKING_TIERS.clear()
+
+
+def _fake_stream(accept):
+    """A ``_run_stream`` stand-in: records each attempt's params, raises a 400 via
+    ``accept(thinking) -> None | message`` until the endpoint "accepts" the shape."""
+    seen: list = []
+
+    async def run(params, publish):
+        seen.append(dict(params))
+        msg = accept(params.get("thinking"))
+        if msg:
+            raise _Exc400(msg)
+        return StreamResult(tool_calls=[], content="done", usage=None, capture={})
+
+    return seen, run
+
+
+# --- pure helper -----------------------------------------------------------
+
+def test_thinking_rejected_recognizes_param_errors() -> None:
+    assert _thinking_rejected(_Exc400(_DISPLAY_REJECTED))
+    assert _thinking_rejected(_Exc400(_ADAPTIVE_REJECTED))
+    assert _thinking_rejected(_Exc400("`budget_tokens` is not supported for this model"))
+    # relay-mangled error with no status / body — text alone must suffice
+    assert _thinking_rejected(ValueError("thinking: adaptive is not supported"))
+    # real texts seen through new-api, which masks every path segment but the last
+    # (``thinking.type.enabled`` → ``***.***.enabled``) — the hint must survive that
+    assert _thinking_rejected(_Exc400("adaptive thinking is not supported on this model"))
+    assert _thinking_rejected(_Exc400(
+        '"***.***.enabled" is not supported for this model. Use "***.***.adaptive" '
+        'and "output_config.effort" to control thinking behavior.'))
+    assert _thinking_rejected(_Exc400("***.display: Extra inputs are not permitted"))
+    assert _thinking_rejected(_Exc400("`max_tokens` must be greater than `***.budget_tokens`."))
+
+
+def test_thinking_rejected_ignores_unrelated() -> None:
+    assert not _thinking_rejected(_Exc400("tools.0.input_schema: Field required"))
+    assert not _thinking_rejected(_Exc400("`temperature` is deprecated for this model."))
+    # a sampling-param conflict is NOT a tier rejection — thinking itself is fine there
+    assert not _thinking_rejected(_Exc400(
+        "`temperature` may only be set to 1 when thinking is enabled or in adaptive mode."))
+    assert not _thinking_rejected(_Exc400("`top_k` is not allowed when thinking is enabled."))
+    # a 5xx that happens to mention thinking is transport, not a param rejection
+    overloaded = _Exc400("thinking overloaded")
+    overloaded.status_code = 529
+    assert not _thinking_rejected(overloaded)
+
+
+# --- stream_turn ladder ----------------------------------------------------
+
+async def test_stream_turn_requests_summarized_adaptive_thinking_first() -> None:
+    _reset()
+    seen, run = _fake_stream(lambda _t: None)
+    llm = _llm()
+    llm._run_stream = run  # type: ignore[method-assign]
+
+    await llm.stream_turn([], None, publish=lambda *a, **k: None)
+
+    assert seen[0]["thinking"] == _SUMMARIZED, "default request must ask for adaptive + summarized, or the UI gets no thinking text"
+    _reset()
+
+
+async def test_stream_turn_steps_down_ladder_and_remembers_tier() -> None:
+    _reset()
+
+    def accept(thinking):
+        if thinking == _SUMMARIZED:
+            return _DISPLAY_REJECTED
+        if thinking == _ADAPTIVE:
+            return _ADAPTIVE_REJECTED
+        return None  # enabled + budget accepted (a pre-4.6 model)
+
+    seen, run = _fake_stream(accept)
+    llm = _llm("claude-sonnet-4-5")
+    llm._run_stream = run  # type: ignore[method-assign]
+
+    result = await llm.stream_turn([], None, publish=lambda *a, **k: None)
+
+    assert result.content == "done"
+    assert [s["thinking"] for s in seen] == [
+        _SUMMARIZED,
+        _ADAPTIVE,
+        {"type": "enabled", "budget_tokens": 4096},
+    ], "steps down the ladder one tier at a time: summarized → adaptive → enabled+budget"
+    # the learned tier is reused: the next turn opens directly at enabled+budget
+    await llm.stream_turn([], None, publish=lambda *a, **k: None)
+    assert len(seen) == 4
+    assert seen[3]["thinking"] == {"type": "enabled", "budget_tokens": 4096}
+    _reset()
+
+
+async def test_stream_turn_budget_stays_below_max_tokens() -> None:
+    _reset()
+    seen, run = _fake_stream(lambda t: None if (t or {}).get("type") == "enabled" else "thinking: no")
+    llm = AnthropicLlm(
+        api_key="k", configuration=AnthropicConfiguration(model="m", max_tokens=3000)
+    )
+    llm._run_stream = run  # type: ignore[method-assign]
+
+    await llm.stream_turn([], None, publish=lambda *a, **k: None)
+
+    budget = seen[-1]["thinking"]["budget_tokens"]
+    assert 1024 <= budget < 3000, "budget_tokens must be >= 1024 and < max_tokens"
+    _reset()
+
+
+async def test_stream_turn_drops_thinking_when_every_tier_is_rejected() -> None:
+    _reset()
+    seen, run = _fake_stream(lambda t: "thinking: not supported" if t is not None else None)
+    llm = _llm("some-relay-alias")
+    llm._run_stream = run  # type: ignore[method-assign]
+
+    result = await llm.stream_turn([], None, publish=lambda *a, **k: None)
+
+    assert result.content == "done"
+    assert "thinking" not in seen[-1], "after every tier is rejected the final attempt carries no thinking"
+    assert len(seen) == 4
+    _reset()
+
+
+async def test_stream_turn_reraises_unrelated_400_without_stepping_down() -> None:
+    _reset()
+    seen, run = _fake_stream(lambda _t: "tools.0.input_schema: Field required")
+    llm = _llm()
+    llm._run_stream = run  # type: ignore[method-assign]
+
+    try:
+        await llm.stream_turn([], None, publish=lambda *a, **k: None)
+    except _Exc400:
+        pass
+    else:  # pragma: no cover - defensive
+        raise AssertionError("a 400 unrelated to thinking must propagate unchanged")
+    assert len(seen) == 1, "an unrelated 400 must not trigger a step-down retry"
+    _reset()
+
+
+async def test_stream_turn_does_not_remember_tier_when_request_still_fails() -> None:
+    _reset()
+    # Every attempt fails with a thinking-flavoured message (e.g. a replay error):
+    # the ladder is exhausted, the error propagates, and nothing is learned — the
+    # next turn starts at the top again instead of silently losing thinking.
+    seen, run = _fake_stream(lambda _t: "messages.3.content.0.thinking: bad block")
+    llm = _llm()
+    llm._run_stream = run  # type: ignore[method-assign]
+
+    try:
+        await llm.stream_turn([], None, publish=lambda *a, **k: None)
+    except _Exc400:
+        pass
+    assert llm._reject_key() not in _THINKING_TIERS
+    _reset()
+
+
+async def test_stream_turn_keeps_caller_supplied_thinking() -> None:
+    _reset()
+    seen, run = _fake_stream(lambda _t: None)
+    llm = _llm()
+    llm._run_stream = run  # type: ignore[method-assign]
+
+    await llm.stream_turn(
+        [], None, publish=lambda *a, **k: None,
+        extra_body={"thinking": {"type": "disabled"}},
+    )
+
+    assert seen[0]["thinking"] == {"type": "disabled"}, "a caller-supplied thinking in extra_body wins and is never overwritten by the ladder"
+    _reset()
+
+
+async def test_stream_turn_omits_sampling_params_while_thinking_is_on() -> None:
+    """Anthropic rejects temperature/top_p/top_k next to thinking ("`temperature` may
+    only be set to 1 when thinking is enabled"), so thinking tiers never carry them."""
+    _reset()
+    seen, run = _fake_stream(lambda _t: None)
+    llm = AnthropicLlm(
+        api_key="k",
+        configuration=AnthropicConfiguration(model="claude-sonnet-5", temperature=0.7),
+    )
+    llm._run_stream = run  # type: ignore[method-assign]
+
+    await llm.stream_turn([], None, publish=lambda *a, **k: None)
+
+    assert len(seen) == 1, "thinking tiers omit temperature up front — no wasted round trip"
+    assert seen[0]["thinking"] == _SUMMARIZED
+    assert "temperature" not in seen[0]
+    _reset()
+
+
+async def test_stream_turn_ladder_bottom_restores_sampling_and_self_heals() -> None:
+    """Every thinking tier rejected, and the model also rejects ``temperature``: the
+    no-thinking attempt carries temperature again, the deprecated-param self-heal
+    strips it, and the request finally succeeds (the path seen live on Sonnet 5
+    before the sampling rule above existed)."""
+    _reset()
+    seen: list = []
+
+    async def run(params, publish):
+        seen.append(dict(params))
+        if params.get("thinking") is not None:
+            raise _Exc400("adaptive thinking is not supported on this model")
+        if "temperature" in params:
+            raise _Exc400("`temperature` is deprecated for this model.")
+        return StreamResult(tool_calls=[], content="done", usage=None, capture={})
+
+    llm = AnthropicLlm(
+        api_key="k",
+        configuration=AnthropicConfiguration(model="claude-sonnet-5", temperature=0.7),
+    )
+    llm._run_stream = run  # type: ignore[method-assign]
+
+    result = await llm.stream_turn([], None, publish=lambda *a, **k: None)
+
+    assert result.content == "done"
+    assert [("thinking" in s, "temperature" in s) for s in seen] == [
+        (True, False), (True, False), (True, False),  # tiers 0-2, sampling dropped
+        (False, True),                                # no-thinking tier sends temperature
+        (False, False),                               # deprecated → stripped → ok
+    ]
+    assert "temperature" in _REJECTED_PARAMS.get(llm._reject_key(), set())
+    _reset()
+
+
+async def test_stream_turn_skips_budget_tier_when_max_tokens_too_small() -> None:
+    """``budget_tokens`` must be ≥1024 AND < max_tokens; with max_tokens 1024 the
+    ``enabled`` tier cannot be satisfied, so it degrades to no thinking."""
+    _reset()
+    seen, run = _fake_stream(lambda t: "adaptive thinking is not supported" if t else None)
+    llm = AnthropicLlm(
+        api_key="k", configuration=AnthropicConfiguration(model="m", max_tokens=1024)
+    )
+    llm._run_stream = run  # type: ignore[method-assign]
+
+    await llm.stream_turn([], None, publish=lambda *a, **k: None)
+
+    assert all(s.get("thinking", {}).get("type") != "enabled" for s in seen), "must never send a request whose budget_tokens >= max_tokens"
+    assert "thinking" not in seen[-1]
+    _reset()
+
+
+# --- achat / chat (probe + classifier) never inject thinking ----------------
+
+async def test_achat_does_not_inject_thinking() -> None:
+    _reset()
+    calls: list = []
+
+    async def create(**params):
+        calls.append(dict(params))
+        return SimpleNamespace(content=[SimpleNamespace(type="text", text="pong")])
+
+    llm = _llm()
+    llm.async_client = SimpleNamespace(messages=SimpleNamespace(create=create))
+
+    await llm.achat([Message.from_text("ping", role=Role.USER)])
+
+    assert "thinking" not in calls[0], "achat (probe / classifier) never injects thinking"
+    _reset()
+
+
+async def test_achat_forwards_extra_body() -> None:
+    """The safety classifier turns reasoning off through ``achat(..., extra_body=…)``;
+    the Anthropic adapter must put those keys on the request."""
+    _reset()
+    calls: list = []
+
+    async def create(**params):
+        calls.append(dict(params))
+        return SimpleNamespace(content=[SimpleNamespace(type="text", text="pong")])
+
+    llm = _llm()
+    llm.async_client = SimpleNamespace(messages=SimpleNamespace(create=create))
+
+    await llm.achat(
+        [Message.from_text("ping", role=Role.USER)],
+        extra_body={"output_config": {"effort": "low"}},
+    )
+
+    assert calls[0]["output_config"] == {"effort": "low"}, "achat must forward extra_body"
+    _reset()

--- a/tests/test_openai_params.py
+++ b/tests/test_openai_params.py
@@ -46,6 +46,35 @@ def test_sanitize_non_openai_untouched() -> None:
     assert sanitize_openai_params(dict(src), base_url="https://api.deepseek.com") == src
 
 
+def test_sanitize_reasoning_model_rules_apply_on_any_host() -> None:
+    """Official rule: reasoning models reject temperature/top_p/... and only take
+    max_completion_tokens — a property of the model, not of the host. A relay
+    (LiteLLM, new-api) serving gpt-5-mini gets the same sanitized request."""
+    out = sanitize_openai_params(
+        {"model": "gpt-5-mini", "temperature": 0.0, "top_p": 1, "max_tokens": 64, "messages": []},
+        base_url="http://litellm.local:4000/v1")
+    assert "temperature" not in out and "top_p" not in out
+    assert "max_tokens" not in out and out["max_completion_tokens"] == 64
+
+
+def test_sanitize_o_series_on_relay_host() -> None:
+    out = sanitize_openai_params(
+        {"model": "o4-mini", "temperature": 0.0, "presence_penalty": 0.5, "max_tokens": 8},
+        base_url="http://136.116.56.93:3000/v1")
+    assert "temperature" not in out and "presence_penalty" not in out
+    assert out["max_completion_tokens"] == 8 and "max_tokens" not in out
+
+
+def test_sanitize_chat_alias_on_relay_host_untouched() -> None:
+    src = {"model": "gpt-5-chat-latest", "temperature": 0.0, "max_tokens": 8}
+    assert sanitize_openai_params(dict(src), base_url="http://litellm.local:4000/v1") == src
+
+
+def test_sanitize_non_reasoning_openai_model_on_relay_host_untouched() -> None:
+    src = {"model": "gpt-4o", "temperature": 0.0, "max_tokens": 8}
+    assert sanitize_openai_params(dict(src), base_url="http://litellm.local:4000/v1") == src
+
+
 def test_sanitize_kimi_code_forces_supported_temperature() -> None:
     src = {"model": "k3", "temperature": 0.0, "max_tokens": 8}
     out = sanitize_openai_params(src, base_url="https://api.kimi.com/coding/v1")
@@ -407,3 +436,130 @@ async def test_kimi_stream_open_timeout_is_bounded(monkeypatch) -> None:
 
     assert calls == 3
     assert [payload["attempt"] for channel, payload in events if channel == "model_retry"] == [1, 2]
+
+
+# ---------------------------------------------------------------------------
+# Relay-shaped unsupported-param errors (LiteLLM) + achat self-heal
+# ---------------------------------------------------------------------------
+# LiteLLM enforces OpenAI's parameter rules itself and raises
+# ``litellm.UnsupportedParamsError`` with code "400" and param null — the
+# parameter name only lives in the message text. new-api tolerates the same
+# params, which is why this never surfaced there.
+
+class _LiteLLMExc(Exception):
+    """The shape the openai SDK exposes for a LiteLLM UnsupportedParamsError."""
+
+    status_code = 400
+
+    def __init__(self, message: str) -> None:
+        super().__init__(f"Error code: 400 - {{'error': {{'message': {message!r}}}}}")
+        self.code = "400"
+        self.param = None
+        self.body = {"error": {"message": message, "type": "None", "param": None, "code": "400"}}
+
+
+_LITELLM_GPT5 = (
+    "litellm.UnsupportedParamsError: gpt-5 models (including gpt-5-codex) don't support "
+    "temperature=0.0. Only temperature=1 is supported. To drop unsupported params set "
+    "`litellm.drop_params = True`. Received Model Group=gpt-5-mini\nAvailable Model Group Fallbacks=None"
+)
+_LITELLM_O_SERIES = (
+    "litellm.UnsupportedParamsError: O-series models don't support temperature=0.0. Only "
+    "temperature=1 is supported. To drop unsupported openai params from the call, set "
+    "`litellm.drop_params = True`"
+)
+
+
+def test_unsupported_param_of_reads_relay_message_text() -> None:
+    assert unsupported_param_of(_LiteLLMExc(_LITELLM_GPT5)) == "temperature"
+    assert unsupported_param_of(_LiteLLMExc(_LITELLM_O_SERIES)) == "temperature"
+    # OpenAI's own wording when the structured code/param fields are missing
+    assert unsupported_param_of(
+        _LiteLLMExc("Unsupported parameter: 'top_p' is not supported with this model.")
+    ) == "top_p"
+    # a 400 that names no request parameter is not healable
+    assert unsupported_param_of(_LiteLLMExc("Invalid model group")) is None
+    # only request parameters are candidates — random words before '=' don't count
+    assert unsupported_param_of(_LiteLLMExc("models don't support images=true")) is None
+
+
+async def test_self_heal_on_relay_unsupported_params_error() -> None:
+    """A LiteLLM-shaped 400 naming temperature → stripped, retried, cached."""
+    from bridgic.llms.openai import OpenAIConfiguration
+    from src.amphi_service.protocol.llms.openai_llm import OpenAICompatLlm, _REJECTED_PARAMS
+
+    _REJECTED_PARAMS.clear()
+    calls: list = []
+
+    async def create(**params):
+        calls.append(dict(params))
+        if "temperature" in params:
+            raise _LiteLLMExc(_LITELLM_GPT5)
+        return _ok_stream()
+
+    # a name the static sanitizer cannot classify (a future reasoning model)
+    llm = OpenAICompatLlm(
+        api_key="k", api_base="http://litellm.local:4000/v1",
+        configuration=OpenAIConfiguration(model="gpt-6-reasoner", temperature=0.0),
+    )
+    llm.async_client = _fake_client(create)
+
+    result = await llm.stream_turn([], None, publish=lambda *a, **k: None)
+
+    assert result.content == "ok"
+    assert len(calls) == 2 and "temperature" not in calls[1]
+    assert "temperature" in _REJECTED_PARAMS.get(llm._reject_key(), set())
+    _REJECTED_PARAMS.clear()
+
+
+def test_build_parameters_pre_strips_learned_rejections() -> None:
+    """What the stream path learned applies to achat/chat too (probe, classifier)."""
+    from bridgic.core.model.types import Message, Role
+    from bridgic.llms.openai import OpenAIConfiguration
+    from src.amphi_service.protocol.llms.openai_llm import OpenAICompatLlm, _REJECTED_PARAMS
+
+    _REJECTED_PARAMS.clear()
+    llm = OpenAICompatLlm(
+        api_key="k", api_base="http://litellm.local:4000/v1",
+        configuration=OpenAIConfiguration(model="gpt-4o", temperature=0.0),
+    )
+    _REJECTED_PARAMS[llm._reject_key()] = {"temperature"}
+
+    params = llm._build_parameters(messages=[Message.from_text("hi", role=Role.USER)])
+
+    assert "temperature" not in params
+    _REJECTED_PARAMS.clear()
+
+
+async def test_achat_self_heals_unsupported_param(monkeypatch) -> None:
+    """achat (probe / classifier) strips a rejected param and retries once, so a
+    brand-new process can talk to gpt-5-mini through LiteLLM without a stream
+    having learned the rejection first."""
+    from bridgic.core.model import ModelUnrecoverableError
+    from bridgic.core.model.types import Message, Role
+    from bridgic.llms.openai import OpenAIConfiguration, OpenAILlm
+    from src.amphi_service.protocol.llms.openai_llm import OpenAICompatLlm, _REJECTED_PARAMS
+
+    _REJECTED_PARAMS.clear()
+    attempts: list = []
+
+    async def fake_super_achat(self, messages, **kwargs):
+        attempts.append(dict(self._build_parameters(messages=messages, **kwargs)))
+        if "temperature" in attempts[-1]:
+            raise ModelUnrecoverableError(
+                "achat failed", operation="achat", original_exception=_LiteLLMExc(_LITELLM_GPT5),
+            )
+        return "pong"
+
+    monkeypatch.setattr(OpenAILlm, "achat", fake_super_achat)
+    llm = OpenAICompatLlm(
+        api_key="k", api_base="http://litellm.local:4000/v1",
+        configuration=OpenAIConfiguration(model="gpt-6-reasoner", temperature=0.0),
+    )
+
+    out = await llm.achat([Message.from_text("ping", role=Role.USER)])
+
+    assert out == "pong"
+    assert len(attempts) == 2 and "temperature" not in attempts[1]
+    assert "temperature" in _REJECTED_PARAMS.get(llm._reject_key(), set())
+    _REJECTED_PARAMS.clear()

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -383,6 +383,35 @@ async def test_connection_probe(
     assert (await client.get("/me/providers")).json() == []
 
 
+async def test_connection_probe_openai_sends_no_token_cap(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The OpenAI-protocol probe must not cap the reply at 1 token: reasoning
+    models (gpt-5.x / o-series) spend that budget on reasoning and the upstream
+    400s with "Could not finish the message because max_tokens ... was reached"
+    — reproduced live through new-api on gpt-5-mini with both ``max_tokens=1``
+    and ``max_completion_tokens=1``. A "ping" reply is short, so no cap is
+    still a cheap probe."""
+    from src.amphi_service.protocol.llms.openai_llm import OpenAICompatLlm
+
+    seen = []
+
+    async def ok_probe(self, messages, **kwargs):
+        seen.append(self.configuration.max_tokens)
+        return "pong"
+
+    monkeypatch.setattr(OpenAICompatLlm, "achat", ok_probe)
+    r = await client.post("/me/providers/test", json={
+        "provider_id": "newapi-openai", "protocol": "openai",
+        "base_url": "http://relay.example:3000/v1",
+        "api_key": "sk-test", "model": "gpt-5-mini",
+    })
+
+    assert r.json()["ok"] is True
+    assert seen == [None], "probe must not send a 1-token cap (breaks reasoning models)"
+
+
 async def test_connection_probe_times_out_before_the_renderer(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -502,16 +531,14 @@ def test_probe_constructs_openai_compat_llm_and_sanitizes_gpt5_params() -> None:
         api_base=None,  # true OpenAI endpoint
         configuration=__import__(
             "bridgic.llms.openai", fromlist=["OpenAIConfiguration"]
-        ).OpenAIConfiguration(model="gpt-5.5", temperature=0.0, max_tokens=1),
+        ).OpenAIConfiguration(model="gpt-5.5", temperature=0.0, max_tokens=None),
     )
 
     msgs = [Message.from_text("ping", role=Role.USER)]
     params = llm_openai._build_parameters(messages=msgs)
 
-    # True-OpenAI gpt-5.x: max_tokens renamed, temperature stripped.
-    assert "max_tokens" not in params, "max_tokens must be renamed for true OpenAI"
-    assert "max_completion_tokens" in params, "must rename to max_completion_tokens"
-    assert params["max_completion_tokens"] == 1
+    # True-OpenAI gpt-5.x: no token cap is sent, temperature stripped.
+    assert "max_tokens" not in params and "max_completion_tokens" not in params
     assert "temperature" not in params, "temperature must be stripped for reasoning model"
 
     # DeepSeek endpoint: sanitizer is a no-op → max_tokens + temperature pass through.

--- a/tests/test_reasoning.py
+++ b/tests/test_reasoning.py
@@ -65,7 +65,53 @@ def test_reasoning_off_provider_matrix() -> None:
         ("openai", "gpt-5", "https://api.openai.com/v1", {"reasoning_effort": "minimal"}, "minimized"),
         ("openai", "gpt-5.1", "https://api.openai.com/v1", {"reasoning_effort": "none"}, "disabled"),
         ("openai", "o3-mini", "https://api.openai.com/v1", {"reasoning_effort": "low"}, "minimized"),
+        # Through a new-api relay (unknown base) → fall back to the model name. From gpt-5.1 on
+        # "minimal" is gone and only "none" is accepted (5.4/5.5 return 400 "does not support
+        # 'minimal'" live); gpt-5 / gpt-5-mini are the reverse and accept only "minimal".
+        ("openai", "gpt-5.4", "http://my-new-api:3000/v1", {"reasoning_effort": "none"}, "disabled"),
+        ("openai", "gpt-5.4-mini", "http://my-new-api:3000/v1", {"reasoning_effort": "none"}, "disabled"),
+        ("openai", "gpt-5.5", "http://my-new-api:3000/v1", {"reasoning_effort": "none"}, "disabled"),
+        ("openai", "gpt-5.6-sol", "http://my-new-api:3000/v1", {"reasoning_effort": "none"}, "disabled"),
+        ("openai", "gpt-5-mini", "http://my-new-api:3000/v1", {"reasoning_effort": "minimal"}, "minimized"),
+        ("openai", "o4-mini", "http://my-new-api:3000/v1", {"reasoning_effort": "low"}, "minimized"),
+        # *-chat-latest aliases: non-reasoning or a fixed effort — never inject anything
+        ("openai", "gpt-5-chat-latest", "http://my-new-api:3000/v1", {}, "not_needed"),
+        ("openai", "gpt-5.2-chat-latest", "https://api.openai.com/v1", {}, "not_needed"),
         ("anthropic", "claude-sonnet-4-5", "", {}, "not_needed"),
+        ("anthropic", "claude-opus-4-8", "", {}, "not_needed"),
+        # The 5 series thinks adaptively by default: Sonnet 5 can genuinely switch it off; Opus 5
+        # leaks <thinking> into the answer when disabled (Anthropic recommends low effort instead);
+        # Fable / Mythos cannot disable at all and only take a lower effort.
+        (
+            "anthropic",
+            "claude-sonnet-5",
+            "https://my-new-api.example/",
+            {"extra_body": {"thinking": {"type": "disabled"}}},
+            "disabled",
+        ),
+        (
+            "anthropic",
+            "claude-opus-5",
+            "",
+            {"extra_body": {"output_config": {"effort": "low"}}},
+            "minimized",
+        ),
+        (
+            "anthropic",
+            "claude-fable-5",
+            "",
+            {"extra_body": {"output_config": {"effort": "low"}}},
+            "minimized",
+        ),
+        (
+            "anthropic",
+            "claude-mythos-5",
+            "",
+            {"extra_body": {"output_config": {"effort": "low"}}},
+            "minimized",
+        ),
+        # An unrecognised relay alias → conservatively inject nothing (the classifier's strip-and-retry covers it)
+        ("anthropic", "my-relay-alias", "https://my-new-api.example/", {}, "unknown"),
         ("openai", "some-random-model", "https://my-proxy.internal/v1", {}, "unknown"),
     ]
 

--- a/tests/test_thinking_passback.py
+++ b/tests/test_thinking_passback.py
@@ -198,13 +198,17 @@ def test_turn_messages_openai_empty_reasoning_fallback() -> None:
     assert ai1.extras["reasoning_content"] == ""
 
 
-def test_turn_messages_anthropic_empty_thinking_fallback() -> None:
-    """Same, Anthropic shape: round 1 with no thinking gets an empty thinking block."""
-    tb = [{"type": "thinking", "thinking": "r", "signature": "S"}]
+def test_turn_messages_anthropic_round_without_thinking_gets_no_fake_block() -> None:
+    """Anthropic shape: adaptive thinking may skip a round entirely (Sonnet 5 on a
+    trivial tool-call round). That round must replay WITHOUT a thinking block — a
+    synthesized ``{"thinking": "", "signature": ""}`` has no valid signature and
+    Anthropic (and relays in front of it) 400 with "each thinking block must
+    contain thinking"."""
+    tb = [{"type": "thinking", "thinking": "", "signature": "S"}]
     msgs = _turn_messages(_ota_two_tool_rounds({"thinking_blocks": tb}, {}))
     ai0, ai1 = msgs[0], msgs[2]
     assert ai0.extras["thinking_blocks"] == tb
-    assert ai1.extras["thinking_blocks"] == [{"type": "thinking", "thinking": "", "signature": ""}]
+    assert "thinking_blocks" not in (ai1.extras or {})
 
 
 ############################################################################


### PR DESCRIPTION
## Summary

Fixes the `400 — each thinking block must contain thinking` failure on `claude-sonnet-5` (and every other adaptive-thinking Claude model), makes the UI show thinking text again on models whose default `thinking.display` is `omitted`, and makes both the Anthropic and OpenAI protocol paths work across model generations and through new-api relays.

### Root cause
`turn_messages` (`src/amphi_agent/_cognitive.py`) fabricated `{"thinking": "", "signature": ""}` for any tool-call round that produced no thinking once some other round had. Adaptive thinking (Sonnet 5 / Opus 5 / Fable 5, Opus 4.7+) legitimately skips thinking on trivial rounds, and a block without a real signature is rejected on the next replay. 4.x models never hit this because they do not think unless asked.

### Changes
- **`_cognitive.py`** — drop the Anthropic empty-block fallback (the DeepSeek-style fallback stays OpenAI-wire only).
- **`anthropic_llm.py`** — `stream_turn` requests thinking explicitly and self-heals per `(base_url, model)`: `adaptive+summarized → adaptive → enabled+budget_tokens → none`, stepping down on thinking-config 400s and remembering the tier that worked (learned from success only). Thinking tiers never carry `temperature`/`top_p`/`top_k` (Anthropic rejects them next to thinking). A caller-supplied `thinking` in `extra_body` is sent as-is. `achat` forwards `extra_body`; `chat`/`achat` never inject thinking.
- **`security/_reasoning.py`** — classifier reasoning-off: Sonnet 5 → `thinking: disabled`; Opus 5 / Fable 5 / Mythos → `output_config.effort: low`; Claude 4.x → nothing; OpenAI `gpt-5.1+` point releases → `reasoning_effort: none` (`minimal` is rejected on 5.4/5.5), `gpt-5` / `gpt-5-mini` → `minimal`, `*-chat*` aliases → nothing.
- **Tests** — new `tests/test_anthropic_thinking.py` (ladder order, tier memory, budget bounds, sampling-param rule, unrelated 400 passthrough, caller override, relay-masked error texts); updated `test_thinking_passback.py`, `test_anthropic_params.py`, `test_reasoning.py`.

### Behaviour changes worth knowing
- Claude 4.x models now get extended thinking on the agent path (`enabled` + `budget_tokens`, half of `max_tokens` capped at 4096) — extra thinking tokens are billed. Pre-4.6 models show thinking only on the first round of a turn (no interleaved-thinking beta yet).
- With thinking on, the configured `temperature` is not sent (Anthropic only allows 1 / unset alongside thinking).
- OpenAI models return no reasoning text over Chat Completions, so no thinking block in the UI for them — protocol, not a bug.

## Test plan
- [x] `uv run pytest -q --timeout=300 --timeout-method=thread` — 1899 passed, 10 skipped
- [x] `cd desktop && bun run check:chinese`
- [x] Live through a new-api relay, Anthropic protocol, 10 models (`claude-sonnet-5`, `opus-5`, `fable-5`, `opus-4-8/4-7/4-6`, `sonnet-4-6`, `sonnet-4-5`, `opus-4-5`, `haiku-4-5`): single + parallel tool calls, multi-round replay with mixed thinking/no-thinking rounds, classifier `achat`
- [x] Live through the same relay, OpenAI protocol, 14 models (`gpt-5.5/5.4/5.4-mini/5.2/5.1/5/5-mini`, `gpt-4.1/4.1-mini`, `gpt-4o/4o-mini`, `o3`, `o4-mini`, `o1`): same matrix
- [x] End to end through the running backend (original 8-step file task, auto mode): `claude-sonnet-5` (10 rounds, 4 thinking blocks in the UI), `claude-haiku-4-5`, `gpt-5.4`, `gpt-4.1-mini` — all completed with the expected `summary.txt`
- [x] Same matrix through a **LiteLLM proxy** (strict parameter validation, default `drop_params: false`): 4 Claude models (Anthropic protocol) + 4 OpenAI models — connectivity, tool calls with replay, and end-to-end all pass; LiteLLM is what exposed the reasoning-model parameter bug fixed in the second commit
- [x] **Direct `api.openai.com` (api_key mode)**: connectivity for `gpt-5.5` / `gpt-5.4-mini` / `gpt-5.4-nano` / `gpt-5-mini` / `o4-mini` / `gpt-4o-mini`; adapter-level single+parallel tool calls with replay and classifier for all six; end to end for `gpt-5.4-mini` / `gpt-5-mini` / `o4-mini` / `gpt-4o-mini` (the last completing after a human approval of the destructive `rm` step — also exercising the pause/approve/resume path)
- [x] **new-api regression after all three commits**: 24/24 connectivity probes across both protocols; adapter-level re-check on 8 models (reasoning models now send no sampling params, one attempt per round; non-reasoning unchanged); multi-round parallel scenario re-run on `gpt-5.4` + `o3` (full 8 serial rounds); end to end re-run on `gpt-5.4` and `claude-sonnet-5`

## Second commit — OpenAI reasoning-model parameters, by model not by host

Found while testing the same agent through a LiteLLM proxy (default `drop_params: false`): OpenAI reasoning models (`gpt-5`, `gpt-5-mini`, `o4-mini`, …) failed on the very first request with `litellm.UnsupportedParamsError: … don't support temperature=0.0`. OpenAI documents `temperature` / `top_p` / penalties / `logprobs` / `logit_bias` / `max_tokens` as unsupported on reasoning models (only `max_completion_tokens` is accepted); `sanitize_openai_params` knew this but only applied it on `api.openai.com`, so relay-served reasoning models still got `temperature=0.0` — new-api silently dropped it, LiteLLM rejects it.

- **`_openai_params.py`** — reasoning-model rules (strip sampling params, `max_tokens` → `max_completion_tokens`) now key on the model name and apply on every host; non-reasoning models keep the old host-scoped behaviour. `unsupported_param_of` additionally reads the parameter name out of relay error text (LiteLLM / OpenAI wording, limited to known request params) as a safety net for names the heuristic doesn't know.
- **`openai_llm.py`** — `_build_parameters` pre-strips learned rejections so `achat` (provider probe, safety classifier) benefits; `achat` self-heals a wrapped unsupported-param 400 once.
- **Tests** — 8 new cases in `tests/test_openai_params.py` (model-keyed sanitizing on relay hosts, relay error-text recognition, pre-strip, `achat` heal).

Verified live through LiteLLM on `gpt-5-mini` / `o4-mini` / `gpt-5`: provider probe → single + parallel tool calls with replay → end-to-end agent run, one attempt per round, no sampling params on the wire. (new-api was unreachable at the time — 502 on every path — so the regression spot-check there is still pending.)

## Third commit — connection-test probe vs reasoning models

The provider probe capped the reply at `max_tokens=1`. Reasoning models spend that budget on reasoning before the first output token, so strict upstreams 400 with "Could not finish the message because max_tokens or model output limit was reached" (reproduced live through new-api on `gpt-5-mini`, with both `max_tokens=1` and `max_completion_tokens=1`) — the UI "test connection" button failed for every reasoning model there. The OpenAI-protocol probe now sends no token cap (a "ping" reply is short, so it stays cheap); the Anthropic probe keeps `max_tokens=1` (required parameter; the probe never enables thinking). Verified live: `gpt-5-mini` / `gpt-5.4` / `o3` / `gpt-4.1-mini` probes all pass through new-api, plus an adapter-level regression pass on both protocols.

## Follow-ups (not in this PR)
- Anthropic prompt caching on the agent path (currently every round pays full price for ~30K input tokens; the relay passes `cache_control` through).
- Record cache-hit tokens in usage accounting.
- `interleaved-thinking` beta for the `enabled+budget` tier so 4.x models show thinking on every round.

