### PR TITLE
fix(workflows): allow referencing failed run results

### DIFF
--- a/desktop/apps/electron/src/renderer/components/amphi/CenterViews.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/CenterViews.tsx
@@ -715,6 +715,7 @@ function WorkflowResultsTree({
               {open ? group.runs.map((run) => {
                 const status = runStatus(t, run)
                 const canDelete = ['completed', 'failed', 'cancelled'].includes(run.status)
+                const canUse = run.status === 'completed' || run.status === 'failed'
                 return (
                   <div key={run.id} className="relative border-t border-border-subtle bg-bg-app">
                     <button
@@ -731,7 +732,7 @@ function WorkflowResultsTree({
                       <span className={cn('w-fit rounded-full px-2 py-0.5 text-2xs font-semibold', status.tone)}>{status.label}</span>
                       <span className="font-mono text-xs text-text-secondary">{formatWorkflowRunShortTimestamp(run.created_at)}</span>
                     </button>
-                    {run.status === 'completed' ? (
+                    {canUse ? (
                       <button
                         type="button"
                         onClick={() => onUseRun(run)}

--- a/desktop/apps/electron/src/renderer/components/amphi/RightPanel.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/RightPanel.tsx
@@ -457,6 +457,7 @@ export function WorkflowRunResultCard({
 }) {
   const { t, i18n } = useTranslation()
   const completed = run.status === 'completed'
+  const reusable = completed || run.status === 'failed'
   const insertWorkflowResult = useSetAtom(useWorkflowResultAtom)
   return (
     <Card className="cursor-pointer border-l-2 border-l-brand-blue" onClick={onPreview}>
@@ -495,7 +496,7 @@ export function WorkflowRunResultCard({
               {completed ? t('rightPanel.runCompleted') : t('rightPanel.runFailed')}
             </span>
           </div>
-          {completed ? (
+          {reusable ? (
             <button
               type="button"
               onMouseDown={(event) => event.preventDefault()}

--- a/desktop/apps/electron/src/renderer/components/amphi/WorkflowResultCard.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/WorkflowResultCard.tsx
@@ -15,7 +15,7 @@ export function WorkflowResultCard({ block }: { block: WorkflowResultBlock }) {
   const openModal = useSetAtom(openModalAtom)
   const insertWorkflowResult = useSetAtom(useWorkflowResultAtom)
   const completed = block.status === 'completed'
-  const hasReusableResult = completed && block.resultFileCount !== 0
+  const hasReusableResult = block.status === 'failed' || block.resultFileCount !== 0
   const title = completed
     ? t('workflow.result.title.completed')
     : t('workflow.result.title.failed')

--- a/desktop/apps/electron/src/renderer/components/amphi/WorkflowRunDetailModal.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/WorkflowRunDetailModal.tsx
@@ -138,6 +138,7 @@ export function WorkflowRunDetailModal({
   const subtitle = detail
     ? `${formatWorkflowRunShortTimestamp(detail.created_at, i18n.language)} · ${detail.id}`
     : runId
+  const referenceable = detail?.status === 'completed' || detail?.status === 'failed'
 
   return (
     <Modal
@@ -180,7 +181,7 @@ export function WorkflowRunDetailModal({
           initialFilePath={initialFilePath}
           detailError={detailError}
           onRetryDetail={() => setDetailReloadKey((key) => key + 1)}
-          onReference={detail.status === 'completed' ? () => referenceRun(detail) : undefined}
+          onReference={referenceable ? () => referenceRun(detail) : undefined}
           referenceLabel={
             composerTarget === ComposerTarget.NewSession ? t('workflow.runDetail.useInNewSession') : t('workflow.common.useResult')
           }

--- a/desktop/apps/electron/src/renderer/components/amphi/__tests__/CenterViews.test.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/__tests__/CenterViews.test.tsx
@@ -239,6 +239,17 @@ describe('CenterAssets', () => {
             created_at: '2026-07-21T08:00:00Z',
             finished_at: '2026-07-21T08:01:00Z',
           },
+          {
+            id: 'wfr_failed',
+            workflow_id: 'wf_1',
+            workflow_name: '论文发现与主题相关性筛选',
+            source_session_id: 'session_1',
+            workflow_input: { text: '失败的筛选运行', blocks: [] },
+            status: 'failed',
+            validation_status: 'failed',
+            created_at: '2026-07-23T08:00:00Z',
+            finished_at: '2026-07-23T08:01:00Z',
+          },
         ])
       }
       return jsonResponse({})
@@ -258,7 +269,7 @@ describe('CenterAssets', () => {
     expect(host.textContent).toContain('—') // folder size cell = placeholder
     expect(host.textContent).toContain('Agent 上下文压缩论文')
     expect(host.textContent).toContain('论文发现与主题相关性筛选')
-    expect(host.textContent).toContain('2 次运行')
+    expect(host.textContent).toContain('3 次运行')
     expect(host.textContent).not.toContain('用户画像.xlsx')
 
     const workflowButton = Array.from(host.querySelectorAll('button'))
@@ -276,14 +287,14 @@ describe('CenterAssets', () => {
       composerTarget: ComposerTarget.NewSession,
     })
 
-    const useResult = host.querySelector<HTMLButtonElement>(
-      'button[aria-label="在新会话中使用结果 wfr_1"]',
+    const useFailedResult = host.querySelector<HTMLButtonElement>(
+      'button[aria-label="在新会话中使用结果 wfr_failed"]',
     )
-    await act(async () => useResult?.click())
+    await act(async () => useFailedResult?.click())
     expect(store.get(activeSessionIdAtom)).toBe(DRAFT_SESSION_ID)
     expect(store.get(pendingComposerSeedAtom)?.segments[0]).toMatchObject({
       type: 'mention',
-      id: 'wfr_1',
+      id: 'wfr_failed',
       group: 'WorkflowRun',
     })
     await act(async () => root.unmount())

--- a/desktop/apps/electron/src/renderer/components/amphi/__tests__/WorkflowOutputCards.test.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/__tests__/WorkflowOutputCards.test.tsx
@@ -328,7 +328,7 @@ describe('Workflow output cards', () => {
     await act(async () => root.unmount())
   })
 
-  it('uses a completed right-panel result in the current conversation', async () => {
+  it('uses completed and failed right-panel results in the current conversation', async () => {
     const store = createStore()
     store.set(activeSessionIdAtom, 'session-existing')
     let previewCount = 0
@@ -364,6 +364,32 @@ describe('Workflow output cards', () => {
     expect(store.get(pendingComposerInsertsAtom)[0]?.[0]).toMatchObject({
       type: 'mention',
       id: 'wfr-report',
+      group: 'WorkflowRun',
+    })
+
+    await act(async () => {
+      root.render(
+        <Provider store={store}>
+          <WorkflowRunResultCard
+            run={{
+              ...run,
+              id: 'wfr-report-failed',
+              status: 'failed',
+              validation_status: 'failed',
+            }}
+            onPreview={() => { previewCount += 1 }}
+          />
+        </Provider>,
+      )
+    })
+    const useFailedResult = Array.from(host.querySelectorAll<HTMLButtonElement>('button'))
+      .find((button) => button.textContent?.includes('使用结果'))
+    await act(async () => useFailedResult?.click())
+
+    expect(previewCount).toBe(0)
+    expect(store.get(pendingComposerInsertsAtom)[1]?.[0]).toMatchObject({
+      type: 'mention',
+      id: 'wfr-report-failed',
       group: 'WorkflowRun',
     })
 
@@ -479,7 +505,16 @@ describe('Workflow output cards', () => {
     expect(host.textContent).toContain('工作流执行失败')
     expect(host.textContent).toContain('本次运行已结束')
     expect(host.textContent).toContain('查看失败详情')
-    expect(host.textContent).not.toContain('引用结果')
+    expect(host.textContent).toContain('引用结果')
+
+    const reuseFailedResult = Array.from(host.querySelectorAll<HTMLButtonElement>('button'))
+      .find((button) => button.textContent?.includes('引用结果'))
+    await act(async () => reuseFailedResult?.click())
+    expect(store.get(pendingComposerInsertsAtom)[0]?.[0]).toMatchObject({
+      type: 'mention',
+      id: 'wfr-report',
+      group: 'WorkflowRun',
+    })
 
     await act(async () => root.unmount())
   })

--- a/desktop/apps/electron/src/renderer/components/amphi/__tests__/WorkflowRunDetailModal.test.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/__tests__/WorkflowRunDetailModal.test.tsx
@@ -196,8 +196,16 @@ describe('WorkflowRunDetailModal', () => {
     await act(async () => root.unmount())
   })
 
-  it('inserts a Workflow Run reference for continuing the conversation', async () => {
-    const run = { ...deletedWorkflowRun, id: 'wfr-live-source', workflow_id: 'wf-live', workflow_name: '可用工作流', files: [] }
+  it('inserts a failed Workflow Run reference for continuing the conversation', async () => {
+    const run = {
+      ...deletedWorkflowRun,
+      id: 'wfr-live-source',
+      workflow_id: 'wf-live',
+      workflow_name: '可用工作流',
+      status: 'failed' as const,
+      validation_status: 'failed' as const,
+      files: [],
+    }
     const fetchMock = mock(async (input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : input.toString()
       const pathname = new URL(url).pathname

--- a/desktop/apps/electron/src/renderer/components/app/WorkflowResultsPanel.tsx
+++ b/desktop/apps/electron/src/renderer/components/app/WorkflowResultsPanel.tsx
@@ -128,9 +128,9 @@ function WorkflowResultsPanelForSession({
           key={run.id}
           run={run}
           onOpen={() => openRun(run)}
-          onReference={effectiveResultStatus(run) === 'completed'
-            ? () => referenceRun(run)
-            : undefined}
+          onReference={effectiveResultStatus(run) === 'other'
+            ? undefined
+            : () => referenceRun(run)}
         />
       ))}
     </div>

--- a/desktop/apps/electron/src/renderer/components/app/__tests__/WorkflowResultsSchedulePanels.test.tsx
+++ b/desktop/apps/electron/src/renderer/components/app/__tests__/WorkflowResultsSchedulePanels.test.tsx
@@ -70,7 +70,7 @@ async function flushEffects() {
 }
 
 describe('WorkflowResultsPanel', () => {
-  it('separates Session/all results, filters failed runs and references a completed result in place', async () => {
+  it('separates Session/all results, filters failed runs and references terminal results in place', async () => {
     const store = readyStore()
     store.set(activeSessionIdAtom, 'session-results')
     const completed = {
@@ -140,6 +140,17 @@ describe('WorkflowResultsPanel', () => {
     })
     expect(host.querySelector('[data-testid="workflow-result-run-completed"]')).toBeNull()
     expect(host.querySelector('[data-testid="workflow-result-run-failed"]')).not.toBeNull()
+
+    await act(async () => {
+      host.querySelector<HTMLButtonElement>(
+        '[data-testid="workflow-result-reference-run-failed"]',
+      )?.click()
+    })
+    expect(store.get(pendingComposerInsertsAtom).at(-1)?.[0]).toMatchObject({
+      type: 'mention',
+      id: 'run-failed',
+      group: 'WorkflowRun',
+    })
 
     await act(async () => {
       host.querySelector<HTMLButtonElement>('[data-testid="workflow-result-view-run-failed"]')?.click()


### PR DESCRIPTION
## Summary

- allow failed Workflow Runs to be referenced from the conversation receipt, results panel, right panel, run detail, and Assets center
- preserve the existing behavior that hides the action for successful runs with an explicit zero result-file count
- add regression coverage for current-session and new-session reference insertion

## Testing

- targeted renderer tests: 29 passed, 0 failed
- Electron TypeScript check
- pre-commit full ESLint and TypeScript checks