### PR TITLE
fix(landing): stop the Chinese tagline from wrapping

### DIFF
--- a/desktop/apps/electron/src/renderer/components/amphi/Landing.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/Landing.tsx
@@ -146,7 +146,11 @@ export function Landing({ needsModelConfig = false, onConfigureModel, marketCard
         <BridgicLogo size={32} />
         <span className="text-2xl font-bold text-text-primary">{APP_PRODUCT_NAME}</span>
       </div>
-      <p className="text-md text-text-secondary mb-8 text-center max-w-[420px] leading-[1.6]">
+      {/* Capped at the composer's 640px, not the 420px it used to be: at 15px the Chinese
+          tagline measures ~430px (a 6-char `/build` chip plus 25 full-width glyphs), so it
+          wrapped to a second line with plenty of window left over, while the shorter English
+          one fit. The cap still holds — a narrow window wraps it as before. */}
+      <p className="text-md text-text-secondary mb-8 text-center max-w-[640px] leading-[1.6]">
         <Trans
           i18nKey="landing.tagline"
           components={{


### PR DESCRIPTION
## Problem

The landing hero tagline wraps onto a second line even when the window is
wide, dropping a single orphan character below the rest of the sentence.

## Cause

`Landing.tsx` caps the tagline `<p>` at `max-w-[420px]`. At `--text-md: 15px`
the Chinese copy measures roughly 430px:

- `/build` chip: 6 mono chars at `0.85em` plus `px-1` padding ≈ 54px
- `：把需求变成真正可运行的工作流。一次构建，持续演进` — 25 full-width glyphs × 15px = 375px

That clears 420px by a hair, so it wraps. The English copy
(`/build: You Set the Goal. Let the Agent Lead.`) comes in around 320px and
fits, which is why only the Chinese locale showed the bug.

## Fix

Raise the cap to 640px — the same width as the composer below it, so hero,
tagline and input now share one baseline width. It remains a cap rather than
`whitespace-nowrap`, so a narrow window still wraps the text instead of
overflowing the column.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` — 1442 pass, 6 skip, 0 fail
- [ ] Visual check: launch the app in Chinese and confirm the tagline sits on one line
- [ ] Visual check: switch to English and confirm it is unchanged
- [ ] Visual check: narrow the window and confirm the tagline wraps rather than overflowing

Python backend untouched — the change is renderer-only.