### PR TITLE
fix(agent): preserve Build stage history across switches

### DIFF
--- a/lab/server/prompt/reconstruct.test.ts
+++ b/lab/server/prompt/reconstruct.test.ts
@@ -201,12 +201,73 @@ describe("rebuildPrompt", () => {
     expect(result.stage).toBe("generate");
     expect(contents).toContain("Generate history");
     expect(contents).not.toContain("Clarify history");
-    expect(contents).not.toContain("Explore history");
+    expect(contents).toContain("Explore history");
     expect(result.components.find((item) => item.id === "current-turn")?.metadata).toMatchObject({
-      completedRounds: 1,
+      completedRounds: 2,
       availableRounds: 3,
-      omittedByStage: 2,
+      omittedByStage: 1,
       historyModel: "stage_scoped",
+      retainedBoundaryRound: true,
+    });
+  });
+
+  test("resumes a stage's earlier Turn history and appends the completed switch round", () => {
+    const reason = "Rewrite the redundant implementation.";
+    const handoff = "[stage handoff] `build/verify` → `build/generate`\nRewrite the redundant implementation.";
+    const current = turn("turn-current", 0, "Return to Generate", [
+      { think_scope: { mode: "build", stage: "generate" }, think_result: { step_content: "Earlier Generate history" } },
+      { think_scope: { mode: "build", stage: "verify" }, think_result: { step_content: "Verify intermediate work" } },
+      {
+        think_scope: { mode: "build", stage: "verify" },
+        think_result: {
+          step_content: "Verify found redundant code",
+          tool_calls: [{ call_id: "switch-call", tool: "switch", tool_arguments: [{ name: "stage", value: "generate" }, { name: "reason", value: reason }] }],
+        },
+        action_result: {
+          results: [{ tool_id: "switch-call", tool_name: "switch", tool_arguments: { stage: "generate", reason }, success: true, tool_result: { stage: "generate", reason } }],
+        },
+        observation_result: handoff,
+      },
+      { think_scope: { mode: "build", stage: "generate" }, think_result: { step_content: "Generate retry history" } },
+      { think_scope: { mode: "build", stage: "verify" } },
+    ], { agentState: { think: { mode: "build", stage: "generate" } } });
+
+    const result = rebuildPrompt(request([current], current.id, 3));
+    const contents = result.messages.map((message) => message.content ?? "");
+
+    expect(result.stage).toBe("generate");
+    expect(contents).toContain(handoff);
+    expect(contents).toContain("Earlier Generate history");
+    expect(contents).not.toContain("Verify intermediate work");
+    expect(contents).toContain("Verify found redundant code");
+    expect(result.messages.find((message) => message.toolCalls?.[0]?.id === "switch-call")?.toolCalls?.[0]).toMatchObject({
+      name: "switch",
+      arguments: { stage: "generate", reason },
+    });
+    const switchResult = result.messages.find((message) => message.toolCallId === "switch-call");
+    expect(switchResult?.role).toBe("tool");
+    expect(switchResult?.content).toContain(reason);
+    expect(result.components.find((item) => item.id === "current-turn")?.metadata).toMatchObject({
+      completedRounds: 2,
+      availableRounds: 3,
+      omittedByStage: 1,
+      historyModel: "stage_scoped",
+      retainedBoundaryRound: true,
+      retainedResumeRounds: 1,
+    });
+
+    const verifyResult = rebuildPrompt(request([current], current.id, 4));
+    const verifyContents = verifyResult.messages.map((message) => message.content ?? "");
+    expect(verifyResult.stage).toBe("verify");
+    expect(verifyContents).toContain("Verify intermediate work");
+    expect(verifyContents).toContain("Verify found redundant code");
+    expect(verifyContents).toContain("Generate retry history");
+    expect(verifyResult.components.find((item) => item.id === "current-turn")?.metadata).toMatchObject({
+      completedRounds: 4,
+      availableRounds: 4,
+      omittedByStage: 0,
+      historyModel: "stage_scoped",
+      retainedResumeRounds: 2,
     });
   });
 
@@ -223,27 +284,29 @@ describe("rebuildPrompt", () => {
 
     expect(contents).toContain("Past Session request");
     expect(contents).toContain("Explore history");
-    expect(contents).not.toContain("Clarify history");
+    expect(contents).toContain("Clarify history");
     expect(result.components.find((item) => item.id === "session-history")?.metadata).toMatchObject({
       omittedByStage: false,
       historyModel: "all_stages",
     });
   });
 
-  test("keeps Session history in marked Workflow Validate while cropping Execute trace", () => {
+  test("keeps Session history and the final Execute boundary in marked Workflow Validate", () => {
     const previous = turn("turn-previous", 0, "Past Workflow request", []);
     const current = turn("turn-workflow", 1, "Run it", [
-      { think_scope: { mode: "run_workflow", stage: "execute", session_history: "all_stages" }, think_result: { step_content: "Execute history" } },
+      { think_scope: { mode: "run_workflow", stage: "execute", session_history: "all_stages" }, think_result: { step_content: "Older Execute history" } },
+      { think_scope: { mode: "run_workflow", stage: "execute", session_history: "all_stages" }, think_result: { step_content: "Final Execute handoff" } },
       { think_scope: { mode: "run_workflow", stage: "validate", session_history: "all_stages" }, think_result: { step_content: "Validate history" } },
       { think_scope: { mode: "run_workflow", stage: "validate", session_history: "all_stages" } },
     ], { agentState: { think: { mode: "run_workflow", stage: "validate" } } });
 
-    const result = rebuildPrompt(request([previous, current], current.id, 2));
+    const result = rebuildPrompt(request([previous, current], current.id, 3));
     const contents = result.messages.map((message) => message.content ?? "");
 
     expect(contents).toContain("Past Workflow request");
     expect(contents).toContain("Validate history");
-    expect(contents).not.toContain("Execute history");
+    expect(contents).toContain("Final Execute handoff");
+    expect(contents).not.toContain("Older Execute history");
     expect(result.components.find((item) => item.id === "session-history")?.metadata).toMatchObject({
       omittedByStage: false,
       historyModel: "all_stages",
@@ -271,7 +334,7 @@ describe("rebuildPrompt", () => {
     });
   });
 
-  test("uses persisted Workflow scope and drops Execute history in Validate", () => {
+  test("uses persisted Workflow scope and retains the final Execute boundary in Validate", () => {
     const previous = turn("turn-previous", 0, "previous-conversation", []);
     const current = turn("turn-workflow", 1, "Run it", [
       { think_scope: { mode: "run_workflow", stage: "execute" }, think_result: { step_content: "Execute history" } },
@@ -284,7 +347,7 @@ describe("rebuildPrompt", () => {
 
     expect(result.stage).toBe("workflow_validate");
     expect(contents).toContain("Validate history");
-    expect(contents).not.toContain("Execute history");
+    expect(contents).toContain("Execute history");
     expect(contents).not.toContain("previous-conversation");
     expect(result.fidelity.limitations.some((item) => item.includes("Workflow stage is inferred"))).toBe(false);
   });

--- a/lab/server/prompt/reconstruct.test.ts
+++ b/lab/server/prompt/reconstruct.test.ts
@@ -201,17 +201,18 @@ describe("rebuildPrompt", () => {
     expect(result.stage).toBe("generate");
     expect(contents).toContain("Generate history");
     expect(contents).not.toContain("Clarify history");
-    expect(contents).toContain("Explore history");
+    expect(contents).not.toContain("Explore history");
     expect(result.components.find((item) => item.id === "current-turn")?.metadata).toMatchObject({
-      completedRounds: 2,
+      completedRounds: 1,
       availableRounds: 3,
-      omittedByStage: 1,
+      omittedByStage: 2,
       historyModel: "stage_scoped",
-      retainedBoundaryRound: true,
+      retainedBoundaryRound: false,
+      retainedSwitchRounds: 0,
     });
   });
 
-  test("resumes a stage's earlier Turn history and appends the completed switch round", () => {
+  test("applies the Build switch history policy when a stage is re-entered", () => {
     const reason = "Rewrite the redundant implementation.";
     const handoff = "[stage handoff] `build/verify` → `build/generate`\nRewrite the redundant implementation.";
     const current = turn("turn-current", 0, "Return to Generate", [
@@ -228,7 +229,17 @@ describe("rebuildPrompt", () => {
         },
         observation_result: handoff,
       },
-      { think_scope: { mode: "build", stage: "generate" }, think_result: { step_content: "Generate retry history" } },
+      {
+        think_scope: { mode: "build", stage: "generate" },
+        think_result: {
+          step_content: "Generate retry history",
+          tool_calls: [{ call_id: "switch-to-verify", tool: "switch", tool_arguments: [{ name: "stage", value: "verify" }, { name: "reason", value: "Retry ready for verification." }] }],
+        },
+        action_result: {
+          results: [{ tool_id: "switch-to-verify", tool_name: "switch", tool_arguments: { stage: "verify", reason: "Retry ready for verification." }, success: true, tool_result: { stage: "verify", reason: "Retry ready for verification." } }],
+        },
+        observation_result: "[stage handoff] `build/generate` → `build/verify`\nRetry ready for verification.",
+      },
       { think_scope: { mode: "build", stage: "verify" } },
     ], { agentState: { think: { mode: "build", stage: "generate" } } });
 
@@ -253,7 +264,7 @@ describe("rebuildPrompt", () => {
       omittedByStage: 1,
       historyModel: "stage_scoped",
       retainedBoundaryRound: true,
-      retainedResumeRounds: 1,
+      retainedSwitchRounds: 1,
     });
 
     const verifyResult = rebuildPrompt(request([current], current.id, 4));
@@ -263,18 +274,24 @@ describe("rebuildPrompt", () => {
     expect(verifyContents).toContain("Verify found redundant code");
     expect(verifyContents).toContain("Generate retry history");
     expect(verifyResult.components.find((item) => item.id === "current-turn")?.metadata).toMatchObject({
-      completedRounds: 4,
+      completedRounds: 3,
       availableRounds: 4,
-      omittedByStage: 0,
+      omittedByStage: 1,
       historyModel: "stage_scoped",
-      retainedResumeRounds: 2,
+      retainedSwitchRounds: 1,
     });
   });
 
   test("keeps Session history in every stage when the persisted scope opts in", () => {
     const previous = turn("turn-previous", 0, "Past Session request", []);
     const current = turn("turn-current", 1, "Build it", [
-      { think_scope: { mode: "build", stage: "clarify", session_history: "all_stages" }, think_result: { step_content: "Clarify history" } },
+      {
+        think_scope: { mode: "build", stage: "clarify", session_history: "all_stages" },
+        think_result: { step_content: "Clarify confirmation history" },
+        action_result: {
+          results: [{ tool_id: "task-confirm", tool_name: "request_human_task_confirm", tool_arguments: {}, success: true, tool_result: { status: "confirmed" } }],
+        },
+      },
       { think_scope: { mode: "build", stage: "explore", session_history: "all_stages" }, think_result: { step_content: "Explore history" } },
       { think_scope: { mode: "build", stage: "explore", session_history: "all_stages" } },
     ], { agentState: { think: { mode: "build", stage: "explore" } } });
@@ -284,14 +301,21 @@ describe("rebuildPrompt", () => {
 
     expect(contents).toContain("Past Session request");
     expect(contents).toContain("Explore history");
-    expect(contents).toContain("Clarify history");
+    expect(contents).not.toContain("Clarify confirmation history");
+    expect(result.components.find((item) => item.id === "current-turn")?.metadata).toMatchObject({
+      completedRounds: 1,
+      availableRounds: 2,
+      omittedByStage: 1,
+      retainedBoundaryRound: false,
+      retainedSwitchRounds: 0,
+    });
     expect(result.components.find((item) => item.id === "session-history")?.metadata).toMatchObject({
       omittedByStage: false,
       historyModel: "all_stages",
     });
   });
 
-  test("keeps Session history and the final Execute boundary in marked Workflow Validate", () => {
+  test("keeps Session history while isolating marked Workflow Validate from Execute", () => {
     const previous = turn("turn-previous", 0, "Past Workflow request", []);
     const current = turn("turn-workflow", 1, "Run it", [
       { think_scope: { mode: "run_workflow", stage: "execute", session_history: "all_stages" }, think_result: { step_content: "Older Execute history" } },
@@ -305,7 +329,7 @@ describe("rebuildPrompt", () => {
 
     expect(contents).toContain("Past Workflow request");
     expect(contents).toContain("Validate history");
-    expect(contents).toContain("Final Execute handoff");
+    expect(contents).not.toContain("Final Execute handoff");
     expect(contents).not.toContain("Older Execute history");
     expect(result.components.find((item) => item.id === "session-history")?.metadata).toMatchObject({
       omittedByStage: false,
@@ -334,7 +358,7 @@ describe("rebuildPrompt", () => {
     });
   });
 
-  test("uses persisted Workflow scope and retains the final Execute boundary in Validate", () => {
+  test("uses persisted Workflow scope and drops Execute history in Validate", () => {
     const previous = turn("turn-previous", 0, "previous-conversation", []);
     const current = turn("turn-workflow", 1, "Run it", [
       { think_scope: { mode: "run_workflow", stage: "execute" }, think_result: { step_content: "Execute history" } },
@@ -347,7 +371,7 @@ describe("rebuildPrompt", () => {
 
     expect(result.stage).toBe("workflow_validate");
     expect(contents).toContain("Validate history");
-    expect(contents).toContain("Execute history");
+    expect(contents).not.toContain("Execute history");
     expect(contents).not.toContain("previous-conversation");
     expect(result.fidelity.limitations.some((item) => item.includes("Workflow stage is inferred"))).toBe(false);
   });

--- a/lab/server/prompt/reconstruct.ts
+++ b/lab/server/prompt/reconstruct.ts
@@ -160,7 +160,7 @@ function projectStageRounds(
   usesStageScope: boolean;
   hasStageBoundary: boolean;
   allStageSessionHistory: boolean;
-  resumeRoundCount: number;
+  switchRoundCount: number;
 } {
   const priorRounds = turn.otaRecords.slice(0, targetRoundIndex);
   // Only think_scope proves that this request was assembled by the new
@@ -173,14 +173,44 @@ function projectStageRounds(
       usesStageScope: false,
       hasStageBoundary: false,
       allStageSessionHistory: false,
-      resumeRoundCount: 0,
+      switchRoundCount: 0,
     };
   }
   const allStageSessionHistory = targetScope.sessionHistory === "all_stages";
 
+  if (targetScope.mode === "run_workflow") {
+    for (let index = priorRounds.length - 1; index >= 0; index -= 1) {
+      const scope = roundThinkScope(priorRounds[index] ?? {});
+      if (scope?.mode === targetScope.mode && scope.stage !== targetScope.stage) {
+        return {
+          rounds: priorRounds.slice(index + 1),
+          usesStageScope: true,
+          hasStageBoundary: true,
+          allStageSessionHistory,
+          switchRoundCount: 0,
+        };
+      }
+    }
+    return {
+      rounds: priorRounds,
+      usesStageScope: true,
+      hasStageBoundary: false,
+      allStageSessionHistory,
+      switchRoundCount: 0,
+    };
+  }
+
+  const switchesToTarget = (round: Record<string, unknown>): boolean => actionSteps(round).some((step) => {
+    if (step.tool_name !== "switch" || step.success === false) return false;
+    const argumentsRecord = record(step.tool_arguments) ?? {};
+    const resultRecord = record(step.tool_result) ?? {};
+    return String(resultRecord.stage ?? argumentsRecord.stage ?? "") === targetScope.stage;
+  });
+
   const scopes = priorRounds.map((round) => roundThinkScope(round));
   const projected: Record<string, unknown>[] = [];
-  let resumeRoundCount = 0;
+  let switchRoundCount = 0;
+  let transitionCount = 0;
   priorRounds.forEach((round, index) => {
     const scope = scopes[index];
     if (scope?.mode === targetScope.mode && scope.stage === targetScope.stage) {
@@ -190,17 +220,20 @@ function projectStageRounds(
     const nextScope = index + 1 < scopes.length ? scopes[index + 1] : targetScope;
     if (scope?.mode === targetScope.mode && scope.stage !== targetScope.stage
       && nextScope?.mode === targetScope.mode && nextScope.stage === targetScope.stage) {
-      projected.push(round);
-      resumeRoundCount += 1;
+      transitionCount += 1;
+      if (switchesToTarget(round)) {
+        projected.push(round);
+        switchRoundCount += 1;
+      }
     }
   });
-  if (resumeRoundCount) {
+  if (transitionCount) {
     return {
       rounds: projected,
       usesStageScope: true,
       hasStageBoundary: true,
       allStageSessionHistory,
-      resumeRoundCount,
+      switchRoundCount,
     };
   }
   return {
@@ -208,7 +241,7 @@ function projectStageRounds(
     usesStageScope: true,
     hasStageBoundary: false,
     allStageSessionHistory,
-    resumeRoundCount: 0,
+    switchRoundCount: 0,
   };
 }
 
@@ -791,8 +824,8 @@ export function rebuildPrompt(input: PromptRebuildInput): PromptRebuildResult {
       availableRounds: priorRounds.length,
       omittedByStage: priorRounds.length - stageProjection.rounds.length,
       historyModel: stageProjection.usesStageScope ? "stage_scoped" : "legacy_full_turn",
-      retainedBoundaryRound: stageProjection.hasStageBoundary,
-      retainedResumeRounds: stageProjection.resumeRoundCount,
+      retainedBoundaryRound: stageProjection.switchRoundCount > 0,
+      retainedSwitchRounds: stageProjection.switchRoundCount,
     },
   ));
 

--- a/lab/server/prompt/reconstruct.ts
+++ b/lab/server/prompt/reconstruct.ts
@@ -160,6 +160,7 @@ function projectStageRounds(
   usesStageScope: boolean;
   hasStageBoundary: boolean;
   allStageSessionHistory: boolean;
+  resumeRoundCount: number;
 } {
   const priorRounds = turn.otaRecords.slice(0, targetRoundIndex);
   // Only think_scope proves that this request was assembled by the new
@@ -172,22 +173,43 @@ function projectStageRounds(
       usesStageScope: false,
       hasStageBoundary: false,
       allStageSessionHistory: false,
+      resumeRoundCount: 0,
     };
   }
   const allStageSessionHistory = targetScope.sessionHistory === "all_stages";
 
-  for (let index = priorRounds.length - 1; index >= 0; index -= 1) {
-    const scope = roundThinkScope(priorRounds[index] ?? {});
-    if (scope?.mode === targetScope.mode && scope.stage !== targetScope.stage) {
-      return {
-        rounds: priorRounds.slice(index + 1),
-        usesStageScope: true,
-        hasStageBoundary: true,
-        allStageSessionHistory,
-      };
+  const scopes = priorRounds.map((round) => roundThinkScope(round));
+  const projected: Record<string, unknown>[] = [];
+  let resumeRoundCount = 0;
+  priorRounds.forEach((round, index) => {
+    const scope = scopes[index];
+    if (scope?.mode === targetScope.mode && scope.stage === targetScope.stage) {
+      projected.push(round);
+      return;
     }
+    const nextScope = index + 1 < scopes.length ? scopes[index + 1] : targetScope;
+    if (scope?.mode === targetScope.mode && scope.stage !== targetScope.stage
+      && nextScope?.mode === targetScope.mode && nextScope.stage === targetScope.stage) {
+      projected.push(round);
+      resumeRoundCount += 1;
+    }
+  });
+  if (resumeRoundCount) {
+    return {
+      rounds: projected,
+      usesStageScope: true,
+      hasStageBoundary: true,
+      allStageSessionHistory,
+      resumeRoundCount,
+    };
   }
-  return { rounds: priorRounds, usesStageScope: true, hasStageBoundary: false, allStageSessionHistory };
+  return {
+    rounds: priorRounds,
+    usesStageScope: true,
+    hasStageBoundary: false,
+    allStageSessionHistory,
+    resumeRoundCount: 0,
+  };
 }
 
 function renderInput(userInput: PromptUserInput, context?: PromptContextSnapshot): string {
@@ -260,7 +282,7 @@ function toolResultContent(step: Record<string, unknown>): string {
   if (step.error || step.success === false) return `failed: ${String(step.error ?? "tool failed")}`;
   if (step.tool_result === null || step.tool_result === undefined) return "(no output)";
   if (step.tool_result === "") return "(awaiting the user's answer)";
-  return String(step.tool_result);
+  return typeof step.tool_result === "string" ? step.tool_result : safeStringify(step.tool_result);
 }
 
 function toolCallArguments(call: Record<string, unknown>): Record<string, unknown> {
@@ -769,6 +791,8 @@ export function rebuildPrompt(input: PromptRebuildInput): PromptRebuildResult {
       availableRounds: priorRounds.length,
       omittedByStage: priorRounds.length - stageProjection.rounds.length,
       historyModel: stageProjection.usesStageScope ? "stage_scoped" : "legacy_full_turn",
+      retainedBoundaryRound: stageProjection.hasStageBoundary,
+      retainedResumeRounds: stageProjection.resumeRoundCount,
     },
   ));
 

--- a/src/amphi_agent/_cognitive.py
+++ b/src/amphi_agent/_cognitive.py
@@ -5,7 +5,7 @@ import re
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
-from bridgic.amphibious import CognitiveWorker, OTARecord, StepToolCall
+from bridgic.amphibious import CognitiveWorker, StepToolCall
 from bridgic.core.agentic.tool_specs import ToolSpec
 from bridgic.core.model.types import Message, Role
 
@@ -435,29 +435,28 @@ class MainThink(CognitiveWorker):
         return ("build", legacy_build_stage) if legacy_build_stage else None
 
     def _stage_turn_context(self, ota_context: AmphiOTAContext, mode: str, stage: str) -> Tuple[AmphiOTAContext, Optional[int]]:
-        """Project this Turn from the latest stage boundary, retaining its handoff."""
-        stage_boundary = next((
-            index
-            for index in range(len(ota_context.ota_record) - 1, -1, -1)
-            if (
-                (scope := self._record_think_scope(ota_context.ota_record[index]))
-                is not None
-                and scope[0] == mode
-                and scope[1] != stage
-            )
-        ), None)
-        if stage_boundary is None:
+        """Resume this stage's existing Turn history across stage switches."""
+        records = ota_context.ota_record
+        scopes = [self._record_think_scope(record) for record in records]
+        projected: List[Any] = []
+        resumes: List[int] = []
+        target_scope = (mode, stage)
+        for index, (record, scope) in enumerate(zip(records, scopes)):
+            if scope == target_scope:
+                projected.append(record)
+                continue
+            next_scope = scopes[index + 1] if index + 1 < len(scopes) else None
+            if scope is not None and scope[0] == mode and scope[1] != stage and next_scope == target_scope:
+                projected.append(record)
+                resumes.append(index)
+        if not resumes:
             return ota_context, None
-        records = list(ota_context.ota_record[stage_boundary + 1:])
-        handoff = _view(ota_context.ota_record[stage_boundary], "observation_result")
-        if handoff:
-            # The boundary round belongs to the source stage, so its thought and
-            # tool activity stay trimmed. Its observation is the concise handoff
-            # deliberately stamped by ``switch`` for the newly active stage.
-            records.insert(0, OTARecord(observation_result=handoff))
         return ota_context.model_copy(update={
-            "ota_record": records,
-        }), stage_boundary
+            # Stage history survives re-entry. A switch continues the existing
+            # target-stage trace by appending the completed transition round;
+            # intermediate work owned by other stages remains excluded.
+            "ota_record": projected,
+        }), resumes[-1]
 
     async def context_blocks(self, ota_context: AmphiOTAContext, context: AmphiContext) -> List[str]:
         """Render Main context from the most stable prefix to live round state."""

--- a/src/amphi_agent/_cognitive.py
+++ b/src/amphi_agent/_cognitive.py
@@ -435,28 +435,8 @@ class MainThink(CognitiveWorker):
         return ("build", legacy_build_stage) if legacy_build_stage else None
 
     def _stage_turn_context(self, ota_context: AmphiOTAContext, mode: str, stage: str) -> Tuple[AmphiOTAContext, Optional[int]]:
-        """Resume this stage's existing Turn history across stage switches."""
-        records = ota_context.ota_record
-        scopes = [self._record_think_scope(record) for record in records]
-        projected: List[Any] = []
-        resumes: List[int] = []
-        target_scope = (mode, stage)
-        for index, (record, scope) in enumerate(zip(records, scopes)):
-            if scope == target_scope:
-                projected.append(record)
-                continue
-            next_scope = scopes[index + 1] if index + 1 < len(scopes) else None
-            if scope is not None and scope[0] == mode and scope[1] != stage and next_scope == target_scope:
-                projected.append(record)
-                resumes.append(index)
-        if not resumes:
-            return ota_context, None
-        return ota_context.model_copy(update={
-            # Stage history survives re-entry. A switch continues the existing
-            # target-stage trace by appending the completed transition round;
-            # intermediate work owned by other stages remains excluded.
-            "ota_record": projected,
-        }), resumes[-1]
+        """Return the full current-Turn trace unless a specialized worker projects it."""
+        return ota_context, None
 
     async def context_blocks(self, ota_context: AmphiOTAContext, context: AmphiContext) -> List[str]:
         """Render Main context from the most stable prefix to live round state."""
@@ -1336,6 +1316,24 @@ class WorkflowRunThink(MainThink):
         | {"report_workflow_step"}
     )
 
+    def _stage_turn_context(self, ota_context: AmphiOTAContext, mode: str, stage: str) -> Tuple[AmphiOTAContext, Optional[int]]:
+        """Keep only the active automatic Workflow stage's trace."""
+        boundary = next((
+            index
+            for index in range(len(ota_context.ota_record) - 1, -1, -1)
+            if (
+                (scope := self._record_think_scope(ota_context.ota_record[index]))
+                is not None
+                and scope[0] == mode
+                and scope[1] != stage
+            )
+        ), None)
+        if boundary is None:
+            return ota_context, None
+        return ota_context.model_copy(update={
+            "ota_record": list(ota_context.ota_record[boundary + 1:]),
+        }), boundary
+
     async def assemble_messages(
         self,
         ota_context: AmphiOTAContext,
@@ -1631,12 +1629,13 @@ class ValidateThink(WorkflowRunThink):
 # Build thinking chain — stage workers (same mechanics as MainThink, different frame)
 ################################################################################################################
 class BuildThink(MainThink):
-    """Provide shared capabilities without owning stage-specific behavior.
+    """Provide the shared history policy and capabilities for Build stages.
 
     Notes
     -----
     Concrete Thinks keep their own prompt assembly and legality checks. This
-    base only centralizes stable build paths, artifact rendering and tool access.
+    base centralizes Build history projection, stable paths, artifact rendering,
+    and tool access.
     """
 
     allowed_tools: frozenset[str] = (
@@ -1654,6 +1653,43 @@ class BuildThink(MainThink):
             "update_schedule",
         })
     )
+
+    def _stage_turn_context(self, ota_context: AmphiOTAContext, mode: str, stage: str) -> Tuple[AmphiOTAContext, Optional[int]]:
+        """Resume the selected Build stage and append only explicit switch rounds."""
+        def switches_to_target(record: Any) -> bool:
+            steps = _view(_view(record, "action_result"), "results") or []
+            for step in steps:
+                if _view(step, "tool_name") != "switch" or _view(step, "success") is False:
+                    continue
+                arguments = _view(step, "tool_arguments") or {}
+                result = _view(step, "tool_result") or {}
+                if str(_view(result, "stage") or _view(arguments, "stage") or "") == stage:
+                    return True
+            return False
+
+        records = ota_context.ota_record
+        scopes = [self._record_think_scope(record) for record in records]
+        projected: List[Any] = []
+        transitions: List[int] = []
+        target_scope = (mode, stage)
+        for index, (record, scope) in enumerate(zip(records, scopes)):
+            if scope == target_scope:
+                projected.append(record)
+                continue
+            next_scope = scopes[index + 1] if index + 1 < len(scopes) else None
+            if scope is None or scope[0] != mode or scope[1] == stage or next_scope != target_scope:
+                continue
+            transitions.append(index)
+            if switches_to_target(record):
+                projected.append(record)
+        if not transitions:
+            return ota_context, None
+        return ota_context.model_copy(update={
+            # Build stages retain their own prior trace. Only an explicit switch
+            # contributes its completed source-stage round to the target trace;
+            # automatic transitions keep their completion round in the source.
+            "ota_record": projected,
+        }), transitions[-1]
 
     def system_block(self, ota_context: AmphiOTAContext, context: AmphiContext) -> str:
         """Render the Build-stage persona with its exact current ToolSurface."""

--- a/tests/agent/prompt/test_mode_prompts.py
+++ b/tests/agent/prompt/test_mode_prompts.py
@@ -116,7 +116,7 @@ async def test_message_scopes() -> None:
 
 
 async def test_workflow_stage_message_scope() -> None:
-    """Validate drops Execute history while Execute sections retain their shared stage trace."""
+    """Validate retains the final Execute boundary while trimming older Execute rounds."""
     class ContextFreeWorkflowThink(WorkflowThink):
         async def context_blocks(self, ota_context: AmphiOTAContext, context: AmphiContext) -> list[str]:
             return []
@@ -140,13 +140,15 @@ async def test_workflow_stage_message_scope() -> None:
         prompt_time=PROMPT_TIME,
         state={"think": {**workflow_state, "stage": "validate", "step_index": 0}},
         ota_record=[
-            record("execute", "Execution history"),
+            record("execute", "Older execution history"),
+            record("execute", "Final execution handoff"),
             record("validate", "Validation progress"),
         ],
     )
     validate_messages = await ContextFreeValidateThink().assemble_messages(validate_ota, _context())
     validate_contents = [message.content for message in validate_messages]
-    assert "Execution history" not in validate_contents
+    assert "Older execution history" not in validate_contents
+    assert "Final execution handoff" in validate_contents
     assert "Past request" in validate_contents
     assert "Past answer" in validate_contents
     assert "Validation progress" in validate_contents
@@ -169,7 +171,7 @@ async def test_workflow_stage_message_scope() -> None:
 
 
 async def test_build_stage_message_scope_uses_generic_marker() -> None:
-    """Build stage isolation trims source activity but retains the switch handoff."""
+    """Build stages resume their existing Turn history when re-entered."""
     def record(mode: str, stage: str, content: str, observation: str = "") -> OTARecord:
         round_ = OTARecord(
             think_result={"step_content": content, "tool_calls": []},
@@ -196,7 +198,7 @@ async def test_build_stage_message_scope_uses_generic_marker() -> None:
         message.content
         for message in await ExploreThink().assemble_messages(explore_ota, _context())
     ]
-    assert "Clarify history" not in explore_contents
+    assert "Clarify history" in explore_contents
     assert "Past request" in explore_contents
     assert "Past answer" in explore_contents
     assert any("Requirements are settled." in content for content in explore_contents)
@@ -217,33 +219,85 @@ async def test_build_stage_message_scope_uses_generic_marker() -> None:
     ]
     assert "Past request" in clarify_contents
     assert "Past answer" in clarify_contents
-    assert "Explore history" not in clarify_contents
+    assert "Explore history" in clarify_contents
     assert "Clarify progress" in clarify_contents
 
     generate_ota = AmphiOTAContext(
         user_input="Build the workflow",
         prompt_time=PROMPT_TIME,
         state={"think": {"mode": "build", "stage": "generate"}},
-        ota_record=[
-            record("build", "generate", "Earlier generation history"),
-            record(
-                "build",
-                "verify",
-                "Verification history",
-                "[stage handoff] `build/verify` → `build/generate`\n"
-                "The generated script mishandles empty input; fix that case and rerun validation.",
-            ),
-            record("build", "generate", "Generate retry progress"),
-        ],
+        ota_record=[],
     )
-    generate_contents = [
-        message.content
-        for message in await GenerateThink().assemble_messages(generate_ota, _context())
+    switch_reason = "The generated script mishandles empty input; fix that case and rerun validation."
+    verification_round = record(
+        "build",
+        "verify",
+        "Verification history",
+        f"[stage handoff] `build/verify` → `build/generate`\n{switch_reason}",
+    )
+    verification_round.think_result = {
+        "step_content": "Verification history",
+        "tool_calls": [{
+            "call_id": "call-switch-back",
+            "tool": "switch",
+            "tool_arguments": [
+                {"name": "stage", "value": "generate"},
+                {"name": "reason", "value": switch_reason},
+            ],
+        }],
+    }
+    verification_round.action_result = ActionResult(results=[ActionStepResult(
+        tool_id="call-switch-back",
+        tool_name="switch",
+        tool_arguments={"stage": "generate", "reason": switch_reason},
+        tool_result={"stage": "generate", "reason": switch_reason},
+    )])
+    generate_ota.ota_record = [
+        record("build", "generate", "Earlier generation history"),
+        record("build", "verify", "Verification intermediate work"),
+        verification_round,
+        record("build", "generate", "Generate retry progress"),
     ]
-    assert "Earlier generation history" not in generate_contents
-    assert "Verification history" not in generate_contents
+    generate_messages = await GenerateThink().assemble_messages(generate_ota, _context())
+    generate_contents = [message.content for message in generate_messages]
+    assert "Earlier generation history" in generate_contents
+    assert "Verification intermediate work" not in generate_contents
+    assert "Verification history" in generate_contents
     assert any("mishandles empty input" in content for content in generate_contents)
     assert "Generate retry progress" in generate_contents
+    switch_call = next(
+        block
+        for message in generate_messages
+        for block in message.blocks
+        if getattr(block, "name", None) == "switch"
+    )
+    assert switch_call.id == "call-switch-back"
+    assert switch_call.arguments == {"stage": "generate", "reason": switch_reason}
+    switch_result = next(
+        block
+        for message in generate_messages
+        for block in message.blocks
+        if getattr(block, "id", None) == "call-switch-back" and hasattr(block, "content")
+    )
+    assert switch_reason in switch_result.content
+
+    verify_again_ota = AmphiOTAContext(
+        user_input="Build the workflow",
+        prompt_time=PROMPT_TIME,
+        state={"think": {"mode": "build", "stage": "verify"}},
+        ota_record=[
+            *generate_ota.ota_record,
+            record("build", "verify", "Second verification progress"),
+        ],
+    )
+    verify_again_contents = [
+        message.content
+        for message in await VerifyThink().assemble_messages(verify_again_ota, _context())
+    ]
+    assert "Verification intermediate work" in verify_again_contents
+    assert "Verification history" in verify_again_contents
+    assert "Generate retry progress" in verify_again_contents
+    assert "Second verification progress" in verify_again_contents
 
 
 async def test_build_dispatch() -> None:

--- a/tests/agent/prompt/test_mode_prompts.py
+++ b/tests/agent/prompt/test_mode_prompts.py
@@ -116,7 +116,7 @@ async def test_message_scopes() -> None:
 
 
 async def test_workflow_stage_message_scope() -> None:
-    """Validate retains the final Execute boundary while trimming older Execute rounds."""
+    """Automatic Workflow stages keep only their own trace."""
     class ContextFreeWorkflowThink(WorkflowThink):
         async def context_blocks(self, ota_context: AmphiOTAContext, context: AmphiContext) -> list[str]:
             return []
@@ -148,7 +148,7 @@ async def test_workflow_stage_message_scope() -> None:
     validate_messages = await ContextFreeValidateThink().assemble_messages(validate_ota, _context())
     validate_contents = [message.content for message in validate_messages]
     assert "Older execution history" not in validate_contents
-    assert "Final execution handoff" in validate_contents
+    assert "Final execution handoff" not in validate_contents
     assert "Past request" in validate_contents
     assert "Past answer" in validate_contents
     assert "Validation progress" in validate_contents
@@ -170,8 +170,8 @@ async def test_workflow_stage_message_scope() -> None:
     assert "Second execution section" in execute_contents
 
 
-async def test_build_stage_message_scope_uses_generic_marker() -> None:
-    """Build stages resume their existing Turn history when re-entered."""
+async def test_build_stage_message_scope_uses_build_switch_policy() -> None:
+    """Build stages resume their history and retain only explicit switch transitions."""
     def record(mode: str, stage: str, content: str, observation: str = "") -> OTARecord:
         round_ = OTARecord(
             think_result={"step_content": content, "tool_calls": []},
@@ -180,17 +180,47 @@ async def test_build_stage_message_scope_uses_generic_marker() -> None:
         round_.think_scope = {"mode": mode, "stage": stage}
         return round_
 
+    def switch_record(source_stage: str, target_stage: str, content: str, reason: str) -> OTARecord:
+        call_id = f"call-{source_stage}-to-{target_stage}"
+        round_ = record(
+            "build",
+            source_stage,
+            content,
+            f"[stage handoff] `build/{source_stage}` → `build/{target_stage}`\n{reason}",
+        )
+        round_.think_result = {
+            "step_content": content,
+            "tool_calls": [{
+                "call_id": call_id,
+                "tool": "switch",
+                "tool_arguments": [
+                    {"name": "stage", "value": target_stage},
+                    {"name": "reason", "value": reason},
+                ],
+            }],
+        }
+        round_.action_result = ActionResult(results=[ActionStepResult(
+            tool_id=call_id,
+            tool_name="switch",
+            tool_arguments={"stage": target_stage, "reason": reason},
+            tool_result={"stage": target_stage, "reason": reason},
+        )])
+        return round_
+
+    clarify_confirmation = record("build", "clarify", "Clarify confirmation history")
+    clarify_confirmation.action_result = ActionResult(results=[ActionStepResult(
+        tool_id="call-task-confirm",
+        tool_name="request_human_task_confirm",
+        tool_arguments={},
+        tool_result={"status": "confirmed"},
+    )])
+
     explore_ota = AmphiOTAContext(
         user_input="Build the workflow",
         prompt_time=PROMPT_TIME,
         state={"think": {"mode": "build", "stage": "explore"}},
         ota_record=[
-            record(
-                "build",
-                "clarify",
-                "Clarify history",
-                "[stage handoff] `build/clarify` → `build/explore`\nRequirements are settled.",
-            ),
+            clarify_confirmation,
             record("build", "explore", "Explore progress"),
         ],
     )
@@ -198,18 +228,23 @@ async def test_build_stage_message_scope_uses_generic_marker() -> None:
         message.content
         for message in await ExploreThink().assemble_messages(explore_ota, _context())
     ]
-    assert "Clarify history" in explore_contents
+    assert "Clarify confirmation history" not in explore_contents
     assert "Past request" in explore_contents
     assert "Past answer" in explore_contents
-    assert any("Requirements are settled." in content for content in explore_contents)
     assert "Explore progress" in explore_contents
 
+    explore_to_clarify = switch_record(
+        "explore",
+        "clarify",
+        "Explore needs clarification",
+        "A required decision is missing from task.md.",
+    )
     clarify_ota = AmphiOTAContext(
         user_input="Build the workflow",
         prompt_time=PROMPT_TIME,
         state={"think": {"mode": "build", "stage": "clarify"}},
         ota_record=[
-            record("build", "explore", "Explore history"),
+            explore_to_clarify,
             record("build", "clarify", "Clarify progress"),
         ],
     )
@@ -219,7 +254,7 @@ async def test_build_stage_message_scope_uses_generic_marker() -> None:
     ]
     assert "Past request" in clarify_contents
     assert "Past answer" in clarify_contents
-    assert "Explore history" in clarify_contents
+    assert "Explore needs clarification" in clarify_contents
     assert "Clarify progress" in clarify_contents
 
     generate_ota = AmphiOTAContext(
@@ -229,31 +264,15 @@ async def test_build_stage_message_scope_uses_generic_marker() -> None:
         ota_record=[],
     )
     switch_reason = "The generated script mishandles empty input; fix that case and rerun validation."
-    verification_round = record(
-        "build",
+    first_generation_handoff = switch_record(
+        "generate",
         "verify",
-        "Verification history",
-        f"[stage handoff] `build/verify` → `build/generate`\n{switch_reason}",
+        "Earlier generation history",
+        "The first implementation is ready for verification.",
     )
-    verification_round.think_result = {
-        "step_content": "Verification history",
-        "tool_calls": [{
-            "call_id": "call-switch-back",
-            "tool": "switch",
-            "tool_arguments": [
-                {"name": "stage", "value": "generate"},
-                {"name": "reason", "value": switch_reason},
-            ],
-        }],
-    }
-    verification_round.action_result = ActionResult(results=[ActionStepResult(
-        tool_id="call-switch-back",
-        tool_name="switch",
-        tool_arguments={"stage": "generate", "reason": switch_reason},
-        tool_result={"stage": "generate", "reason": switch_reason},
-    )])
+    verification_round = switch_record("verify", "generate", "Verification history", switch_reason)
     generate_ota.ota_record = [
-        record("build", "generate", "Earlier generation history"),
+        first_generation_handoff,
         record("build", "verify", "Verification intermediate work"),
         verification_round,
         record("build", "generate", "Generate retry progress"),
@@ -269,24 +288,31 @@ async def test_build_stage_message_scope_uses_generic_marker() -> None:
         block
         for message in generate_messages
         for block in message.blocks
-        if getattr(block, "name", None) == "switch"
+        if getattr(block, "id", None) == "call-verify-to-generate"
     )
-    assert switch_call.id == "call-switch-back"
+    assert switch_call.id == "call-verify-to-generate"
     assert switch_call.arguments == {"stage": "generate", "reason": switch_reason}
     switch_result = next(
         block
         for message in generate_messages
         for block in message.blocks
-        if getattr(block, "id", None) == "call-switch-back" and hasattr(block, "content")
+        if getattr(block, "id", None) == "call-verify-to-generate" and hasattr(block, "content")
     )
     assert switch_reason in switch_result.content
 
+    generation_handoff = switch_record(
+        "generate",
+        "verify",
+        "Generate retry completed",
+        "The corrected implementation is ready for verification.",
+    )
     verify_again_ota = AmphiOTAContext(
         user_input="Build the workflow",
         prompt_time=PROMPT_TIME,
         state={"think": {"mode": "build", "stage": "verify"}},
         ota_record=[
             *generate_ota.ota_record,
+            generation_handoff,
             record("build", "verify", "Second verification progress"),
         ],
     )
@@ -296,7 +322,8 @@ async def test_build_stage_message_scope_uses_generic_marker() -> None:
     ]
     assert "Verification intermediate work" in verify_again_contents
     assert "Verification history" in verify_again_contents
-    assert "Generate retry progress" in verify_again_contents
+    assert "Generate retry progress" not in verify_again_contents
+    assert "Generate retry completed" in verify_again_contents
     assert "Second verification progress" in verify_again_contents
 
 


### PR DESCRIPTION
## Summary

- move stage-history projection into `BuildThink` so other cognitive workers do not inherit Build handoff rules
- resume each Build stage from its existing Turn history and append only successful `switch` transition rounds
- exclude automatic transitions such as `request_human_task_confirm` from the target stage history
- mirror the backend behavior in Agent Lab prompt reconstruction and cover repeated Generate/Verify re-entry

## Verification

- `uv run pytest tests/agent/prompt -q` — 29 passed
- `bun test server/prompt/reconstruct.test.ts` — 15 passed
- `bun run typecheck` — passed
- commit hooks: ESLint and desktop/shared TypeScript checks passed
- full Lab suite: 116 passed; 3 existing persona snapshot/import tests remain unrelated failures