### PR TITLE
chore(release): bump version to 0.1.3

### DIFF
--- a/desktop/apps/electron/package.json
+++ b/desktop/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amphi",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Bridgic Agent desktop app",
   "repository": {
     "type": "git",

--- a/desktop/apps/electron/src/shared/app-meta.ts
+++ b/desktop/apps/electron/src/shared/app-meta.ts
@@ -84,7 +84,7 @@ export const APP_BUNDLE_ID = 'ai.bridgic.agent'
 export const APP_DEEPLINK_SCHEME = 'amphi'
 
 /** App version — keep in sync with root and apps/electron package.json. */
-export const APP_VERSION = '0.1.2'
+export const APP_VERSION = '0.1.3'
 
 /** GitHub page used for user-confirmed issue reports from the desktop app. */
 export const APP_NEW_ISSUE_URL = 'https://github.com/bitsky-tech/bridgic-agent/issues/new'

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bridgic-agent-desktop",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "license": "SEE LICENSE IN ../LICENSE",
   "description": "Bridgic Agent — Electron GUI client for the Bridgic Agent backend daemon",

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -11,7 +11,7 @@ The command-line entry is ``python -m src <subcommand>`` (see
 :mod:`.amphi_cli`).
 """
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 
 __all__ = ["__version__"]


### PR DESCRIPTION
Summary:
- bump all four release version sources from 0.1.2 to 0.1.3
- keep the release commit based exactly on origin/main at 218525967ed8e8c3b1943b460d61974a772f8e22

Validation:
- release manifest generated successfully for desktop 0.1.3 and backend 0.1.3
- release-manifest unit tests: 12 passed
- desktop lint passed
- desktop typecheck passed