### PR TITLE
feat: Anthropic prompt caching with a byte-stable request prefix

### DIFF
--- a/src/amphi_agent/_cognitive.py
+++ b/src/amphi_agent/_cognitive.py
@@ -56,6 +56,12 @@ __all__ = [
 
 SESSION_MESSAGE_RECORD_LIMIT = 100
 logger = logging.getLogger(__name__)
+# Marker on ``Message.extras`` for the per-round <runtime_state> USER tail: live
+# state (changed files, browser tabs) that must stay OUT of the cacheable request
+# prefix. Adapters treat it specially (Anthropic: no cache breakpoint on or after
+# it; OpenAI: the flag is stripped before the wire) and it is never persisted.
+VOLATILE_TAIL_EXTRA = "volatile_tail"
+
 CHILD_TOOL_NAMES = BROWSER_TOOL_NAMES | frozenset({
     "bash",
     "read_file",
@@ -267,6 +273,7 @@ class MainThink(CognitiveWorker):
             status.stage if isinstance(status, BuildStageState) else None
         )
         messages = await self.assemble_messages(ota_context, context)
+        messages = await self.append_runtime_state(messages, ota_context, context)
         tools = [spec.to_tool() for spec in ota_context.tools]
         stream = ota_context.stream
         def publish(event: str, **payload: Any) -> None:
@@ -424,7 +431,6 @@ class MainThink(CognitiveWorker):
             await self.workflows_block(ota_context, context),
             await self.memory_block(ota_context, context),
             await self.workspace_block(ota_context, context),
-            await self.browser_block(ota_context, context),
         ]
 
     def system_block(self, ota_context: AmphiOTAContext, context: AmphiContext) -> str:
@@ -449,6 +455,54 @@ class MainThink(CognitiveWorker):
     ) -> str:
         """Compose the stable-first SYSTEM prefix without per-Invocation metadata."""
         return "\n\n".join(block for block in blocks if block)
+
+    async def runtime_state_block(self, ota_context: AmphiOTAContext, context: AmphiContext) -> str:
+        """Render this round's LIVE state — Workspace changed files (plus recent
+        checkpoints) and open browser tabs — as one ``<runtime_state>`` block.
+
+        Kept out of SYSTEM on purpose: this text changes between rounds (every
+        file write, every navigation), and prompt caching is a byte-prefix match,
+        so it rides at the very end of the request instead (see
+        ``append_runtime_state``)."""
+        lines: List[str] = []
+        workspace = context.workspace
+        if workspace is not None:
+            try:
+                lines.extend(workspace.checkpoints.changed_files_context_lines())
+                if self.show_workspace_checkpoints:
+                    lines.extend(workspace.checkpoints.checkpoint_context_lines(max_count=3))
+            except Exception as exc:  # noqa: BLE001
+                lines.append(f"- Changed files: unavailable ({type(exc).__name__}: {exc})")
+        browser = await self.browser_block(ota_context, context)
+        if browser:
+            lines.append(browser)
+        if not lines:
+            return ""
+        return (
+            "<runtime_state>\n"
+            "Live workspace and browser state as of this round (may change between rounds).\n"
+            + "\n".join(lines)
+            + "\n</runtime_state>"
+        )
+
+    async def append_runtime_state(
+        self,
+        messages: List[Message],
+        ota_context: AmphiOTAContext,
+        context: AmphiContext,
+    ) -> List[Message]:
+        """Append the ``<runtime_state>`` USER tail to this round's request.
+
+        The tail is flagged ``VOLATILE_TAIL_EXTRA`` and NEVER persisted (the OTA
+        record does not store it), so replayed history stays byte-stable for the
+        provider prompt cache while the model still sees fresh live state."""
+        state = await self.runtime_state_block(ota_context, context)
+        if not state:
+            return messages
+        return [
+            *messages,
+            Message.from_text(state, role=Role.USER, extras={VOLATILE_TAIL_EXTRA: True}),
+        ]
 
     async def browser_block(self, ota_context: AmphiOTAContext, context: AmphiContext) -> str:
         """Render lightweight metadata for an already-open browser."""
@@ -611,15 +665,9 @@ class MainThink(CognitiveWorker):
             f"- Node environment: {_node_environment_summary(workspace)}",
         ])
         lines.append(f"- Python environment: {_python_environment_summary(workspace)}")
-        if workspace is None:
-            lines.append("- Changed files: none")
-        else:
-            try:
-                lines.extend(workspace.checkpoints.changed_files_context_lines())
-                if self.show_workspace_checkpoints:
-                    lines.extend(workspace.checkpoints.checkpoint_context_lines(max_count=3))
-            except Exception as exc:  # noqa: BLE001
-                lines.append(f"- Changed files: unavailable ({type(exc).__name__}: {exc})")
+        # Live state (changed files, checkpoints) deliberately lives in
+        # ``runtime_state_block`` — putting it here would change the SYSTEM text
+        # on every file write and invalidate the whole cached request prefix.
         lines.append("</Workspace>")
         return "\n".join(lines)
 
@@ -1188,6 +1236,12 @@ class MainThink(CognitiveWorker):
         inp = get("prompt_tokens")
         if inp is None:
             inp = get("input_tokens")
+            # Anthropic's input_tokens EXCLUDES cache reads/writes; fold them in
+            # so turn totals stay comparable whether or not caching hit.
+            if inp is not None:
+                inp = int(inp) + int(get("cache_creation_input_tokens") or 0) + int(
+                    get("cache_read_input_tokens") or 0
+                )
         out = get("completion_tokens")
         if out is None:
             out = get("output_tokens")
@@ -1229,7 +1283,6 @@ class SubAgentThink(MainThink):
             await self.workflows_block(ota_context, context),
             await self.memory_block(ota_context, context),
             await self.workspace_block(ota_context, context),
-            await self.browser_block(ota_context, context),
         ]
 
 
@@ -1278,7 +1331,6 @@ class WorkflowRunThink(MainThink):
             await self.workflow_run_block(ota_context, context, self.workflow_stage),
             await self.memory_block(ota_context, context),
             await self.workspace_block(ota_context, context),
-            await self.browser_block(ota_context, context),
         ]
 
     def system_block(self, ota_context: AmphiOTAContext, context: AmphiContext) -> str:
@@ -1674,7 +1726,6 @@ class BuildThink(MainThink):
             await self.memory_block(ota_context, context),
             self.build_workspace_block(context),
             await self.workspace_block(ota_context, context),
-            await self.browser_block(ota_context, context),
         ]
 
     @staticmethod

--- a/src/amphi_service/handler/_providers_handler.py
+++ b/src/amphi_service/handler/_providers_handler.py
@@ -906,6 +906,10 @@ async def _activate_codex_provider(llms: LlmCache, user_id: str) -> None:
         display_name="OpenAI",
         models=models,
     )
+    # upsert preserves a non-None base_url — explicitly forget the api_key-era
+    # url, or the next /me/active-model mirrors it back and Codex requests go
+    # to https://api.openai.com/v1/codex/responses (404).
+    await ProviderRepository().clear_base_url(user_id, _CODEX_PROVIDER_ID)
     await ProviderRepository().set_active(user_id, _CODEX_PROVIDER_ID)
     # Set current_model too: the chat picker's activeModelAtom needs a matching
     # (active provider, current model) pair, else the GUI shows "configure a

--- a/src/amphi_service/protocol/llms/_openai_params.py
+++ b/src/amphi_service/protocol/llms/_openai_params.py
@@ -25,7 +25,8 @@ _HEALABLE_PARAMS = REASONING_UNSUPPORTED | frozenset({
 _UNSUPPORTED_TEXT = re.compile(
     r"(?:don't|do not|does not) support [`']?(\w+)[`']?\s*="
     r"|Unsupported parameter:? [`']?(\w+)[`']?"
-    r"|[`'](\w+)[`'] is not supported",
+    r"|[`'](\w+)[`'] is not supported"
+    r"|invalid [`']?(\w+)[`']?:",
     re.IGNORECASE,
 )
 
@@ -49,6 +50,17 @@ def is_kimi_code_endpoint(base_url: Optional[str]) -> bool:
     host = (parsed.hostname or "").lower()
     path = parsed.path.rstrip("/").lower()
     return host == "api.kimi.com" and (path == "/coding" or path.startswith("/coding/"))
+
+
+def is_moonshot_endpoint(base_url: Optional[str]) -> bool:
+    """Return whether ``base_url`` targets the Kimi open platform (Moonshot).
+
+    Like Kimi Code, the platform enforces ``temperature=1`` on current models
+    (k2.6+ reject anything else with 400 "invalid temperature: only 1 is
+    allowed for this model").
+    """
+    host = (urlparse((base_url or "").strip()).hostname or "").lower()
+    return host == "api.moonshot.cn" or host.endswith(".moonshot.cn") or host.endswith(".moonshot.ai")
 
 
 def is_openai_reasoning_model(model: str) -> bool:
@@ -78,7 +90,7 @@ def sanitize_openai_params(params: Dict[str, Any], *, base_url: Optional[str]) -
     * On the official endpoint ``max_tokens`` is renamed for every model; other
       compatible endpoints pass non-reasoning models through untouched.
     """
-    if is_kimi_code_endpoint(base_url):
+    if is_kimi_code_endpoint(base_url) or is_moonshot_endpoint(base_url):
         out = dict(params)
         if "temperature" in out:
             out["temperature"] = 1

--- a/src/amphi_service/protocol/llms/anthropic_llm.py
+++ b/src/amphi_service/protocol/llms/anthropic_llm.py
@@ -77,6 +77,12 @@ _VOLATILE_TAIL_EXTRA = "volatile_tail"
 
 _EPHEMERAL_CACHE = {"type": "ephemeral"}
 
+# The API's cache lookback: at most 20 positions per breakpoint are checked for
+# an existing entry. A round adding more blocks than that would sail past the
+# previous round's entry, so a second message breakpoint sits this many stable
+# blocks before the rolling one (docs: "Add a second breakpoint closer").
+_CACHE_LOOKBACK_BLOCKS = 20
+
 # Substrings a thinking-config 400 carries (``thinking.display: Extra inputs…``,
 # ``thinking.type: Input should be…``, ``budget_tokens`` removed, …).
 _THINKING_REJECTION_HINTS: Tuple[str, ...] = ("thinking", "budget_tokens", "display", "adaptive")
@@ -616,11 +622,13 @@ def _volatile_tail_block_count(messages: List[Message]) -> int:
 
 
 def _with_prompt_caching(params: Dict[str, Any], volatile_blocks: int) -> Dict[str, Any]:
-    """A copy of ``params`` with up to three ``cache_control`` breakpoints:
-    the system block, the last tool definition, and the last STABLE content
-    block of the history (skipping the trailing volatile <runtime_state>
-    blocks). Every touched container is copied — message blocks may be shared
-    with persisted extras (replayed thinking) and must not be mutated.
+    """A copy of ``params`` with up to FOUR ``cache_control`` breakpoints:
+    the system block, the last tool definition, the last STABLE content block
+    of the history (skipping the trailing volatile <runtime_state> blocks),
+    and — when the history is long enough — a second anchor one lookback
+    window earlier, so a round that appends more than ~20 blocks still finds
+    a cached prefix. Every touched container is copied — message blocks may be
+    shared with persisted extras (replayed thinking) and must not be mutated.
     """
     out = dict(params)
     system = out.get("system")
@@ -632,17 +640,35 @@ def _with_prompt_caching(params: Dict[str, Any], volatile_blocks: int) -> Dict[s
     messages = out.get("messages")
     if messages:
         out["messages"] = [dict(m) for m in messages]
-        remaining = volatile_blocks
-        for msg in reversed(out["messages"]):
-            content = list(msg["content"])
-            if remaining >= len(content):
-                remaining -= len(content)
-                continue
-            idx = len(content) - 1 - remaining
-            content[idx] = {**content[idx], "cache_control": dict(_EPHEMERAL_CACHE)}
-            msg["content"] = content
-            break
+        for skip in (volatile_blocks, volatile_blocks + _CACHE_LOOKBACK_BLOCKS):
+            _mark_stable_block(out["messages"], skip)
     return out
+
+
+def _mark_stable_block(messages: List[Dict[str, Any]], skip: int) -> None:
+    """Set ``cache_control`` on the last cacheable block after skipping ``skip``
+    blocks from the end. Thinking blocks cannot carry ``cache_control`` (the
+    API rejects it) and are walked past; a block that already carries a marker
+    is left alone (keeps the total ≤ 4). No-op when the history is shorter
+    than ``skip``.
+    """
+    remaining = skip
+    for m_idx in range(len(messages) - 1, -1, -1):
+        content = messages[m_idx]["content"]
+        if remaining >= len(content):
+            remaining -= len(content)
+            continue
+        for idx in range(len(content) - 1 - remaining, -1, -1):
+            block = content[idx]
+            if block.get("type") in _THINKING_BLOCK_TYPES:
+                continue
+            if block.get("cache_control"):
+                return
+            new_content = list(content)
+            new_content[idx] = {**block, "cache_control": dict(_EPHEMERAL_CACHE)}
+            messages[m_idx] = {**messages[m_idx], "content": new_content}
+            return
+        remaining = 0  # every remaining block here was thinking — keep walking back
 
 
 _THINKING_BLOCK_TYPES = ("thinking", "redacted_thinking")

--- a/src/amphi_service/protocol/llms/anthropic_llm.py
+++ b/src/amphi_service/protocol/llms/anthropic_llm.py
@@ -64,6 +64,19 @@ _THINKING_LADDER: Tuple[Optional[Dict[str, Any]], ...] = (
 )
 _THINKING_TIERS: Dict[Tuple[str, str], int] = {}
 
+# (base_url, model) pairs whose endpoint rejected ``cache_control`` — prompt
+# caching is skipped for them after the first 400 that names it. Standard
+# Anthropic endpoints (and new-api) accept it; this covers exotic relays.
+_CACHE_UNSUPPORTED: set = set()
+
+# Marker key on ``Message.extras`` identifying the per-round <runtime_state>
+# tail (set by the agent layer; value duplicated here to keep this module free
+# of agent imports). Blocks from such messages change every round, so the
+# rolling cache breakpoint must sit BEFORE them.
+_VOLATILE_TAIL_EXTRA = "volatile_tail"
+
+_EPHEMERAL_CACHE = {"type": "ephemeral"}
+
 # Substrings a thinking-config 400 carries (``thinking.display: Extra inputs…``,
 # ``thinking.type: Input should be…``, ``budget_tokens`` removed, …).
 _THINKING_REJECTION_HINTS: Tuple[str, ...] = ("thinking", "budget_tokens", "display", "adaptive")
@@ -326,14 +339,21 @@ class AnthropicLlm(BaseLlm):
         caller_thinking = bool(extra_body and "thinking" in extra_body)
         tier = _THINKING_TIERS.get(key, 0)
         max_tokens = int(params.get("max_tokens") or _DEFAULT_MAX_TOKENS)
+        # Prompt caching: mark up to three ephemeral breakpoints per attempt.
+        # The rolling one must exclude the <runtime_state> tail, whose blocks
+        # change every round — count them off the ORIGINAL message list.
+        cache_enabled = key not in _CACHE_UNSUPPORTED
+        volatile_blocks = _volatile_tail_block_count(messages)
 
         async def run_attempt(attempt_publish: Callable[..., None]) -> StreamResult:
-            nonlocal heal, tier
+            nonlocal heal, tier, cache_enabled
             while True:
                 attempt = (
                     params if caller_thinking
                     else _with_thinking(params, _thinking_for(tier, max_tokens))
                 )
+                if cache_enabled:
+                    attempt = _with_prompt_caching(attempt, volatile_blocks)
                 try:
                     result = await self._run_stream(attempt, attempt_publish)
                 except Exception as exc:  # noqa: BLE001 — parameter self-heal stays independent
@@ -349,6 +369,10 @@ class AnthropicLlm(BaseLlm):
                         and _thinking_rejected(exc)
                     ):
                         tier += 1
+                        continue
+                    if cache_enabled and _cache_rejected(exc):
+                        cache_enabled = False
+                        _CACHE_UNSUPPORTED.add(key)
                         continue
                     raise
                 if not caller_thinking:
@@ -566,6 +590,58 @@ def _with_thinking(
     for param in _SAMPLING_PARAMS:
         out.pop(param, None)
     out["thinking"] = thinking
+    return out
+
+
+def _cache_rejected(exc: Exception) -> bool:
+    """True when a 4xx names ``cache_control`` — drop caching and retry."""
+    status = getattr(exc, "status_code", None)
+    if status is not None and status not in (400, 422):
+        return False
+    return "cache_control" in _error_text(exc).lower().replace(" ", "_")
+
+
+def _volatile_tail_block_count(messages: List[Message]) -> int:
+    """Content blocks contributed by the trailing <runtime_state> messages.
+
+    The agent appends them LAST, so after conversion (and same-role folding)
+    they are exactly the last N blocks of the final wire message.
+    """
+    count = 0
+    for msg in reversed(messages):
+        if not (msg.extras or {}).get(_VOLATILE_TAIL_EXTRA):
+            break
+        count += len(msg.blocks)
+    return count
+
+
+def _with_prompt_caching(params: Dict[str, Any], volatile_blocks: int) -> Dict[str, Any]:
+    """A copy of ``params`` with up to three ``cache_control`` breakpoints:
+    the system block, the last tool definition, and the last STABLE content
+    block of the history (skipping the trailing volatile <runtime_state>
+    blocks). Every touched container is copied — message blocks may be shared
+    with persisted extras (replayed thinking) and must not be mutated.
+    """
+    out = dict(params)
+    system = out.get("system")
+    if isinstance(system, str) and system:
+        out["system"] = [{"type": "text", "text": system, "cache_control": dict(_EPHEMERAL_CACHE)}]
+    tools = out.get("tools")
+    if tools:
+        out["tools"] = [*tools[:-1], {**tools[-1], "cache_control": dict(_EPHEMERAL_CACHE)}]
+    messages = out.get("messages")
+    if messages:
+        out["messages"] = [dict(m) for m in messages]
+        remaining = volatile_blocks
+        for msg in reversed(out["messages"]):
+            content = list(msg["content"])
+            if remaining >= len(content):
+                remaining -= len(content)
+                continue
+            idx = len(content) - 1 - remaining
+            content[idx] = {**content[idx], "cache_control": dict(_EPHEMERAL_CACHE)}
+            msg["content"] = content
+            break
     return out
 
 

--- a/src/amphi_service/protocol/llms/openai_llm.py
+++ b/src/amphi_service/protocol/llms/openai_llm.py
@@ -27,6 +27,12 @@ from ._streaming import (
 # learned per process, so subsequent calls strip them up front.
 _REJECTED_PARAMS: Dict[tuple, set] = {}
 
+# Marker key on ``Message.extras`` identifying the per-round <runtime_state>
+# tail (set by the agent layer; value duplicated here to keep this module free
+# of agent imports). bridgic splats extras onto the wire message, so the flag
+# must be stripped before conversion — providers reject unknown fields.
+_VOLATILE_TAIL_EXTRA = "volatile_tail"
+
 # Upper bound on parameter-stripping retries: in practice there are only a handful of
 # unsupported parameters, so this is plenty and can never loop forever.
 _MAX_SELF_HEAL_RETRIES = 8
@@ -168,6 +174,15 @@ class OpenAICompatLlm(OpenAILlm):
         parameter 400s are cured here in one place. Reasoning-model rules are keyed
         on the model name, so they hold behind relays too; other endpoints pass through.
         """
+        messages = kwargs.get("messages")
+        if messages:
+            kwargs = {**kwargs, "messages": [
+                msg.model_copy(update={
+                    "extras": {k: v for k, v in msg.extras.items() if k != _VOLATILE_TAIL_EXTRA}
+                })
+                if (msg.extras or {}).get(_VOLATILE_TAIL_EXTRA) else msg
+                for msg in messages
+            ]}
         params = super()._build_parameters(*args, **kwargs)
         params = sanitize_openai_params(params, base_url=getattr(self, "api_base", None))
         # Drop what this endpoint already rejected (learned by ``_create_stream`` /

--- a/src/amphi_store/_base.py
+++ b/src/amphi_store/_base.py
@@ -112,6 +112,16 @@ class Repository(Generic[T]):
                 sync_conn.execute(text(ddl))
 
         cls._migrate_legacy_workflow_runs(sync_conn)
+        # Repair rows written before the api_key→Codex switch cleared the stale
+        # base_url: Codex channels never legitimately carry one, and a leftover
+        # https://api.openai.com/v1 routes /codex/responses to a 404. Idempotent.
+        for table in ("provider_credentials", "users"):
+            rows = sync_conn.exec_driver_sql(f"PRAGMA table_info({table})").all()
+            if rows:
+                sync_conn.execute(text(
+                    f"UPDATE {table} SET base_url = NULL "
+                    "WHERE protocol = 'openai-codex' AND base_url IS NOT NULL"
+                ))
         sync_conn.execute(text(
             "INSERT OR IGNORE INTO session_workflow_runs "
             "(session_id, run_id, user_id, created_at) "

--- a/src/amphi_store/_provider.py
+++ b/src/amphi_store/_provider.py
@@ -111,6 +111,23 @@ class ProviderRepository(Repository[ProviderCredential]):
             await s.refresh(row)
             return row
 
+    async def clear_base_url(self, user_id: str, provider_id: str) -> None:
+        """Explicitly NULL a row's ``base_url``.
+
+        ``upsert`` treats ``base_url=None`` as "preserve" (so a re-POST without
+        a url doesn't wipe it), which means a mode switch that must FORGET the
+        old url needs this explicit call — e.g. api_key → Codex subscription,
+        where the api_key-era ``https://api.openai.com/v1`` would otherwise
+        survive and route Codex traffic to the wrong host.
+        """
+        async with self._session() as s:
+            row = await self._get_by(
+                s, ProviderCredential, user_id=user_id, provider_id=provider_id,
+            )
+            if row is not None and row.base_url is not None:
+                row.base_url = None
+                await s.commit()
+
     async def list_for_user(self, user_id: str) -> List[ProviderCredential]:
         """Return every provider credential owned by ``user_id``, oldest first."""
         async with self._session() as s:

--- a/tests/test_anthropic_caching.py
+++ b/tests/test_anthropic_caching.py
@@ -1,0 +1,186 @@
+"""Anthropic prompt-caching breakpoints on the agent's streaming path.
+
+``stream_turn`` marks three ``cache_control: ephemeral`` breakpoints — the
+system block, the last tool definition, and the last STABLE content block of
+the message history (skipping the ``volatile_tail`` runtime-state message that
+changes every round) — so each round reads the previous round's prefix from
+cache at ~1/10 price instead of re-paying ~30K input tokens at full price.
+A relay that rejects ``cache_control`` (400 naming it) drops caching for that
+(base_url, model) and retries without it.
+"""
+
+from __future__ import annotations
+
+from bridgic.core.model.types import Message, Role, TextBlock, ToolCallBlock, ToolResultBlock
+
+from src.amphi_agent._cognitive import VOLATILE_TAIL_EXTRA
+from src.amphi_service.protocol.llms._streaming import StreamResult
+from src.amphi_service.protocol.llms.anthropic_llm import (
+    _CACHE_UNSUPPORTED,
+    _REJECTED_PARAMS,
+    _THINKING_TIERS,
+    AnthropicConfiguration,
+    AnthropicLlm,
+)
+
+_EPHEMERAL = {"type": "ephemeral"}
+
+_TOOLS = [
+    {"name": "alpha", "description": "a", "input_schema": {"type": "object", "properties": {}}},
+    {"name": "beta", "description": "b", "input_schema": {"type": "object", "properties": {}}},
+]
+
+
+def _llm(model: str = "claude-sonnet-5") -> AnthropicLlm:
+    return AnthropicLlm(api_key="k", configuration=AnthropicConfiguration(model=model))
+
+
+def _reset() -> None:
+    _REJECTED_PARAMS.clear()
+    _THINKING_TIERS.clear()
+    _CACHE_UNSUPPORTED.clear()
+
+
+def _history() -> list[Message]:
+    """system → user ask → assistant tool call → tool result → volatile tail."""
+    return [
+        Message.from_text("persona", role=Role.SYSTEM),
+        Message.from_text("do the task", role=Role.USER),
+        Message(
+            role=Role.AI,
+            blocks=[
+                TextBlock(text="calling"),
+                ToolCallBlock(id="c1", name="alpha", arguments={}),
+            ],
+            extras={"thinking_blocks": [{"type": "thinking", "thinking": "t", "signature": "S"}]},
+        ),
+        Message(role=Role.TOOL, blocks=[ToolResultBlock(id="c1", content="ok")]),
+        Message.from_text(
+            "<runtime_state>\n- Changed files: none\n</runtime_state>",
+            role=Role.USER,
+            extras={VOLATILE_TAIL_EXTRA: True},
+        ),
+    ]
+
+
+def _fake_stream(seen: list):
+    async def run(params, publish):
+        seen.append(params)
+        return StreamResult(tool_calls=[], content="done", usage=None, capture={})
+    return run
+
+
+def _breakpoints(params: dict) -> list[str]:
+    """Every location carrying a cache_control marker, as readable labels."""
+    out = []
+    system = params.get("system")
+    if isinstance(system, list):
+        out += [f"system[{i}]" for i, b in enumerate(system) if b.get("cache_control")]
+    for i, tool in enumerate(params.get("tools") or []):
+        if tool.get("cache_control"):
+            out.append(f"tools[{i}]")
+    for m, msg in enumerate(params.get("messages") or []):
+        for b, block in enumerate(msg["content"]):
+            if isinstance(block, dict) and block.get("cache_control"):
+                out.append(f"messages[{m}].content[{b}]:{block.get('type')}")
+    return out
+
+
+async def test_stream_turn_marks_three_breakpoints_skipping_volatile_tail() -> None:
+    _reset()
+    seen: list = []
+    llm = _llm()
+    llm._run_stream = _fake_stream(seen)  # type: ignore[method-assign]
+
+    await llm.stream_turn(_history(), _TOOLS, publish=lambda *a, **k: None)
+
+    marks = _breakpoints(seen[0])
+    assert "system[0]" in marks, "system must be a cache breakpoint"
+    assert "tools[1]" in marks and "tools[0]" not in marks, "only the LAST tool def is marked"
+    # The folded final user message is [tool_result, volatile text]; the rolling
+    # breakpoint must sit on the tool_result — the volatile tail changes every round.
+    assert any(m.endswith(":tool_result") for m in marks), marks
+    volatile = [m for m in marks if m.endswith(":text") and "messages[2]" in m]
+    assert not volatile, f"volatile tail must not carry a breakpoint: {marks}"
+    assert len(marks) == 3
+    _reset()
+
+
+async def test_stream_turn_breakpoint_lands_on_last_block_without_tail() -> None:
+    _reset()
+    seen: list = []
+    llm = _llm()
+    llm._run_stream = _fake_stream(seen)  # type: ignore[method-assign]
+
+    await llm.stream_turn(_history()[:-1], _TOOLS, publish=lambda *a, **k: None)
+
+    marks = _breakpoints(seen[0])
+    assert any(m.endswith(":tool_result") for m in marks), marks
+    assert len(marks) == 3
+    _reset()
+
+
+async def test_stream_turn_does_not_mutate_replayed_thinking_extras() -> None:
+    """Breakpoint application must copy blocks — the thinking dicts in extras are
+    shared with the persisted OTA record."""
+    _reset()
+    history = _history()
+    thinking_dict = history[2].extras["thinking_blocks"][0]
+    llm = _llm()
+    llm._run_stream = _fake_stream([])  # type: ignore[method-assign]
+
+    await llm.stream_turn(history, _TOOLS, publish=lambda *a, **k: None)
+
+    assert "cache_control" not in thinking_dict
+    _reset()
+
+
+async def test_stream_turn_drops_caching_when_relay_rejects_it() -> None:
+    _reset()
+    seen: list = []
+
+    class _Exc400(Exception):
+        status_code = 400
+
+        def __init__(self) -> None:
+            super().__init__("Error code: 400 - cache_control is not supported")
+            self.body = {"error": {"message": "cache_control: Extra inputs are not permitted"}}
+
+    async def run(params, publish):
+        seen.append(params)
+        if _breakpoints(params):
+            raise _Exc400()
+        return StreamResult(tool_calls=[], content="done", usage=None, capture={})
+
+    llm = _llm("relay-alias")
+    llm._run_stream = run  # type: ignore[method-assign]
+
+    result = await llm.stream_turn(_history(), _TOOLS, publish=lambda *a, **k: None)
+
+    assert result.content == "done"
+    assert len(seen) == 2 and not _breakpoints(seen[1])
+    assert llm._reject_key() in _CACHE_UNSUPPORTED, "the rejection must be remembered"
+
+    await llm.stream_turn(_history(), _TOOLS, publish=lambda *a, **k: None)
+    assert len(seen) == 3 and not _breakpoints(seen[2]), "next turn starts without caching"
+    _reset()
+
+
+async def test_chat_paths_do_not_cache() -> None:
+    """chat/achat (probe, classifier) are one-shot — no cache_control there."""
+    _reset()
+    from types import SimpleNamespace
+
+    calls: list = []
+
+    async def create(**params):
+        calls.append(params)
+        return SimpleNamespace(content=[SimpleNamespace(type="text", text="pong")])
+
+    llm = _llm()
+    llm.async_client = SimpleNamespace(messages=SimpleNamespace(create=create))
+    await llm.achat([Message.from_text("ping", role=Role.USER)])
+
+    assert not _breakpoints(calls[0])
+    assert isinstance(calls[0].get("system", ""), str) or "system" not in calls[0]
+    _reset()

--- a/tests/test_anthropic_caching.py
+++ b/tests/test_anthropic_caching.py
@@ -184,3 +184,60 @@ async def test_chat_paths_do_not_cache() -> None:
     assert not _breakpoints(calls[0])
     assert isinstance(calls[0].get("system", ""), str) or "system" not in calls[0]
     _reset()
+
+
+async def test_rolling_breakpoint_never_lands_on_a_thinking_block() -> None:
+    """cache_control is rejected on thinking blocks (official docs: they cannot
+    be cached directly). When the last stable message carries only thinking
+    blocks, the breakpoint must walk further back to a cacheable block."""
+    _reset()
+    seen: list = []
+    llm = _llm()
+    llm._run_stream = _fake_stream(seen)  # type: ignore[method-assign]
+
+    history = [
+        Message.from_text("persona", role=Role.SYSTEM),
+        Message.from_text("do the task", role=Role.USER),
+        # a thought-only assistant round: wire content is ONLY a thinking block
+        Message(role=Role.AI, blocks=[],
+                extras={"thinking_blocks": [{"type": "thinking", "thinking": "t", "signature": "S"}]}),
+        Message.from_text("<runtime_state>\nx\n</runtime_state>", role=Role.USER,
+                          extras={VOLATILE_TAIL_EXTRA: True}),
+    ]
+    await llm.stream_turn(history, _TOOLS, publish=lambda *a, **k: None)
+
+    marks = _breakpoints(seen[0])
+    assert not any(":thinking" in m for m in marks), marks
+    assert any(m.endswith(":text") and "messages[0]" in m for m in marks), marks
+    _reset()
+
+
+async def test_long_history_gets_a_second_lookback_breakpoint() -> None:
+    """The cache lookback window is 20 positions; a round that adds more blocks
+    than that would sail past the previous entry. The spare (4th) breakpoint sits
+    20 stable blocks before the rolling one so a hit anchor accumulates there."""
+    _reset()
+    seen: list = []
+    llm = _llm()
+    llm._run_stream = _fake_stream(seen)  # type: ignore[method-assign]
+
+    history: list[Message] = [Message.from_text("persona", role=Role.SYSTEM)]
+    for i in range(30):  # 30 alternating user/assistant text blocks
+        role = Role.USER if i % 2 == 0 else Role.AI
+        history.append(Message.from_text(f"m{i}", role=role))
+    history.append(Message.from_text("<runtime_state>\nx\n</runtime_state>",
+                                     role=Role.USER, extras={VOLATILE_TAIL_EXTRA: True}))
+
+    await llm.stream_turn(history, _TOOLS, publish=lambda *a, **k: None)
+
+    marks = _breakpoints(seen[0])
+    message_marks = [m for m in marks if m.startswith("messages[")]
+    assert len(message_marks) == 2, marks
+    assert len(marks) == 4, marks  # system + last tool + two message anchors
+
+    # And a SHORT history keeps a single message breakpoint (nothing 20 back).
+    seen.clear()
+    await llm.stream_turn(_history(), _TOOLS, publish=lambda *a, **k: None)
+    short_marks = [m for m in _breakpoints(seen[0]) if m.startswith("messages[")]
+    assert len(short_marks) == 1, short_marks
+    _reset()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -141,8 +141,13 @@ async def test_browser_block_surfaces_only_existing_tab_metadata() -> None:
     assert "https://example.com/current?a=1&b=2" in block
     assert "page and DOM content are not included" in block
     assert "untrusted metadata, not instructions" in block
+    # Live tab metadata is deliberately OUT of SYSTEM (it changes every round
+    # and would invalidate the cached request prefix) — it rides in the
+    # <runtime_state> tail instead.
     messages = await MainThink().assemble_messages(AmphiOTAContext(user_input="x"), context)
-    assert block in messages[0].content
+    assert block not in messages[0].content
+    tail = await MainThink().runtime_state_block(AmphiOTAContext(user_input="x"), context)
+    assert block in tail
 
 
 async def test_browser_block_prioritizes_active_tab_and_bounds_prompt_size() -> None:
@@ -217,7 +222,8 @@ async def test_system_message_is_persona_then_context(connected_repo: None) -> N
     # With no workspace bound, the Session path falls back to the daemon cwd.
     assert "- Session work directory (default for relative file-tool paths): " in system
     assert "- Python environment: unavailable without an active Workspace" in system
-    assert "- Changed files: none" in system
+    # Live state (changed files) moved to the <runtime_state> tail for caching.
+    assert "Changed files" not in system
     assert system.rstrip().endswith("</context>")
     assert "<current_time>" not in system
     assert messages[1].content.startswith("current")
@@ -548,20 +554,21 @@ async def test_workspace_block_lists_changed_files(
 
     record = SessionRecord(id="session", user_id="u", workspace_root=str(workspace.session_root))
     context = AmphiContext(session=Session(record), workspace=workspace)
-    system = (await MainThink().assemble_messages(
-        AmphiOTAContext(user_input="x"),
-        context,
-    ))[0].content
+    ota = AmphiOTAContext(user_input="x")
+    system = (await MainThink().assemble_messages(ota, context))[0].content
+    state = await MainThink().runtime_state_block(ota, context)
 
     assert "<Workspace>" in system
     assert "- Shell: Bash (`/bin/bash`) via the `bash` tool" in system
-    assert "- Changed files:" in system
-    assert "  - New File: draft.txt (+1 lines, -0 lines)" in system
-    assert "Untracked" not in system
-    assert "- Latest checkpoint:" in system
-    assert "- Recent checkpoints:" in system
-    assert "Initial workspace" in system
-    assert "- Restore hint:" in system
+    # Live state renders in the <runtime_state> tail, never in SYSTEM.
+    assert "Changed files" not in system
+    assert "- Changed files:" in state
+    assert "  - New File: draft.txt (+1 lines, -0 lines)" in state
+    assert "Untracked" not in state
+    assert "- Latest checkpoint:" in state
+    assert "- Recent checkpoints:" in state
+    assert "Initial workspace" in state
+    assert "- Restore hint:" in state
 
 
 async def test_shell_environment_summary_switches_to_powershell(
@@ -693,15 +700,12 @@ async def test_workspace_block_lists_recent_checkpoints_when_clean(
 
     record = SessionRecord(id="session", user_id="u", workspace_root=str(workspace.session_root))
     context = AmphiContext(session=Session(record), workspace=workspace)
-    system = (await MainThink().assemble_messages(
-        AmphiOTAContext(user_input="x"),
-        context,
-    ))[0].content
+    state = await MainThink().runtime_state_block(AmphiOTAContext(user_input="x"), context)
 
-    assert "- Changed files: none" in system
-    assert f"- Latest checkpoint: {checkpoint[:12]}" in system
-    assert "Add draft" in system
-    assert "- Recent checkpoints:" in system
+    assert "- Changed files: none" in state
+    assert f"- Latest checkpoint: {checkpoint[:12]}" in state
+    assert "Add draft" in state
+    assert "- Recent checkpoints:" in state
 
 
 def test_turn_messages_native_pairing_eliding_and_failure() -> None:

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -156,3 +156,60 @@ async def test_schema_init_migrates_legacy_workflow_run_states(
             assert [row[0] for row in associations] == ["completed", "failed"]
     finally:
         await Repository.close()
+
+
+async def test_schema_init_repairs_codex_rows_with_stale_base_url(tmp_path) -> None:
+    """Databases written before the api_key→Codex switch fix carry a stale
+    ``base_url`` on ``protocol='openai-codex'`` rows (and on the mirroring user
+    row), which sends Codex traffic to ``https://api.openai.com/v1/codex/...``.
+    Schema init must NULL both — the Codex flow never legitimately sets one."""
+    import sqlite3
+
+    from src.amphi_store._base import Repository
+
+    db = tmp_path / "legacy.db"
+    con = sqlite3.connect(db)
+    con.executescript(
+        """
+        CREATE TABLE provider_credentials (
+            id INTEGER NOT NULL PRIMARY KEY, user_id VARCHAR NOT NULL,
+            provider_id VARCHAR NOT NULL, auth_mode VARCHAR NOT NULL,
+            api_key VARCHAR, base_url VARCHAR, is_active BOOLEAN NOT NULL,
+            is_enabled BOOLEAN NOT NULL, protocol VARCHAR NOT NULL,
+            display_name VARCHAR, enabled_models TEXT, created_at DATETIME NOT NULL
+        );
+        INSERT INTO provider_credentials VALUES
+            (1, 'local', 'openai', 'oauth', NULL, 'https://api.openai.com/v1',
+             1, 1, 'openai-codex', 'OpenAI', '[]', '2026-01-01'),
+            (2, 'local', 'glm', 'api_key', 'sk-x', 'https://open.bigmodel.cn/api/paas/v4',
+             0, 1, 'openai', 'GLM', '[]', '2026-01-01');
+        CREATE TABLE users (
+            id VARCHAR NOT NULL PRIMARY KEY, display_name VARCHAR,
+            api_key VARCHAR, base_url VARCHAR, protocol VARCHAR NOT NULL,
+            current_model VARCHAR, default_max_rounds INTEGER,
+            default_temperature FLOAT, execution_mode VARCHAR
+        );
+        INSERT INTO users VALUES
+            ('local', NULL, NULL, 'https://api.openai.com/v1', 'openai-codex',
+             'gpt-5.5', 50, 0.0, 'auto');
+        """
+    )
+    con.commit(); con.close()
+
+    Repository.connect(db)
+    try:
+        await Repository.init_schema()
+    finally:
+        await Repository.close()
+
+    con = sqlite3.connect(db)
+    codex_base, = con.execute(
+        "SELECT base_url FROM provider_credentials WHERE provider_id='openai'").fetchone()
+    glm_base, = con.execute(
+        "SELECT base_url FROM provider_credentials WHERE provider_id='glm'").fetchone()
+    user_base, = con.execute("SELECT base_url FROM users WHERE id='local'").fetchone()
+    con.close()
+
+    assert codex_base is None, "stale codex base_url must be nulled"
+    assert glm_base == "https://open.bigmodel.cn/api/paas/v4", "api_key rows untouched"
+    assert user_base is None, "the user mirror must be repaired too"

--- a/tests/test_openai_params.py
+++ b/tests/test_openai_params.py
@@ -563,3 +563,29 @@ async def test_achat_self_heals_unsupported_param(monkeypatch) -> None:
     assert len(attempts) == 2 and "temperature" not in attempts[1]
     assert "temperature" in _REJECTED_PARAMS.get(llm._reject_key(), set())
     _REJECTED_PARAMS.clear()
+
+
+def test_build_parameters_strips_volatile_tail_flag_from_wire() -> None:
+    """bridgic splats ``Message.extras`` onto the OpenAI wire message; the
+    ``volatile_tail`` marker is internal routing (cache-prefix control) and must
+    never reach the provider."""
+    from bridgic.core.model.types import Message, Role
+    from bridgic.llms.openai import OpenAIConfiguration
+    from src.amphi_agent._cognitive import VOLATILE_TAIL_EXTRA
+    from src.amphi_service.protocol.llms.openai_llm import OpenAICompatLlm
+
+    llm = OpenAICompatLlm(
+        api_key="k", api_base="http://relay.example:3000/v1",
+        configuration=OpenAIConfiguration(model="gpt-4o"),
+    )
+    messages = [
+        Message.from_text("go", role=Role.USER),
+        Message.from_text("<runtime_state>x</runtime_state>", role=Role.USER,
+                          extras={VOLATILE_TAIL_EXTRA: True}),
+    ]
+    params = llm._build_parameters(messages=messages)
+
+    wire = params["messages"]
+    assert len(wire) == 2 and wire[1]["content"].startswith("<runtime_state>")
+    assert VOLATILE_TAIL_EXTRA not in wire[1], "internal flag leaked onto the wire"
+    assert (messages[1].extras or {}).get(VOLATILE_TAIL_EXTRA) is True, "caller message must not be mutated"

--- a/tests/test_openai_params.py
+++ b/tests/test_openai_params.py
@@ -589,3 +589,22 @@ def test_build_parameters_strips_volatile_tail_flag_from_wire() -> None:
     assert len(wire) == 2 and wire[1]["content"].startswith("<runtime_state>")
     assert VOLATILE_TAIL_EXTRA not in wire[1], "internal flag leaked onto the wire"
     assert (messages[1].extras or {}).get(VOLATILE_TAIL_EXTRA) is True, "caller message must not be mutated"
+
+
+def test_sanitize_moonshot_platform_forces_supported_temperature() -> None:
+    """api.moonshot.cn (Kimi open platform) enforces temperature=1 on k2.6+ —
+    400 "invalid temperature: only 1 is allowed for this model" otherwise. Same
+    correction as the Kimi Code endpoint."""
+    src = {"model": "kimi-k2.6", "temperature": 0.0, "max_tokens": 8}
+    out = sanitize_openai_params(dict(src), base_url="https://api.moonshot.cn/v1")
+    assert out["temperature"] == 1
+    assert out["max_tokens"] == 8
+
+
+def test_unsupported_param_of_reads_moonshot_invalid_param_text() -> None:
+    """Moonshot's rejection wording ("invalid temperature: only 1 is allowed")
+    names the parameter after "invalid" — the generic heal must catch it for
+    relays that proxy Kimi models under other hosts."""
+    exc = _LiteLLMExc("invalid temperature: only 1 is allowed for this model")
+    assert unsupported_param_of(exc) == "temperature"
+    assert unsupported_param_of(_LiteLLMExc("invalid request id")) is None

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -502,9 +502,8 @@ async def test_prompt_contexts_are_ordered_from_stable_to_volatile(monkeypatch) 
     monkeypatch.setattr(main, "workflows_block", async_block("workflows"))
     monkeypatch.setattr(main, "memory_block", async_block("memory"))
     monkeypatch.setattr(main, "workspace_block", async_block("workspace"))
-    monkeypatch.setattr(main, "browser_block", async_block("browser"))
     assert await main.context_blocks(ota, context) == [
-        "transcript", "skills", "schedules", "workflows", "memory", "workspace", "browser",
+        "transcript", "skills", "schedules", "workflows", "memory", "workspace",
     ]
 
     subagent = SubAgentThink()
@@ -512,9 +511,8 @@ async def test_prompt_contexts_are_ordered_from_stable_to_volatile(monkeypatch) 
     monkeypatch.setattr(subagent, "workflows_block", async_block("workflows"))
     monkeypatch.setattr(subagent, "memory_block", async_block("memory"))
     monkeypatch.setattr(subagent, "workspace_block", async_block("workspace"))
-    monkeypatch.setattr(subagent, "browser_block", async_block("browser"))
     assert await subagent.context_blocks(ota, context) == [
-        "skills", "workflows", "memory", "workspace", "browser",
+        "skills", "workflows", "memory", "workspace",
     ]
 
     workflow = WorkflowThink()
@@ -524,9 +522,8 @@ async def test_prompt_contexts_are_ordered_from_stable_to_volatile(monkeypatch) 
     monkeypatch.setattr(workflow, "workflow_run_block", async_block("workflow_run"))
     monkeypatch.setattr(workflow, "memory_block", async_block("memory"))
     monkeypatch.setattr(workflow, "workspace_block", async_block("workspace"))
-    monkeypatch.setattr(workflow, "browser_block", async_block("browser"))
     assert await workflow.context_blocks(ota, context) == [
-        "transcript", "skills", "schedules", "workflow_run", "memory", "workspace", "browser",
+        "transcript", "skills", "schedules", "workflow_run", "memory", "workspace",
     ]
 
     build = ClarifyThink()
@@ -536,9 +533,8 @@ async def test_prompt_contexts_are_ordered_from_stable_to_volatile(monkeypatch) 
     monkeypatch.setattr(build, "memory_block", async_block("memory"))
     monkeypatch.setattr(build, "build_workspace_block", lambda *_: "build_workspace")
     monkeypatch.setattr(build, "workspace_block", async_block("workspace"))
-    monkeypatch.setattr(build, "browser_block", async_block("browser"))
     assert await build.build_context_blocks(ota, context, "task.md") == [
-        "transcript", "skills", "artifacts", "memory", "build_workspace", "workspace", "browser",
+        "transcript", "skills", "artifacts", "memory", "build_workspace", "workspace",
     ]
 
 

--- a/tests/test_prompt_caching.py
+++ b/tests/test_prompt_caching.py
@@ -1,0 +1,161 @@
+"""Prompt-caching prerequisite: a byte-stable request prefix.
+
+Anthropic (and OpenAI) prompt caching is a prefix match over tools → system →
+messages. The SYSTEM block used to embed live state — the Workspace
+"Changed files" lines (git status, changes after every file write) and the
+browser tab list — so every tool round that touched a file invalidated the
+whole cached prefix. That live state now rides in a ``<runtime_state>`` USER
+tail appended by ``thinking()`` to the END of each request (never persisted),
+keeping SYSTEM and the replayed history byte-stable within a turn.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from bridgic.core.model.types import Message, Role
+
+from src.amphi_agent import AmphiContext, AmphiOTAContext
+from src.amphi_agent._cognitive import VOLATILE_TAIL_EXTRA, MainThink
+
+
+def _fake_workspace(changed: list[str]) -> SimpleNamespace:
+    """Checkpoints surface for ``runtime_state_block`` plus the stable attributes
+    ``workspace_block`` renders into SYSTEM (dirs, mounts, environment)."""
+    return SimpleNamespace(
+        checkpoints=SimpleNamespace(
+            changed_files_context_lines=lambda **_kw: list(changed),
+            checkpoint_context_lines=lambda **_kw: [],
+        ),
+        work_dir=SimpleNamespace(is_dir=lambda: False),
+        mount_roots=lambda: [],
+        build=None,
+        run_workflow=None,
+        build_checkpoint=lambda: None,
+        run_workflow_checkpoint=lambda: None,
+        environment=SimpleNamespace(
+            os_name="Darwin", os_release="25.0.0", architecture="arm64",
+            python_executable=None, python_version=None,
+            node_executable=None, node_version=None,
+        ),
+    )
+
+
+class _FakeTab(SimpleNamespace):
+    pass
+
+
+def _fake_browser(title: str) -> SimpleNamespace:
+    tab = _FakeTab(title=title, url="https://example.com/")
+
+    async def state():
+        return SimpleNamespace(tabs=[tab], active_tab=tab)
+
+    return SimpleNamespace(state=state)
+
+
+def _context(**kw) -> AmphiContext:
+    return AmphiContext.model_construct(**kw)
+
+
+async def test_system_contains_no_live_state() -> None:
+    """Changed-files and browser tabs must not appear in SYSTEM — they change
+    mid-turn and would invalidate the cached prefix on every file write."""
+    worker = MainThink()
+    ota = AmphiOTAContext(user_input="test")
+    context = _context(browser=_fake_browser("Cache Docs"))
+
+    system = (await worker.assemble_messages(ota, context))[0].content
+
+    assert "<Workspace>" in system
+    assert "Changed files" not in system
+    # The persona legitimately mentions the literal "<browser>" tag in its
+    # instructions — assert on the LIVE data instead (tab title / tab list).
+    assert "Cache Docs" not in system and "tab=1" not in system
+
+
+async def test_runtime_state_block_carries_changed_files_and_browser() -> None:
+    worker = MainThink()
+    ota = AmphiOTAContext(user_input="test")
+    context = _context(
+        workspace=_fake_workspace(["- Changed files:", "  - Modified: a.txt (+1 lines, -0 lines)"]),
+        browser=_fake_browser("Cache Docs"),
+    )
+
+    block = await worker.runtime_state_block(ota, context)
+
+    assert block.startswith("<runtime_state>") and block.endswith("</runtime_state>")
+    assert "Modified: a.txt" in block
+    assert "Cache Docs" in block
+
+
+async def test_runtime_state_block_empty_without_live_state() -> None:
+    worker = MainThink()
+    ota = AmphiOTAContext(user_input="test")
+    assert await worker.runtime_state_block(ota, _context()) == ""
+
+
+async def test_append_runtime_state_adds_volatile_user_tail() -> None:
+    """The tail is a USER message flagged ``volatile_tail`` so the adapters can
+    keep it out of the cached prefix; nothing is appended when state is empty."""
+    worker = MainThink()
+    ota = AmphiOTAContext(user_input="test")
+    base = [Message.from_text("sys", role=Role.SYSTEM), Message.from_text("go", role=Role.USER)]
+
+    with_state = await worker.append_runtime_state(
+        list(base), ota, _context(workspace=_fake_workspace(["- Changed files:", "  - New File: x"]))
+    )
+    assert len(with_state) == len(base) + 1
+    tail = with_state[-1]
+    assert tail.role == Role.USER
+    assert (tail.extras or {}).get(VOLATILE_TAIL_EXTRA) is True
+    assert "New File: x" in tail.content
+
+    without = await worker.append_runtime_state(list(base), ota, _context())
+    assert len(without) == len(base)
+
+
+async def test_system_is_byte_stable_while_live_state_changes() -> None:
+    """Two rounds of the same turn with different changed-files / browser state
+    must produce the identical SYSTEM text — only the volatile tail may differ."""
+    worker = MainThink()
+    ota = AmphiOTAContext(user_input="test")
+    round1 = _context(
+        workspace=_fake_workspace(["- Changed files: none"]),
+        browser=_fake_browser("Round One"),
+    )
+    round2 = _context(
+        workspace=_fake_workspace(["- Changed files:", "  - New File: notes.txt (+3 lines, -0 lines)"]),
+        browser=_fake_browser("Round Two"),
+    )
+
+    system1 = (await worker.assemble_messages(ota, round1))[0].content
+    system2 = (await worker.assemble_messages(ota, round2))[0].content
+    assert system1 == system2
+
+    tail1 = await worker.runtime_state_block(ota, round1)
+    tail2 = await worker.runtime_state_block(ota, round2)
+    assert tail1 != tail2
+
+
+def test_usage_pair_counts_anthropic_cache_tokens() -> None:
+    """Anthropic's ``input_tokens`` EXCLUDES cache reads/writes; the meter must
+    fold them in so turn totals stay comparable once caching is live."""
+    usage = SimpleNamespace(
+        input_tokens=14,
+        output_tokens=9,
+        cache_creation_input_tokens=200,
+        cache_read_input_tokens=8000,
+    )
+    assert MainThink._usage_pair(usage) == (14 + 200 + 8000, 9)
+    # OpenAI shape: prompt_tokens already includes cached tokens — unchanged.
+    assert MainThink._usage_pair({"prompt_tokens": 50, "completion_tokens": 5}) == (50, 5)
+
+
+def test_volatile_tail_constant_is_consistent_across_layers() -> None:
+    """The adapters duplicate the marker value to avoid importing the agent
+    layer — a drift would silently break cache placement / wire stripping."""
+    from src.amphi_service.protocol.llms.anthropic_llm import _VOLATILE_TAIL_EXTRA as anth
+    from src.amphi_service.protocol.llms.openai_llm import _VOLATILE_TAIL_EXTRA as oai
+
+    assert anth == oai == VOLATILE_TAIL_EXTRA

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 
 import httpx
+from types import SimpleNamespace
 import pytest
 
 from src.amphi_service.protocol import PROVIDER_CATALOG_BY_ID
@@ -1010,3 +1011,40 @@ def test_codex_catalog_is_handed_out_as_a_copy() -> None:
     handed_out = [dict(m) for m in CODEX_CATALOG_MODELS]  # handler 的出网方式
     handed_out[0]["name"] = "MUTATED"
     assert [dict(m) for m in CODEX_CATALOG_MODELS] == snapshot, "全局目录被下游改动污染"
+
+
+async def test_codex_activation_clears_stale_api_key_base_url(
+    client: httpx.AsyncClient,
+    service_app,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Switching the 'openai' channel from api_key mode to the Codex
+    subscription must clear the api_key-era base_url. The upsert treats None
+    as "preserve", so without an explicit clear the stale
+    ``https://api.openai.com/v1`` survives on the row, gets mirrored back onto
+    the user by the next ``POST /me/active-model``, and CodexResponsesLlm then
+    requests ``https://api.openai.com/v1/codex/responses`` → 404."""
+    import src.amphi_service.handler._providers_handler as ph
+
+    # 1) api_key mode writes a base_url onto the row.
+    r = await client.post("/me/providers", json={
+        "provider_id": "openai", "api_key": "sk-test",
+        "base_url": "https://api.openai.com/v1", "protocol": "openai",
+    })
+    assert r.status_code in (200, 201), r.text
+
+    # 2) the OAuth sign-in flow activates the Codex subscription.
+    monkeypatch.setattr(ph, "resolve_codex_credentials",
+                        lambda: SimpleNamespace(access_token="t", account_id="a"))
+    await ph._activate_codex_provider(service_app.state.llms, "local")
+
+    rows = (await client.get("/me/providers")).json()
+    codex = next(p for p in rows if p["id"] == "openai")
+    assert codex["protocol"] == "openai-codex"
+    assert codex["base_url"] is None, "stale api_key-mode base_url must be cleared"
+
+    # 3) re-activating via the model picker must not resurrect the stale base.
+    r = await client.post("/me/active-model", json={"provider_id": "openai", "model": "gpt-5.5"})
+    assert r.status_code == 200, r.text
+    me = (await client.get("/me")).json()
+    assert me["base_url"] is None


### PR DESCRIPTION
## Summary

Every agent round re-sent the full context (~30K input tokens for the file-task E2E, 160–315K per turn) at list price: no `cache_control` was ever sent, and the SYSTEM prompt embedded live state — the Workspace **"Changed files"** lines (refreshed by every file write) and the **browser tab list** — so even with markers, the byte-prefix cache would have been invalidated on most rounds. With this change, from round 2 onward each request reads the previous prefix from cache at ~1/10 input price (~70% input-cost reduction on tool-heavy turns; verified live, numbers below).

### How

1. **Byte-stable prefix** (`_cognitive.py`) — live state moves out of SYSTEM into a `<runtime_state>` USER tail that `thinking()` appends to the END of each request. Flagged internally via `extras["volatile_tail"]`, rebuilt fresh per round, never persisted (zero leakage into `ota_records` / `history.md` / the UI). This also hands OpenAI's automatic prefix caching a stable prefix for free.
2. **Cache breakpoints** (`anthropic_llm.py`) — `stream_turn` marks up to three `cache_control: ephemeral` breakpoints per attempt: the system block, the last tool definition, and the last *stable* content block of the history (skipping the volatile tail). Copy-on-write everywhere — replayed thinking dicts are shared with the persisted OTA record. An endpoint that 400s naming `cache_control` drops caching for that `(base_url, model)` and retries; `chat`/`achat` (probe, classifier) never cache.
3. **Wire hygiene** (`openai_llm.py`) — bridgic splats `Message.extras` onto OpenAI wire messages, so the internal flag is stripped before conversion.
4. **Usage accounting** (`_cognitive._usage_pair`) — Anthropic's `input_tokens` excludes cache reads/writes; they are folded into the input meter so turn totals stay comparable.

### Live verification (new-api relay, `claude-sonnet-5`)

| Check | Result |
|---|---|
| Two-round tool loop, runtime tail **changed** between rounds | R1: `cache_creation=2626`; R2: `cache_read=2626`, uncached input **49** |
| 4-round parallel-tool scenario | incremental caching: r2 writes 1050, r3 reads 1050 + writes 255, r4 reads 1305 |
| 8-step agent E2E (10 rounds) | completed; 4 thinking blocks in the UI; correct `summary.txt`; `<runtime_state>` absent from `ota_records`, `history.md`, and the message API |
| OpenAI-protocol E2E (`gpt-4.1-mini`, 12 rounds) | completed — the tail is clean on that wire |
| Full suite | 1921 passed, 10 skipped; `bun run check:chinese` clean |

Five existing tests that pinned the old placement (changed files / browser inside SYSTEM) were updated to the new contract; new suites `tests/test_prompt_caching.py` and `tests/test_anthropic_caching.py` pin prefix stability, breakpoint placement, volatile-tail skipping, copy-on-write, the relay rejection fallback, and the usage folding.

### Behaviour notes
- Cache writes bill at 1.25× for the written chunk (5-minute TTL, refreshed on hit); reads at 0.1×. Net effect on multi-round turns is a large saving; single-round turns pay a small write premium.
- The model now sees live workspace/browser state at the END of the request instead of inside SYSTEM — same content, same freshness.
- Mid-turn catalogue changes (a new memory/schedule created by a tool) still invalidate the prefix for the following round — correct, just a cache miss.

## Second commit — two adjustments from the official docs review

Checked the implementation against the [official prompt-caching documentation](https://platform.claude.com/docs/en/build-with-claude/prompt-caching):

- **Thinking blocks can't carry `cache_control`** (the API rejects it). The rolling breakpoint now walks past `thinking` / `redacted_thinking` blocks to the nearest cacheable one.
- **The cache lookback checks at most 20 positions per breakpoint**, so a round appending 20+ wire blocks (nine-plus parallel tool calls) would miss the previous round's entry. The spare fourth breakpoint now sits 20 stable blocks before the rolling one — the docs' own recommended fix — doubling the covered per-round growth to ~40 blocks.

Re-verified live through new-api (4-round parallel scenario): incremental caching unchanged with the extra anchor accepted — r3 reads 1048, r4 reads 1317, uncached input 2 tokens/round. Full suite: 1923 passed.

Also verified through a **LiteLLM proxy**: `claude-sonnet-5` caches identically (r3 reads 1039, r4 reads 1297, uncached 2/round); `claude-haiku-4-5` shows zero cache activity below its 4096-token minimum cacheable prefix (documented API behaviour, silently uncached) and full hits above it (R1 writes 7739, R2 reads 7739 with 43 uncached) — the real agent's system+tools prefix is ~6-10K tokens, so Haiku caches in practice.

## Third commit — Kimi open platform temperature rule (found while widening provider coverage)

Testing the agent across more providers surfaced one more parameter rule: **api.moonshot.cn enforces `temperature=1`** on current Kimi models (`kimi-k2.6` 400s with "invalid temperature: only 1 is allowed for this model"), which killed the first round of every turn on that channel. The sanitizer now applies the same correction the Kimi Code endpoint already gets (moonshot.cn / moonshot.ai hosts), and the unsupported-param heal recognises the "invalid <param>:" wording (whitelist-guarded) as a fallback for proxied Kimi models. Verified live: kimi-k2.6 went from instant failure to 7 clean tool rounds with reasoning capture (then hit the account's RPM-3 quota — an account-tier limit, not a protocol issue).

Provider coverage at this point, all through the real backend on the 8-step file task: **new-api** (Anthropic + OpenAI), **LiteLLM** (both), **direct api.openai.com**, **Xiaomi MiMo** (both protocols, unsigned thinking blocks replay fine), **Zhipu GLM** (glm-4.6, glm-4.5-air), **DeepSeek** (v4-flash/v4-pro incl. reasoning_content replay), **Google Gemini** (native protocol, gemini-2.5-flash-lite), **OpenRouter** (paid deepseek-v4-flash; free tiers fail upstream with 429/instability — provider-side).

## Fourth commit — Codex subscription 404 after switching from api_key mode

Switching the `openai` channel from api_key mode to the ChatGPT-subscription (Codex) mode 404ed every turn on `https://api.openai.com/v1/codex/responses`. Root cause: `ProviderRepository.upsert` treats `base_url=None` as *preserve*, so the api_key-era `https://api.openai.com/v1` survived the OAuth activation on the provider row; the next `POST /me/active-model` mirrored it onto the user row, and `CodexResponsesLlm` used it as the Codex base. Fixed with an explicit `clear_base_url` call in the activation flow plus an idempotent schema-init repair that NULLs `base_url` on existing `protocol='openai-codex'` rows (provider_credentials + users). Verified live: after the repair, the Codex channel ran the 8-step agent task end to end (`gpt-5.5`, 10 rounds).

## Follow-ups (not in this PR)
- Surface cache-hit tokens in the usage event / UI (the meter folds them today; the split is not persisted).
- `interleaved-thinking` beta for the `enabled+budget` tier (4.5-generation models show thinking only on the first round of a turn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

