### PR TITLE
fix(desktop): keep renderer overlays clear of the embedded browser

### DIFF
--- a/desktop/apps/electron/src/renderer/atoms/browser.ts
+++ b/desktop/apps/electron/src/renderer/atoms/browser.ts
@@ -1,5 +1,5 @@
 import { atom } from 'jotai'
-import type { EmbeddedBrowserSnapshot } from '@shared/types'
+import type { EmbeddedBrowserBounds, EmbeddedBrowserSnapshot } from '@shared/types'
 import { viewedSessionIdAtom } from './navigation'
 import {
   rightPanelCollapsedAtom,
@@ -73,6 +73,34 @@ export const setBrowserSurfaceBlockerAtom = atom(
     if (next.size !== current.size || ![...next].every((source) => current.has(source))) {
       set(browserSurfaceBlockersAtom, next)
     }
+  },
+)
+
+const nativeSurfaceRect = atom<EmbeddedBrowserBounds | null>(null)
+
+/**
+ * Where the native WebContentsView is currently drawn, or null when nothing is.
+ *
+ * The renderer cannot paint inside this rectangle — Electron composites the view
+ * above the page, so an overlay that lands there is invisible rather than merely
+ * dimmed. A dialog answers that by blocking the surface outright; a small
+ * corner card or dropdown reads this and steps aside instead, which is why this
+ * is a live rect and not a boolean.
+ */
+export const nativeSurfaceRectAtom = atom((get) => get(nativeSurfaceRect))
+
+/** Publish the surface rect from the panel that measures it; null once it is gone. */
+export const setNativeSurfaceRectAtom = atom(
+  null,
+  (get, set, rect: EmbeddedBrowserBounds | null) => {
+    const current = get(nativeSurfaceRect)
+    if (current === rect) return
+    if (
+      current !== null && rect !== null
+      && current.x === rect.x && current.y === rect.y
+      && current.width === rect.width && current.height === rect.height
+    ) return
+    set(nativeSurfaceRect, rect)
   },
 )
 

--- a/desktop/apps/electron/src/renderer/components/amphi/ImageLightbox.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/ImageLightbox.tsx
@@ -13,6 +13,7 @@ import Download from 'yet-another-react-lightbox/plugins/download'
 import Fullscreen from 'yet-another-react-lightbox/plugins/fullscreen'
 import 'yet-another-react-lightbox/styles.css'
 import { closeImageAtom, lightboxItemAtom } from '@/atoms/lightbox'
+import { useBrowserSurfaceBlocker } from '@/hooks/useBrowserSurfaceBlocker'
 import { rlog } from '@/lib/logger'
 
 /**
@@ -34,6 +35,10 @@ export function ImageLightbox() {
   const item = useAtomValue(lightboxItemAtom)
   const close = useSetAtom(closeImageAtom)
   const isOpen = item !== null
+  // YARL owns its own portal, so this is the one overlay that cannot inherit the
+  // blocker from `ModalBackdrop` — same reason the traffic lights are handled by
+  // hand below. Without it the embedded Browser's native view paints over the image.
+  useBrowserSurfaceBlocker('image-lightbox', isOpen)
   // external-system sync: the traffic lights are native controls drawn above the web content, so a
   // full-screen backdrop cannot cover them — only the window itself can hide them.
   useEffect(() => {

--- a/desktop/apps/electron/src/renderer/components/amphi/ModalBackdrop.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/ModalBackdrop.tsx
@@ -11,7 +11,7 @@
  * not wrap this component simply has no backdrop, so missing an update is
  * physically impossible.
  *
- * Four invariants (understand why before changing anything):
+ * Six invariants (understand why before changing anything):
  *
  *   1. **Portal to body**. An `absolute` backdrop only covers the nearest
  *      positioned ancestor — a dialog opened from inside the composer would
@@ -55,13 +55,22 @@
  *      pair — unlike `click` — also fires for the right and middle buttons: without the
  *      filter, right-clicking the dim area (reaching for a paste menu and missing the
  *      input) would dismiss the dialog.
+ *   6. **Mounting blocks the native Browser surface.** The embedded Browser is
+ *      an Electron `WebContentsView` composited above this page, so no z-index
+ *      reaches over it: the native view must hide before a dialog can be seen.
+ *      Owning that here rather than in each consumer is the same trade as the
+ *      backdrop itself — a dialog that does not wrap this component simply has
+ *      no backdrop, so forgetting the blocker is physically impossible. The
+ *      blocker is keyed per instance so a stacked dialog closing does not
+ *      uncover the browser over the one still open.
  *
  * Not responsible for: closing on Esc (consumers use `useEscapeToClose`
  * themselves), or content layout and animation.
  */
 
 import { createPortal } from 'react-dom'
-import { useRef, type ReactNode } from 'react'
+import { useId, useRef, type ReactNode } from 'react'
+import { useBrowserSurfaceBlocker } from '@/hooks/useBrowserSurfaceBlocker'
 import { cn } from '@/lib/cn'
 
 export interface ModalBackdropProps {
@@ -89,6 +98,9 @@ export function ModalBackdrop({
 }: ModalBackdropProps) {
   // Where the current press started; see invariant 5 in the file header.
   const pressedOnBackdrop = useRef(false)
+  // Invariant 6, see the file header. Per-instance id: stacked dialogs must not
+  // release each other's blocker.
+  useBrowserSurfaceBlocker(useId(), true)
   return createPortal(
     <div
       data-testid={testId}

--- a/desktop/apps/electron/src/renderer/components/amphi/__tests__/ImageLightbox.test.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/__tests__/ImageLightbox.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * ImageLightbox — the one overlay that cannot inherit the native-surface
+ * blocker from `ModalBackdrop`.
+ *
+ * Every other dialog in the app goes through `ModalBackdrop`, which registers
+ * the blocker for it. This one is a third-party viewer (YARL) that portals
+ * itself, so the blocker is wired by hand — and hand-wiring is exactly what a
+ * later refactor deletes without noticing. Until recently the protection came
+ * from an atom whitelist inside `useEmbeddedBrowserSurfaceEligible`; that
+ * whitelist is gone, so this test is the only thing standing between a viewed
+ * image and the browser's WebContentsView painting straight over it.
+ */
+import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+GlobalRegistrator.register()
+;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+afterAll(async () => {
+  await GlobalRegistrator.unregister()
+})
+
+// YARL owns a portal, a stylesheet and three plugin entry points — none of
+// which this test is about. Stub the whole package down to "did it open?".
+mock.module('yet-another-react-lightbox', () => ({
+  default: ({ open }: { open: boolean }) => (open ? <div data-testid="yarl" /> : null),
+}))
+mock.module('yet-another-react-lightbox/plugins/zoom', () => ({ default: {} }))
+mock.module('yet-another-react-lightbox/plugins/download', () => ({ default: {} }))
+mock.module('yet-another-react-lightbox/plugins/fullscreen', () => ({ default: {} }))
+mock.module('yet-another-react-lightbox/styles.css', () => ({}))
+
+const { act } = await import('react')
+const { createRoot } = await import('react-dom/client')
+const { createStore, Provider } = await import('jotai')
+const { browserSurfaceBlockedAtom } = await import('@/atoms/browser')
+const { openImageAtom, closeImageAtom } = await import('@/atoms/lightbox')
+const { ImageLightbox } = await import('../ImageLightbox')
+
+beforeEach(() => {
+  ;(globalThis as unknown as { window: Record<string, unknown> }).window.api = {
+    window: { setTrafficLightsVisible: async () => {} },
+  }
+})
+
+describe('ImageLightbox', () => {
+  it('hides the native Browser surface while an image is open', async () => {
+    const store = createStore()
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const root = createRoot(host)
+    await act(async () => {
+      root.render(<Provider store={store}><ImageLightbox /></Provider>)
+    })
+    expect(store.get(browserSurfaceBlockedAtom)).toBe(false)
+
+    await act(async () => {
+      store.set(openImageAtom, { src: 'file:///tmp/a.png' })
+    })
+    expect(store.get(browserSurfaceBlockedAtom)).toBe(true)
+
+    await act(async () => { store.set(closeImageAtom) })
+    expect(store.get(browserSurfaceBlockedAtom)).toBe(false)
+
+    await act(async () => root.unmount())
+    host.remove()
+  })
+})

--- a/desktop/apps/electron/src/renderer/components/amphi/__tests__/ModalBackdrop.test.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/__tests__/ModalBackdrop.test.tsx
@@ -24,6 +24,8 @@ afterAll(async () => {
 
 const { act } = await import('react')
 const { createRoot } = await import('react-dom/client')
+const { getDefaultStore } = await import('jotai')
+const { browserSurfaceBlockedAtom } = await import('@/atoms/browser')
 const { ModalBackdrop } = await import('../ModalBackdrop')
 
 /** 挂载到一个**独立**容器,好证明遮罩确实 portal 到了 body 而不是留在原地。 */
@@ -179,5 +181,49 @@ describe('ModalBackdrop', () => {
     // 容器已让位,暗色层铺满容器即可;它若还带自己的 top 偏移就是让位做了两遍。
     expect(backdropOf().querySelector('div')!.className).toContain('inset-0')
     await cleanup()
+  })
+
+  // The embedded Browser is an Electron WebContentsView composited ABOVE this
+  // page, so no z-index puts a dialog in front of it: the native view has to
+  // hide first. Owning that here is what makes every ModalBackdrop consumer
+  // immune by construction — the same reasoning as the backdrop itself (a
+  // dialog that does not wrap this component has no backdrop at all, so
+  // forgetting is impossible).
+  it('hides the native Browser surface for as long as it is mounted', async () => {
+    const store = getDefaultStore()
+    expect(store.get(browserSurfaceBlockedAtom)).toBe(false)
+
+    const { cleanup } = await mount(
+      <ModalBackdrop data-testid="bd"><span data-testid="card">x</span></ModalBackdrop>,
+    )
+    expect(store.get(browserSurfaceBlockedAtom)).toBe(true)
+
+    await cleanup()
+    expect(store.get(browserSurfaceBlockedAtom)).toBe(false)
+  })
+
+  it('gives every overlay its own blocker, so closing the top dialog does not uncover the browser under the one below', async () => {
+    const store = getDefaultStore()
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const root = createRoot(host)
+    const Stack = ({ second }: { second: boolean }) => (
+      <>
+        <ModalBackdrop data-testid="bd"><span>x</span></ModalBackdrop>
+        {second ? <ModalBackdrop data-testid="bd2"><span>y</span></ModalBackdrop> : null}
+      </>
+    )
+
+    await act(async () => { root.render(<Stack second />) })
+    expect(store.get(browserSurfaceBlockedAtom)).toBe(true)
+
+    // A shared blocker key would release here and let the native view paint
+    // over the dialog that is still open (settings → confirm → dismiss).
+    await act(async () => { root.render(<Stack second={false} />) })
+    expect(store.get(browserSurfaceBlockedAtom)).toBe(true)
+
+    await act(async () => { root.unmount() })
+    host.remove()
+    expect(store.get(browserSurfaceBlockedAtom)).toBe(false)
   })
 })

--- a/desktop/apps/electron/src/renderer/components/app/AutoUpdateBanner.tsx
+++ b/desktop/apps/electron/src/renderer/components/app/AutoUpdateBanner.tsx
@@ -23,6 +23,12 @@
  *     "scheduled" card auto-dismisses after a few seconds; if the poll were
  *     keyed off the visible card, that dismissal would silently cancel the very
  *     thing the card just promised.
+ *   - **The card steps around the embedded Browser, it does not blank it.** That
+ *     native view composites above this page, so the card was invisible under it
+ *     until it started dodging. Hiding the view instead (what a modal dialog
+ *     does) is wrong here: this card is deliberately non-blocking and can sit in
+ *     the corner indefinitely, so the page behind it would stay blank for as
+ *     long as the user ignored the card.
  *   - Exactly ONE control cancels the update, and it is on the ready card. The
  *     acknowledgement cards only close themselves — an "cancel" button on the
  *     scheduled card cannot be read unambiguously (cancel the schedule, or
@@ -41,7 +47,9 @@ import {
   updateCardReopenAtom,
 } from '@/atoms/update'
 import { rlog } from '@/lib/logger'
+import { useBrowserSurfaceBlocker } from '@/hooks/useBrowserSurfaceBlocker'
 import { useCountdownDismiss } from '@/hooks/useCountdownDismiss'
+import { useOverlayRightLimit } from '@/hooks/useOverlayRightLimit'
 import { Btn, Card } from '@/components/amphi'
 
 /** How often the parked update re-checks whether the agent went idle. */
@@ -49,6 +57,12 @@ const IDLE_POLL_MS = 10_000
 
 /** How long an acknowledgement card stays up before closing itself. */
 const AUTO_DISMISS_SECONDS = 5
+
+/** Gap from whichever edge the card is currently hugging (matches `bottom-4`). */
+const EDGE_GAP_PX = 16
+
+/** Card's widest form (matches `max-w-[380px]`); the width it needs to step aside into. */
+const CARD_WIDTH_PX = 380
 
 /**
  * Consecutive idle readings required before a parked update installs itself.
@@ -116,6 +130,27 @@ export function AutoUpdateBanner() {
   const beginHandover = useSetAtom(beginUpdateHandoverAtom)
   const fetchAgentActivity = useSetAtom(fetchAgentActivityAtom)
   const endHandover = useSetAtom(endUpdateHandoverAtom)
+  // Bottom-right is exactly where the embedded Browser's native view sits, and
+  // that view composites above this page — `z-50` buys nothing against it. The
+  // card steps left of the surface rather than blocking it: this card is not
+  // modal and can sit there for as long as the user ignores it, and blanking a
+  // whole web page behind it would read as a bug rather than as a decision.
+  const rightLimit = useOverlayRightLimit()
+  // Expanded Browser leaves only the sidebar's width beside the surface — none
+  // at all with the sidebar collapsed — so there is nowhere to step to and the
+  // card falls back to hiding the view instead.
+  //
+  // A latch (`squeezed ||`), measured ONLY while not already hiding the view:
+  // blocking clears the rect, so re-deciding from the rect would unblock →
+  // re-measure → block, every frame. Adjusted during render rather than in an
+  // effect so the blocker below acts on the decision in the same commit. The
+  // cost of the latch is that un-expanding the browser while a card is up
+  // leaves it blocked until the card closes.
+  const [squeezed, setSqueezed] = useState(false)
+  const nextSqueezed = view !== null
+    && (squeezed || rightLimit - EDGE_GAP_PX * 2 < CARD_WIDTH_PX)
+  if (nextSqueezed !== squeezed) setSqueezed(nextSqueezed)
+  useBrowserSurfaceBlocker('auto-update-banner', nextSqueezed)
 
   useEffect(() => {
     return window.api.events.onAutoUpdate((event) => {
@@ -224,7 +259,19 @@ export function AutoUpdateBanner() {
   return (
     <>
       {view !== null && (
-        <div className="fixed bottom-4 right-4 z-50 max-w-[380px]">
+        <div
+          className="fixed bottom-4 z-50 max-w-[380px] transition-[right] duration-200 ease-out motion-reduce:transition-none"
+          // Viewport-derived offset — the §1.22 dynamic-value exception. Animated
+          // rather than snapped: the browser opening under a card the user is
+          // already reading should look like the card making room, not like it
+          // being thrown across the window.
+          style={{
+            right: nextSqueezed
+              ? EDGE_GAP_PX
+              : Math.max(EDGE_GAP_PX, window.innerWidth - rightLimit + EDGE_GAP_PX),
+          }}
+          data-testid="auto-update-banner"
+        >
           <BannerBody
             view={view}
             installing={installing}

--- a/desktop/apps/electron/src/renderer/components/app/EmbeddedBrowserPanel.tsx
+++ b/desktop/apps/electron/src/renderer/components/app/EmbeddedBrowserPanel.tsx
@@ -14,6 +14,7 @@ import type { EmbeddedBrowserSessionInfo, EmbeddedBrowserTabInfo } from '@shared
 import {
   activeEmbeddedBrowserSessionAtom,
   browserExpandedAtom,
+  setNativeSurfaceRectAtom,
 } from '@/atoms/browser'
 import { viewedSessionIdAtom } from '@/atoms/amphi'
 import { isBlankTabUrl } from '@/lib/browserTabUrl'
@@ -515,6 +516,10 @@ function useNativeBrowserSurface(
   onPresentationHideFailed?: () => void,
 ): void {
   const hiddenAcknowledgementRequested = onPresentationHidden !== undefined
+  // Publishing the rect alongside every setVisible/setBounds keeps renderer
+  // overlays that dodge the native view (rather than hiding it) in step with
+  // what Electron was actually told — see `nativeSurfaceRectAtom`.
+  const publishSurfaceRect = useSetAtom(setNativeSurfaceRectAtom)
   const hiddenRef = useRef(hidden)
   const onPresentationReadyRef = useRef(onPresentationReady)
   const onPresentationHiddenRef = useRef(onPresentationHidden)
@@ -546,6 +551,12 @@ function useNativeBrowserSurface(
       }
       return
     }
+    // AFTER the round trip, mirroring the show path's "before". Both orderings
+    // pick the same safe side: an overlay may sit clear of a view that is gone
+    // (harmless), never on top of one that is still there. Publishing null up
+    // front would hand overlays the corner back while a failed hide left the
+    // view on screen — the exact occlusion this rect exists to prevent.
+    publishSurfaceRect(null)
     if (
       hiddenRef.current
       && presentationRevisionRef.current === presentationRevision
@@ -559,7 +570,7 @@ function useNativeBrowserSurface(
       confirmedHiddenRevisionRef.current = presentationRevision
       onPresentationHiddenRef.current?.()
     }
-  }, [])
+  }, [publishSurfaceRect])
 
   useLayoutEffect(() => {
     onPresentationReadyRef.current = onPresentationReady
@@ -572,6 +583,7 @@ function useNativeBrowserSurface(
     lifecycleRevisionRef.current = lifecycleRevision
     const viewport = viewportRef.current
     if (!sessionId || !viewport) {
+      publishSurfaceRect(null)
       void window.api.browser.setVisible(false)
       return () => {
         if (lifecycleRevisionRef.current === lifecycleRevision) {
@@ -604,8 +616,12 @@ function useNativeBrowserSurface(
           }
           if (!bounds || bounds.width <= 0 || bounds.height <= 0) {
             await window.api.browser.setVisible(false)
+            publishSurfaceRect(null)
             continue
           }
+          // Published before the IPC round trip, not after: an overlay that steps
+          // aside must have moved by the time the view actually appears.
+          publishSurfaceRect(bounds)
           await window.api.browser.setBounds(bounds)
           if (disposed) return
           if (hiddenRef.current) {
@@ -729,10 +745,11 @@ function useNativeBrowserSurface(
       window.removeEventListener('scroll', scheduleMeasure, true)
       window.visualViewport?.removeEventListener('resize', scheduleMeasure)
       window.visualViewport?.removeEventListener('scroll', scheduleMeasure)
+      publishSurfaceRect(null)
       void window.api.browser.setVisible(false)
       void window.api.browser.activateSession(null)
     }
-  }, [hideNativeSurface, sessionId, viewportRef])
+  }, [hideNativeSurface, publishSurfaceRect, sessionId, viewportRef])
 
   useLayoutEffect(() => {
     hiddenRef.current = hidden

--- a/desktop/apps/electron/src/renderer/components/app/__tests__/AutoUpdateBanner.test.tsx
+++ b/desktop/apps/electron/src/renderer/components/app/__tests__/AutoUpdateBanner.test.tsx
@@ -18,7 +18,7 @@ GlobalRegistrator.register()
 
 const { act } = await import('react')
 const { createRoot } = await import('react-dom/client')
-const { atom } = await import('jotai')
+const { atom, getDefaultStore } = await import('jotai')
 // The activity probe is a Jotai write atom talking to the daemon; there is no
 // daemon here, so swap the module before the component imports it. `mock.module`
 // must run before that import for the substitution to take.
@@ -36,6 +36,7 @@ mock.module('@/atoms/update', () => {
   }
 })
 
+const { browserSurfaceBlockedAtom, setNativeSurfaceRectAtom } = await import('@/atoms/browser')
 const { AutoUpdateBanner, nextView } = await import('../AutoUpdateBanner')
 
 /** Drive the mocked probe: mirrors what `GET /api/agent/status` would answer. */
@@ -264,5 +265,83 @@ describe('AutoUpdateBanner', () => {
 
     expect(installNow).toHaveBeenCalledTimes(1)
     await cleanup()
+  })
+
+  it('steps left of the embedded Browser instead of sitting under it', async () => {
+    // The card is anchored bottom-right — exactly where the Browser's
+    // WebContentsView sits. That view composites above this page, so `z-50` buys
+    // nothing: staying put means the card is invisible except for the sliver
+    // beside the dock rail. It moves rather than hiding the view, because it is
+    // non-modal and can sit in the corner for as long as the user ignores it.
+    const store = getDefaultStore()
+    const { host, emit, cleanup } = await mountBanner()
+    const cardRight = () => (
+      host.querySelector<HTMLElement>('[data-testid="auto-update-banner"]')?.style.right
+    )
+
+    await emit({ type: 'downloaded', info: { version: '2.1.0' } })
+    expect(cardRight()).toBe('16px')
+
+    // The browser opens while the card is already up — the common case, and the
+    // one a position measured once at mount would get wrong.
+    await act(async () => {
+      store.set(setNativeSurfaceRectAtom, {
+        x: window.innerWidth - 500,
+        y: 100,
+        width: 420,
+        height: 400,
+      })
+    })
+    expect(cardRight()).toBe('516px')
+
+    // Browser closes → the card reclaims the corner.
+    await act(async () => { store.set(setNativeSurfaceRectAtom, null) })
+    expect(cardRight()).toBe('16px')
+
+    await cleanup()
+  })
+
+  it('does not hide the browser when there is room to step aside', async () => {
+    // Blanking a whole web page to make room for a corner card reads as a bug.
+    // Blocking the surface is the fallback, not the default.
+    const store = getDefaultStore()
+    const { emit, cleanup } = await mountBanner()
+
+    await emit({ type: 'downloaded', info: { version: '2.1.0' } })
+    expect(store.get(browserSurfaceBlockedAtom)).toBe(false)
+
+    await act(async () => {
+      store.set(setNativeSurfaceRectAtom, {
+        x: window.innerWidth - 500, y: 100, width: 420, height: 400,
+      })
+    })
+    expect(store.get(browserSurfaceBlockedAtom)).toBe(false)
+
+    await act(async () => { store.set(setNativeSurfaceRectAtom, null) })
+    await cleanup()
+  })
+
+  it('falls back to hiding the browser when nothing is left to step into', async () => {
+    // Expanded Browser: the surface starts at the sidebar's edge, so the free
+    // column is far narrower than the card. Stepping aside there would push the
+    // card off-screen or straight back under the view.
+    const store = getDefaultStore()
+    const { host, emit, cleanup } = await mountBanner()
+    await act(async () => {
+      store.set(setNativeSurfaceRectAtom, { x: 200, y: 40, width: 900, height: 700 })
+    })
+
+    await emit({ type: 'downloaded', info: { version: '2.1.0' } })
+    expect(store.get(browserSurfaceBlockedAtom)).toBe(true)
+    // Blocked, so it stays in its natural corner rather than dodging a view
+    // that is no longer there.
+    expect(
+      host.querySelector<HTMLElement>('[data-testid="auto-update-banner"]')?.style.right,
+    ).toBe('16px')
+
+    // Closing the card must release the surface — the browser is unusable until it does.
+    await cleanup()
+    expect(store.get(browserSurfaceBlockedAtom)).toBe(false)
+    await act(async () => { store.set(setNativeSurfaceRectAtom, null) })
   })
 })

--- a/desktop/apps/electron/src/renderer/components/app/__tests__/EmbeddedBrowserPanel.test.tsx
+++ b/desktop/apps/electron/src/renderer/components/app/__tests__/EmbeddedBrowserPanel.test.tsx
@@ -16,13 +16,14 @@ const {
   browserExpandedAtom,
   browserSurfaceBlockedAtom,
   embeddedBrowserSnapshotAtom,
+  nativeSurfaceRectAtom,
   setEmbeddedBrowserSnapshotAtom,
   setBrowserSurfaceBlockerAtom,
 } = await import('@/atoms/browser')
 const {
   BROWSER_OVERFLOW_INSPECTION_DELAY_MS,
 } = await import('@/hooks/useBrowserOverflowReminder')
-const { closeIssueReportAtom, openIssueReportAtom } = await import('@/atoms/issue-report')
+const { ModalBackdrop } = await import('@/components/amphi/ModalBackdrop')
 const { activeSessionIdAtom } = await import('@/atoms/sessions')
 const {
   EmbeddedBrowserPanel,
@@ -1020,7 +1021,10 @@ describe('EmbeddedBrowserPanel', () => {
     await act(async () => root.unmount())
   })
 
-  it('hides the native browser while issue feedback is open and restores it after closing', async () => {
+  // Not tied to one feature any more: every dialog reaches the native surface
+  // through `ModalBackdrop`, so this covers the whole class at the seam that
+  // matters instead of standing in for it with the issue-report atom.
+  it('hides the native browser while a dialog is open and restores it after closing', async () => {
     const calls = browserApiCalls()
     const host = document.createElement('div')
     document.body.appendChild(host)
@@ -1030,9 +1034,15 @@ describe('EmbeddedBrowserPanel', () => {
     store.set(embeddedBrowserSnapshotAtom, {
       sessions: [{ sessionId: 'session-a', activeTabId: 'tab-a', tabs: [tab()] }],
     })
+    const renderWithDialog = (dialogOpen: boolean) => withZhTranslation(
+      <Provider store={store}>
+        <EmbeddedBrowserPanel />
+        {dialogOpen ? <ModalBackdrop><span>dialog</span></ModalBackdrop> : null}
+      </Provider>,
+    )
 
     await act(async () => {
-      root.render(withZhTranslation(<Provider store={store}><EmbeddedBrowserPanel /></Provider>))
+      root.render(renderWithDialog(false))
     })
     const canvas = host.querySelector<HTMLElement>('[data-testid="browser-canvas"]')!
     canvas.getBoundingClientRect = () => ({
@@ -1054,13 +1064,13 @@ describe('EmbeddedBrowserPanel', () => {
     expect(calls.at(-1)).toBe('setVisible:true')
 
     await act(async () => {
-      store.set(openIssueReportAtom, { source: 'renderer' })
+      root.render(renderWithDialog(true))
       await Promise.resolve()
     })
     expect(calls.at(-1)).toBe('setVisible:false')
 
     await act(async () => {
-      store.set(closeIssueReportAtom)
+      root.render(renderWithDialog(false))
       await Promise.resolve()
     })
     await act(async () => {
@@ -1071,6 +1081,50 @@ describe('EmbeddedBrowserPanel', () => {
     expect(calls.at(-1)).toBe('setVisible:true')
 
     await act(async () => root.unmount())
+  })
+
+  // Overlays that dodge the native view instead of blocking it (the update card,
+  // the sched-freq popover) read this rect. It has to track the same measurement
+  // that goes over IPC, or they dodge to the wrong place — or, worse, sit under a
+  // view they believe is not there.
+  it('publishes the native surface rect while presenting, and clears it when it stops', async () => {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const root = createRoot(host)
+    const store = createStore()
+    store.set(activeSessionIdAtom, 'session-a')
+    store.set(embeddedBrowserSnapshotAtom, {
+      sessions: [{ sessionId: 'session-a', activeTabId: 'tab-a', tabs: [tab()] }],
+    })
+
+    await act(async () => {
+      root.render(withZhTranslation(<Provider store={store}><EmbeddedBrowserPanel /></Provider>))
+    })
+    expect(store.get(nativeSurfaceRectAtom)).toBeNull()
+
+    const canvas = host.querySelector<HTMLElement>('[data-testid="browser-canvas"]')!
+    canvas.getBoundingClientRect = () => ({
+      x: 420,
+      y: 96,
+      width: 640,
+      height: 600,
+      top: 96,
+      right: 1060,
+      bottom: 696,
+      left: 420,
+      toJSON: () => ({}),
+    })
+    await act(async () => {
+      animationFrame?.(0)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(store.get(nativeSurfaceRectAtom)).toEqual({ x: 420, y: 96, width: 640, height: 600 })
+
+    // Unmounting is the panel's own "the view is gone" path; leaving a stale rect
+    // behind would keep every overlay dodging an empty rectangle forever.
+    await act(async () => root.unmount())
+    expect(store.get(nativeSurfaceRectAtom)).toBeNull()
   })
 
   it('shows a renderer-owned empty state when a Session has no active tab', async () => {

--- a/desktop/apps/electron/src/renderer/components/composer/widgets/SchedFreqWidget.tsx
+++ b/desktop/apps/electron/src/renderer/components/composer/widgets/SchedFreqWidget.tsx
@@ -8,7 +8,10 @@
  * composer's overflow clipping; keydown inside is stopped so it won't reach the
  * composer's send/menu handlers. Registers kind `'sched-freq'`.
  *
- * Positioning invariant: the popover **must land entirely inside the viewport**. The
+ * Positioning invariant: the popover **must land entirely inside the region the
+ * renderer actually paints** — inside the viewport, and to the left of the embedded
+ * Browser's native surface, which composites above this page and would swallow any
+ * overlapping part outright. It narrows before it overflows either edge. The
  * chip lives inside the composer and the composer is pinned to the bottom of the window,
  * so "always open downward" inevitably pushes the popover past the bottom edge of the
  * screen — the user simply cannot click it (we actually hit this).
@@ -32,8 +35,9 @@ import {
   type CronState,
 } from '@/lib/cron'
 import { Icons } from '@/components/amphi'
+import { useOverlayRightLimit } from '@/hooks/useOverlayRightLimit'
 import { throttleRaf } from '@/lib/throttleRaf'
-import { computePopoverPos, POPOVER_WIDTH, type PopoverPos } from './popoverPos'
+import { computePopoverPos, type PopoverPos } from './popoverPos'
 import { registerWidget, WidgetKind, type WidgetViewProps } from './registry'
 
 const buildPeriodOpts = (t: TFunction): { value: CronPeriod; label: string }[] => [
@@ -235,13 +239,21 @@ function PeriodFields({ st, set }: { st: CronState; set: (k: keyof CronState, v:
   return <div className="flex flex-wrap items-center gap-x-2 gap-y-2.5">{timeFields}</div>
 }
 
-const viewportSize = () => ({ width: window.innerWidth, height: window.innerHeight })
+// `rightLimit` comes from the caller (`useOverlayRightLimit`): the embedded
+// Browser paints over this page, and the popover keeps to its left rather than
+// blanking the browser for a dropdown.
+const viewportSize = (rightLimit: number) => ({
+  width: window.innerWidth,
+  height: window.innerHeight,
+  rightLimit,
+})
 
 /** Whether two positions are equivalent — used to skip pointless re-renders while scrolling. */
 function samePos(a: PopoverPos | null, b: PopoverPos): boolean {
   return (
     a != null
     && a.left === b.left
+    && a.width === b.width
     && a.top === b.top
     && a.bottom === b.bottom
     && a.maxHeight === b.maxHeight
@@ -258,6 +270,7 @@ export function SchedFreqWidget({ value, onChange }: WidgetViewProps) {
   const [pos, setPos] = useState<PopoverPos | null>(null)
   const chipRef = useRef<HTMLButtonElement>(null)
   const popoverRef = useRef<HTMLDivElement>(null)
+  const rightLimit = useOverlayRightLimit()
 
   const cron = buildCron(st)
 
@@ -273,7 +286,7 @@ export function SchedFreqWidget({ value, onChange }: WidgetViewProps) {
   // intermediate state and nothing has to be hidden on the first frame.
   const toggle = () => {
     const anchor = chipRef.current?.getBoundingClientRect()
-    if (anchor) setPos(computePopoverPos(anchor, viewportSize()))
+    if (anchor) setPos(computePopoverPos(anchor, viewportSize(rightLimit)))
     setOpen((o) => !o)
   }
 
@@ -287,12 +300,16 @@ export function SchedFreqWidget({ value, onChange }: WidgetViewProps) {
     const place = () => {
       const anchor = chipRef.current?.getBoundingClientRect()
       if (!anchor) return
-      const next = computePopoverPos(anchor, viewportSize())
+      const next = computePopoverPos(anchor, viewportSize(rightLimit))
       // Skip setState when the value did not change: scroll fires once per frame, and
       // setting blindly would re-render the whole popover (Sel + PeriodFields + preview)
       // every frame.
       setPos((prev) => (samePos(prev, next) ? prev : next))
     }
+    // Re-place immediately, not only on the listeners below: `rightLimit` changes
+    // when the browser appears or its dock is resized, and an already-open popover
+    // would otherwise sink underneath the native view it was placed to avoid.
+    place()
     const schedulePlace = throttleRaf(place)
     // scroll uses the capture phase: what scrolls is an ancestor container (composer /
     // message list), and the event does not bubble to window.
@@ -303,7 +320,7 @@ export function SchedFreqWidget({ value, onChange }: WidgetViewProps) {
       window.removeEventListener('resize', schedulePlace)
       window.removeEventListener('scroll', schedulePlace, true)
     }
-  }, [open])
+  }, [open, rightLimit])
 
   // Close on outside mousedown / Esc while open.
   useEffect(() => {
@@ -346,18 +363,17 @@ export function SchedFreqWidget({ value, onChange }: WidgetViewProps) {
             ref={popoverRef}
             onKeyDown={(e) => e.stopPropagation()}
             className="fixed z-[110] overflow-y-auto bg-bg-modal border border-border-default rounded-xl shadow-modal p-4 flex flex-col gap-4"
-            // width comes from POPOVER_WIDTH instead of a hard-coded `w-[420px]`:
-            // computePopoverPos clamps the left offset against that same constant, so
-            // writing it twice would drift silently — widen it without updating the
-            // constant and the popover's right edge runs off screen when the chip sits
-            // near the right side, while the unit tests stay green.
+            // Width is part of the placement, not a class: computePopoverPos narrows it
+            // when the free column cannot hold POPOVER_WIDTH, and it clamps `left` against
+            // whatever width it settled on. Writing the width here as well would drift
+            // silently from the offset it was clamped with.
             //
             // Exactly one of top / bottom is set: opening upward must anchor via bottom,
             // otherwise positioning would depend on the popover height (see the infinite
             // loop in the popoverPos.ts header). maxHeight is always present, so
             // overflowing content scrolls inside the popover instead of overturning the
             // placement.
-            style={{ width: POPOVER_WIDTH, ...pos }}
+            style={{ ...pos }}
           >
             {/* Frequency mode */}
             <div className="flex items-center gap-2.5">

--- a/desktop/apps/electron/src/renderer/components/composer/widgets/__tests__/schedFreqPos.test.ts
+++ b/desktop/apps/electron/src/renderer/components/composer/widgets/__tests__/schedFreqPos.test.ts
@@ -22,7 +22,7 @@ describe('computePopoverPos', () => {
     // 反馈环就构造不出来。签名变了(比如有人加回 popoverHeight 参数)这里会红。
     expect(computePopoverPos.length).toBe(2)
     const pos = computePopoverPos({ top: 100, bottom: 124, left: 300 }, VIEWPORT)
-    expect(Object.keys(pos).sort()).toEqual(['left', 'maxHeight', 'top'])
+    expect(Object.keys(pos).sort()).toEqual(['left', 'maxHeight', 'top', 'width'])
   })
 
   it('opens downward when below is the roomier side', () => {
@@ -68,6 +68,33 @@ describe('computePopoverPos', () => {
   it('clamps left to the right edge when the chip sits far right', () => {
     const pos = computePopoverPos({ top: 100, bottom: 124, left: 1200 }, VIEWPORT)
     expect(pos.left).toBe(VIEWPORT.width - POPOVER_WIDTH - 8)
+  })
+
+  // The embedded Browser is an Electron WebContentsView composited above the page:
+  // anything the popover puts past its left edge is not dimmed or clipped, it is
+  // simply invisible. `rightLimit` is that edge.
+  it('stops at the native Browser surface instead of sliding under it', () => {
+    const withBrowser = { width: 1280, height: 800, rightLimit: 900 }
+    const pos = computePopoverPos({ top: 100, bottom: 124, left: 700 }, withBrowser)
+    expect(pos.width).toBe(POPOVER_WIDTH)
+    expect(pos.left + pos.width).toBeLessThanOrEqual(withBrowser.rightLimit)
+  })
+
+  it('narrows rather than hiding when the free column cannot fit the full width', () => {
+    // Reachable on an ordinary window: dragging the browser dock to its widest
+    // leaves the centre column under 420px. The picker's fields already wrap, so
+    // a narrower popover degrades gracefully — sliding under the browser does not.
+    const squeezed = { width: 1280, height: 800, rightLimit: 300 }
+    const pos = computePopoverPos({ top: 100, bottom: 124, left: 120 }, squeezed)
+    expect(pos.width).toBeLessThan(POPOVER_WIDTH)
+    expect(pos.left).toBeGreaterThanOrEqual(8)
+    expect(pos.left + pos.width).toBeLessThanOrEqual(squeezed.rightLimit)
+  })
+
+  it('falls back to the viewport when no native surface is on screen', () => {
+    const pos = computePopoverPos({ top: 100, bottom: 124, left: 1200 }, VIEWPORT)
+    expect(pos.width).toBe(POPOVER_WIDTH)
+    expect(pos.left + pos.width).toBeLessThanOrEqual(VIEWPORT.width)
   })
 
   it('never returns a negative maxHeight in a degenerate viewport', () => {

--- a/desktop/apps/electron/src/renderer/components/composer/widgets/popoverPos.ts
+++ b/desktop/apps/electron/src/renderer/components/composer/widgets/popoverPos.ts
@@ -23,7 +23,7 @@
  * Merging would first require unifying the alignment axis, which is a separate change.
  */
 
-/** Popover width — consumers set `width` from it, and the left-offset math uses it too. */
+/** Popover width when there is room for it; narrower when the free column cannot fit it. */
 export const POPOVER_WIDTH = 420
 /** Breathing gap between the anchor and the popover. */
 export const POPOVER_GAP = 6
@@ -37,10 +37,18 @@ export interface PopoverAnchor {
   left: number
 }
 
-/** Viewport size (`window.innerWidth/innerHeight`). */
+/** Viewport size (`window.innerWidth/innerHeight`), plus how far right the renderer may paint. */
 export interface Viewport {
   width: number
   height: number
+  /**
+   * Right-most x this popover may occupy; defaults to `width`.
+   *
+   * The embedded Browser is an Electron `WebContentsView` composited ABOVE the
+   * page, so anything placed past its left edge is not dimmed or clipped — it is
+   * invisible. Callers pass that edge here (see `lib/overlayBounds.ts`).
+   */
+  rightLimit?: number
 }
 
 /**
@@ -52,6 +60,8 @@ export interface Viewport {
  */
 export interface PopoverPos {
   left: number
+  /** `POPOVER_WIDTH`, or narrower when that is all the free column can hold. */
+  width: number
   top?: number
   bottom?: number
   /** Headroom on that side; content that overflows scrolls inside the popover. */
@@ -71,16 +81,22 @@ export interface PopoverPos {
  * @param viewport current viewport size
  */
 export function computePopoverPos(anchor: PopoverAnchor, viewport: Viewport): PopoverPos {
+  const rightLimit = Math.min(viewport.rightLimit ?? viewport.width, viewport.width)
+  // Narrow before overflowing: the picker's fields already wrap, so a shorter
+  // popover stays usable, whereas the overflowing part would be swallowed whole
+  // by the native Browser surface (or run off the window).
+  const width = Math.max(0, Math.min(POPOVER_WIDTH, rightLimit - VIEWPORT_MARGIN * 2))
   // Horizontal: never hand back a negative left offset (or one smaller than the margin), even when the window is narrower than the popover.
   const left = Math.max(
     VIEWPORT_MARGIN,
-    Math.min(anchor.left, viewport.width - POPOVER_WIDTH - VIEWPORT_MARGIN),
+    Math.min(anchor.left, rightLimit - width - VIEWPORT_MARGIN),
   )
   const spaceAbove = anchor.top - VIEWPORT_MARGIN
   const spaceBelow = viewport.height - anchor.bottom - VIEWPORT_MARGIN
   if (spaceAbove >= spaceBelow) {
     return {
       left,
+      width,
       // Grow upward from the anchor's top edge — use bottom rather than top so no measuring is needed.
       bottom: viewport.height - anchor.top + POPOVER_GAP,
       maxHeight: Math.max(0, spaceAbove - POPOVER_GAP),
@@ -88,6 +104,7 @@ export function computePopoverPos(anchor: PopoverAnchor, viewport: Viewport): Po
   }
   return {
     left,
+    width,
     top: anchor.bottom + POPOVER_GAP,
     maxHeight: Math.max(0, spaceBelow - POPOVER_GAP),
   }

--- a/desktop/apps/electron/src/renderer/hooks/useBrowserSurfaceBlocker.ts
+++ b/desktop/apps/electron/src/renderer/hooks/useBrowserSurfaceBlocker.ts
@@ -1,0 +1,29 @@
+/**
+ * Hold one native-Browser-surface blocker for as long as a component needs it.
+ *
+ * The embedded Browser is an Electron `WebContentsView` added to the window's
+ * `contentView`, so the OS composites it ABOVE this page: no `z-index` can put
+ * renderer UI in front of it. The only way an overlay becomes visible over the
+ * Browser canvas is for the native view to hide first, which is what
+ * `useEmbeddedBrowserSurfaceEligible` decides from these blockers.
+ *
+ * Every `source` is independent, so stacked overlays cannot release each
+ * other's blocker — pass a per-instance id (`useId()`) when a component can be
+ * mounted more than once at a time.
+ *
+ * `useLayoutEffect`, not `useEffect`: the request has to be queued in the same
+ * commit that paints the overlay, otherwise the overlay's first frame is drawn
+ * underneath the native view.
+ */
+import { useLayoutEffect } from 'react'
+import { useSetAtom } from 'jotai'
+import { setBrowserSurfaceBlockerAtom } from '@/atoms/browser'
+
+/** Block the native Browser surface under `source` while `blocked` holds. */
+export function useBrowserSurfaceBlocker(source: string, blocked: boolean): void {
+  const setBlocker = useSetAtom(setBrowserSurfaceBlockerAtom)
+  useLayoutEffect(() => {
+    setBlocker({ source, blocked })
+    return () => setBlocker({ source, blocked: false })
+  }, [source, blocked, setBlocker])
+}

--- a/desktop/apps/electron/src/renderer/hooks/useEmbeddedBrowserSurfaceEligible.ts
+++ b/desktop/apps/electron/src/renderer/hooks/useEmbeddedBrowserSurfaceEligible.ts
@@ -4,16 +4,19 @@
  * This is eligibility, not a native show acknowledgement: renderer overlays
  * and explicit blockers can prevent presentation before Electron receives the
  * measured bounds and setVisible request.
+ *
+ * Overlays are read through ONE channel — `browserSurfaceBlockedAtom`, fed by
+ * `useBrowserSurfaceBlocker`. This used to enumerate the overlay atoms one by
+ * one instead, which meant every new global overlay had to remember to come
+ * back and edit this file, with nothing to catch it if it did not: both the
+ * auto-update card and the model picker shipped drawn underneath the native
+ * view that way. `ModalBackdrop` now registers a blocker for every dialog that
+ * wraps it, so the only overlays that need to think about this are the ones
+ * that cannot use it (YARL's lightbox, the non-blocking update card).
  */
 import { useAtomValue } from 'jotai'
 import type { EmbeddedBrowserTabInfo } from '@shared/types'
-import { activeModalAtom } from '@/atoms/amphi'
 import { browserSurfaceBlockedAtom } from '@/atoms/browser'
-import { confirmRequestAtom } from '@/atoms/confirm'
-import { externalLinkRequestAtom } from '@/atoms/external-link'
-import { issueReportRequestAtom } from '@/atoms/issue-report'
-import { lightboxItemAtom } from '@/atoms/lightbox'
-import { scheduleOverlayAtom } from '@/atoms/schedules'
 
 /** Whether renderer state allows the active native Browser page to be shown. */
 export function useEmbeddedBrowserSurfaceEligible(
@@ -21,19 +24,9 @@ export function useEmbeddedBrowserSurfaceEligible(
   activeTab: EmbeddedBrowserTabInfo | null,
 ): boolean {
   const surfaceBlocked = useAtomValue(browserSurfaceBlockedAtom)
-  const activeModal = useAtomValue(activeModalAtom)
-  const confirm = useAtomValue(confirmRequestAtom)
-  const externalLink = useAtomValue(externalLinkRequestAtom)
-  const issueReport = useAtomValue(issueReportRequestAtom)
-  const lightbox = useAtomValue(lightboxItemAtom)
-  const scheduleOverlay = useAtomValue(scheduleOverlayAtom)
-  const overlayOpen = Boolean(
-    activeModal || confirm || externalLink || issueReport || lightbox || scheduleOverlay,
-  )
 
   return presentationRequested
     && !surfaceBlocked
-    && !overlayOpen
     && activeTab !== null
     && !activeTab.crashed
 }

--- a/desktop/apps/electron/src/renderer/hooks/useOverlayRightLimit.ts
+++ b/desktop/apps/electron/src/renderer/hooks/useOverlayRightLimit.ts
@@ -1,0 +1,28 @@
+/**
+ * How far right a renderer-drawn overlay can go and still be seen.
+ *
+ * The embedded Browser is an Electron `WebContentsView` composited ABOVE this
+ * page. Whatever an overlay puts inside its rectangle is not dimmed or clipped —
+ * it is invisible, with no hint that anything is missing.
+ *
+ * Two answers to that, and which one is right depends on the overlay:
+ *
+ *   - **A dialog blocks the surface** (`useBrowserSurfaceBlocker`). It already
+ *     dims the whole window, so the browser being gone reads as intended.
+ *   - **A corner card or a dropdown steps aside** — this hook. Blanking a whole
+ *     web page to make room for a 380px card reads as a bug, not a decision, and
+ *     the card can sit there for as long as the user ignores it.
+ *
+ * Live, not measured once: the browser can appear while the overlay is already
+ * up (an agent opening a tab mid-task), and an overlay pinned at open time would
+ * quietly sink underneath it.
+ */
+import { useAtomValue } from 'jotai'
+import { nativeSurfaceRectAtom } from '@/atoms/browser'
+
+/** Right-most x an overlay may occupy: the native surface's left edge, else the window's. */
+export function useOverlayRightLimit(): number {
+  const surface = useAtomValue(nativeSurfaceRectAtom)
+  if (!surface || surface.width <= 0 || surface.height <= 0) return window.innerWidth
+  return Math.max(0, Math.min(surface.x, window.innerWidth))
+}


### PR DESCRIPTION
## The problem

The embedded browser is an Electron `WebContentsView` on the window's
`contentView`, so the compositor draws it above the renderer and **no z-index
reaches over it**. The auto-update card sits at `bottom-4 right-4`, exactly
where that view lands: everything but the sliver beside the dock rail was
invisible, with nothing to suggest anything was missing.

The same root cause hit the model picker (a component-local `useState`
rendering a Modal, absent from the old whitelist) and the sched-freq cron
popover.

## The approach

An overlay now answers this in one of two ways, chosen by what it is:

**A dialog HIDES the view.** It dims the whole window anyway, so the browser
going away reads as intended. `ModalBackdrop` registers the blocker itself,
keyed per instance so a stacked dialog closing does not uncover the browser
over the one still open. Every dialog that wraps it is covered by
construction — which is what fixes the model picker without touching it.

**A corner card or dropdown STEPS ASIDE.** Blanking a web page to make room
for a 380px card reads as a bug, and that card can sit there for as long as
the user ignores it. The update card and the cron popover read the live
surface rect and keep to its left; the popover narrows before it would
overflow (its fields already wrap). Where nothing is left to step into —
expanded browser leaves at most the sidebar's 300px, less than the card needs
— the card falls back to hiding the view. That decision is **latched**:
blocking clears the rect, so re-deciding from the rect would unblock,
re-measure and block again every frame.

## Structural change

`useEmbeddedBrowserSurfaceEligible` enumerated the overlay atoms one by one,
so every new global overlay had to remember to edit that file and nothing
caught it when it did not — both the update card and the model picker shipped
drawn underneath the view that way. It now reads a single blocker channel.

The rect is published from the panel that already measures it: **before the
show IPC, after the hide IPC**. Both orderings pick the same safe side — an
overlay may sit clear of a view that is gone (harmless), never on top of one
that is still there.

## Verification

`bun run test` 1452 pass / 0 fail; `typecheck`, `lint` and `check:chinese`
all clean.

New tests, each written failing first:

- `ModalBackdrop` — blocks while mounted, releases on unmount, stacked
  instances hold independent keys
- `AutoUpdateBanner` — steps aside and back as the rect changes (including
  the browser-appears-later path), does not block when there is room, falls
  back to blocking when there is none
- `ImageLightbox` — the one overlay with a hand-wired blocker (YARL owns its
  own portal, so it cannot use `ModalBackdrop`); confirmed red without the
  implementation
- `EmbeddedBrowserPanel` — publishes and clears the surface rect
- `computePopoverPos` — clamps to the native surface's left edge, narrows
  when it cannot fit, falls back to the viewport when no surface is on screen

Checked by hand in the running dev app: update card over a live page, model
picker, image viewer, cron popover, and the mode-surface handoff.

## Known and deliberate

The `fixed inset-0` click-catchers behind the composer and asset menus still
miss clicks that land on the native view, so those menus do not close when
the browser is clicked. That is an interaction gap, not occlusion, so it is
left out of this PR.

## Test plan

- [x] `cd desktop && bun run test`
- [x] `cd desktop && bun run typecheck`
- [x] `cd desktop && bun run lint`
- [x] `cd desktop && bun run check:chinese`
- [x] Manual: update card / model picker / image viewer / cron popover /
      mode-surface handoff
