### PR TITLE
fix(agent): retain stage handoff after prompt trimming

### DIFF
--- a/src/amphi_agent/_cognitive.py
+++ b/src/amphi_agent/_cognitive.py
@@ -5,7 +5,7 @@ import re
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
-from bridgic.amphibious import CognitiveWorker, StepToolCall
+from bridgic.amphibious import CognitiveWorker, OTARecord, StepToolCall
 from bridgic.core.agentic.tool_specs import ToolSpec
 from bridgic.core.model.types import Message, Role
 
@@ -435,7 +435,7 @@ class MainThink(CognitiveWorker):
         return ("build", legacy_build_stage) if legacy_build_stage else None
 
     def _stage_turn_context(self, ota_context: AmphiOTAContext, mode: str, stage: str) -> Tuple[AmphiOTAContext, Optional[int]]:
-        """Project this Turn from the latest different stage in the same cognitive mode."""
+        """Project this Turn from the latest stage boundary, retaining its handoff."""
         stage_boundary = next((
             index
             for index in range(len(ota_context.ota_record) - 1, -1, -1)
@@ -448,8 +448,15 @@ class MainThink(CognitiveWorker):
         ), None)
         if stage_boundary is None:
             return ota_context, None
+        records = list(ota_context.ota_record[stage_boundary + 1:])
+        handoff = _view(ota_context.ota_record[stage_boundary], "observation_result")
+        if handoff:
+            # The boundary round belongs to the source stage, so its thought and
+            # tool activity stay trimmed. Its observation is the concise handoff
+            # deliberately stamped by ``switch`` for the newly active stage.
+            records.insert(0, OTARecord(observation_result=handoff))
         return ota_context.model_copy(update={
-            "ota_record": ota_context.ota_record[stage_boundary + 1:],
+            "ota_record": records,
         }), stage_boundary
 
     async def context_blocks(self, ota_context: AmphiOTAContext, context: AmphiContext) -> List[str]:

--- a/tests/agent/prompt/test_mode_prompts.py
+++ b/tests/agent/prompt/test_mode_prompts.py
@@ -169,9 +169,12 @@ async def test_workflow_stage_message_scope() -> None:
 
 
 async def test_build_stage_message_scope_uses_generic_marker() -> None:
-    """Build stage isolation uses think_scope while Main-to-Clarify retains its entry context."""
-    def record(mode: str, stage: str, content: str) -> OTARecord:
-        round_ = OTARecord(think_result={"step_content": content, "tool_calls": []})
+    """Build stage isolation trims source activity but retains the switch handoff."""
+    def record(mode: str, stage: str, content: str, observation: str = "") -> OTARecord:
+        round_ = OTARecord(
+            think_result={"step_content": content, "tool_calls": []},
+            observation_result=observation or None,
+        )
         round_.think_scope = {"mode": mode, "stage": stage}
         return round_
 
@@ -180,7 +183,12 @@ async def test_build_stage_message_scope_uses_generic_marker() -> None:
         prompt_time=PROMPT_TIME,
         state={"think": {"mode": "build", "stage": "explore"}},
         ota_record=[
-            record("build", "clarify", "Clarify history"),
+            record(
+                "build",
+                "clarify",
+                "Clarify history",
+                "[stage handoff] `build/clarify` → `build/explore`\nRequirements are settled.",
+            ),
             record("build", "explore", "Explore progress"),
         ],
     )
@@ -191,6 +199,7 @@ async def test_build_stage_message_scope_uses_generic_marker() -> None:
     assert "Clarify history" not in explore_contents
     assert "Past request" in explore_contents
     assert "Past answer" in explore_contents
+    assert any("Requirements are settled." in content for content in explore_contents)
     assert "Explore progress" in explore_contents
 
     clarify_ota = AmphiOTAContext(
@@ -210,6 +219,31 @@ async def test_build_stage_message_scope_uses_generic_marker() -> None:
     assert "Past answer" in clarify_contents
     assert "Explore history" not in clarify_contents
     assert "Clarify progress" in clarify_contents
+
+    generate_ota = AmphiOTAContext(
+        user_input="Build the workflow",
+        prompt_time=PROMPT_TIME,
+        state={"think": {"mode": "build", "stage": "generate"}},
+        ota_record=[
+            record("build", "generate", "Earlier generation history"),
+            record(
+                "build",
+                "verify",
+                "Verification history",
+                "[stage handoff] `build/verify` → `build/generate`\n"
+                "The generated script mishandles empty input; fix that case and rerun validation.",
+            ),
+            record("build", "generate", "Generate retry progress"),
+        ],
+    )
+    generate_contents = [
+        message.content
+        for message in await GenerateThink().assemble_messages(generate_ota, _context())
+    ]
+    assert "Earlier generation history" not in generate_contents
+    assert "Verification history" not in generate_contents
+    assert any("mishandles empty input" in content for content in generate_contents)
+    assert "Generate retry progress" in generate_contents
 
 
 async def test_build_dispatch() -> None:


### PR DESCRIPTION
## Summary
- retain the previous stage boundary observation as a minimal synthetic round
- keep the source stage thought and tool activity trimmed from the target-stage prompt
- cover forward handoffs and verify-to-generate retry handoffs with regression tests

## Testing
- `.venv/bin/pytest -q tests/agent` (177 passed)
- commit hooks: ESLint and TypeScript type checks passed