### PR TITLE
fix: preserve managed runtime environments across updates

### DIFF
--- a/src/amphi_agent/runtime/_node_env.py
+++ b/src/amphi_agent/runtime/_node_env.py
@@ -8,7 +8,6 @@ import re
 import shutil
 import subprocess
 import sys
-import tempfile
 import threading
 from functools import cache
 from pathlib import Path
@@ -16,10 +15,9 @@ from typing import MutableMapping, Optional
 
 from filelock import FileLock, Timeout as FileLockTimeout
 
-from ._errors import BundledRuntimeUnavailable
+from ._errors import BundledRuntimeUnavailable, EnvNotReady
 from ._probe import (
     BaseProbe,
-    UnreadableBaseGuard,
     is_directory,
     is_regular_file,
     probe_base,
@@ -354,7 +352,6 @@ class BundledNodeBaseRuntime:
         self._process_lock = threading.Lock()
         self._node_fingerprint: Optional[tuple[Path, str]] = None
         self._ready = False
-        self._unreadable = UnreadableBaseGuard()
 
     @property
     def modules_dir(self) -> Path:
@@ -390,12 +387,9 @@ class BundledNodeBaseRuntime:
         Path, optional
             Shared base root, or ``None`` when no packaged Node exists.
 
-        Raises
-        ------
-        EnvNotReady
-            While the existing base cannot be read. Rebuilding is only ever the
-            answer to a base that reads as broken; one that stays unreadable
-            past :data:`~._probe.QUARANTINE_GRACE_SEC` is moved aside instead.
+        Existing package directories are never replaced to answer a runtime
+        update. Identity, resolver, and npm shims are refreshed in place while
+        node_modules and package commands remain untouched.
         """
         node = self.node_runtime.executable()
         if node is None:
@@ -414,30 +408,24 @@ class BundledNodeBaseRuntime:
         expected_files = self._expected_files(npm_cli, npx_cli)
 
         with self._process_lock:
-            try:
-                # An unreadable base falls through to the locked path rather
-                # than raising here: moving one aside is only safe while
-                # holding the cross-process lock.
-                if (
-                    self._ready
-                    and not self.cache.is_symlink()
-                    and self.cache.is_dir()
-                    and self._probe_available(self.root, identity, expected_files).usable
-                ):
-                    return self.root
-                parent = self._prepare_parent()
-                try:
-                    with FileLock(parent / ".base.lock", timeout=self.PREPARE_TIMEOUT_SEC):
-                        self._recover_interrupted_install(identity)
-                        self._prepare_base(identity, expected_files)
-                except FileLockTimeout as exc:
-                    raise RuntimeError(
-                        "Timed out waiting for the shared Node base"
-                    ) from exc
-                self._ready = True
+            if (
+                self._ready
+                and not self.cache.is_symlink()
+                and self.cache.is_dir()
+                and self._probe_available(self.root, identity, expected_files).usable
+            ):
                 return self.root
-            finally:
-                self._unreadable.close_round()
+            parent = self._prepare_parent()
+            try:
+                with FileLock(parent / ".base.lock", timeout=self.PREPARE_TIMEOUT_SEC):
+                    self._recover_interrupted_install()
+                    self._prepare_base(identity, expected_files)
+            except FileLockTimeout as exc:
+                raise RuntimeError(
+                    "Timed out waiting for the shared Node base"
+                ) from exc
+            self._ready = True
+            return self.root
 
     def _prepare_base(
         self,
@@ -445,21 +433,21 @@ class BundledNodeBaseRuntime:
         expected_files: dict[Path, str],
     ) -> None:
         """Bring the base up to ``identity`` and ``expected_files`` in place."""
-        if not self._settle(self._probe_compatible(self.root, identity)).usable:
-            self._create(identity, expected_files)
-            return
-        if self._settle(
-            self._probe_support_files(self.root, expected_files)
-        ).usable:
-            return
-        # Settling may have moved the whole base aside, and refreshing shims
-        # into a root that is no longer there would leave a husk holding
-        # nothing but the shims -- returned as ready, with every installed
-        # package gone from the environment it claims to be.
-        if self._probe_compatible(self.root, identity).usable:
+        compatible = self._probe_compatible(self.root, identity)
+        if compatible.unreadable:
+            raise EnvNotReady(compatible.path, compatible.error)
+        if not compatible.usable:
+            self._ensure_layout()
             self._refresh_support_files(expected_files)
-        else:
-            self._create(identity, expected_files)
+            self._write_manifest(identity)
+            if not self._probe_available(self.root, identity, expected_files).usable:
+                raise RuntimeError("Failed to prepare the shared Node base")
+            return
+        support = self._probe_support_files(self.root, expected_files)
+        if support.unreadable:
+            raise EnvNotReady(support.path, support.error)
+        if not support.usable:
+            self._refresh_support_files(expected_files)
 
     def apply(self, target: MutableMapping[str, str]) -> None:
         """Inject packaged Node and the shared dependency base into a command."""
@@ -490,68 +478,26 @@ class BundledNodeBaseRuntime:
         """Forget process-local readiness without deleting the shared base."""
         self._node_fingerprint = None
         self._ready = False
-        self._unreadable.forget()
 
-    def _create(
-        self,
-        identity: dict[str, object],
-        expected_files: dict[Path, str],
-    ) -> None:
-        stage = Path(tempfile.mkdtemp(prefix=".base.stage.", dir=self.root.parent))
-        backup: Optional[Path] = None
-        try:
-            self._stage_files(stage, identity, expected_files)
-            if not self._probe_available(stage, identity, expected_files).usable:
-                raise RuntimeError("Failed to prepare the shared Node base")
-            if self.root.exists() or self.root.is_symlink():
-                backup = Path(tempfile.mkdtemp(prefix=".base.backup.", dir=self.root.parent))
-                backup.rmdir()
-                os.replace(self.root, backup)
-            try:
-                os.replace(stage, self.root)
-            except BaseException:
-                if backup is not None:
-                    preserved_backup = backup
-                    try:
-                        os.replace(backup, self.root)
-                    except BaseException:
-                        backup = None
-                        logger.exception(
-                            "Failed to restore the previous Node base; backup preserved at %s",
-                            preserved_backup,
-                        )
-                        raise
-                    else:
-                        backup = None
-                raise
-            if backup is not None:
-                self._remove(backup)
-                backup = None
-        finally:
-            self._remove(stage)
-            if backup is not None:
-                self._remove(backup)
-
-    def _stage_files(
-        self,
-        stage: Path,
-        identity: dict[str, object],
-        expected_files: dict[Path, str],
-    ) -> None:
-        modules_relative = self.modules_dir.relative_to(self.root)
-        bin_relative = self.bin_dir.relative_to(self.root)
-        (stage / modules_relative).mkdir(parents=True, exist_ok=True)
-        (stage / bin_relative).mkdir(parents=True, exist_ok=True)
-        for relative, content in expected_files.items():
-            destination = stage / relative
-            destination.parent.mkdir(parents=True, exist_ok=True)
-            destination.write_text(content, encoding="utf-8", newline="")
-            if not self._is_windows() and relative.parent.name == "bin":
-                destination.chmod(0o755)
-        (stage / self.MANIFEST_NAME).write_text(
-            json.dumps(identity, ensure_ascii=False, sort_keys=True),
-            encoding="utf-8",
+    def _ensure_layout(self) -> None:
+        directories = (
+            self.root,
+            self.root / ".amphi",
+            self.shim_dir,
+            self.modules_dir,
+            self.bin_dir,
         )
+        for directory in directories:
+            try:
+                directory.mkdir(parents=True, exist_ok=True)
+            except OSError as exc:
+                raise RuntimeError(
+                    f"Cannot repair the shared Node base at {directory}; preserving existing files"
+                ) from exc
+            if not is_directory(directory):
+                raise RuntimeError(
+                    f"The shared Node path at {directory} is not a directory; preserving it unchanged"
+                )
 
     def _refresh_support_files(self, expected_files: dict[Path, str]) -> None:
         for relative, content in expected_files.items():
@@ -567,6 +513,20 @@ class BundledNodeBaseRuntime:
                 os.replace(temporary, destination)
             finally:
                 temporary.unlink(missing_ok=True)
+
+    def _write_manifest(self, identity: dict[str, object]) -> None:
+        destination = self.root / self.MANIFEST_NAME
+        temporary = destination.with_name(
+            f".{destination.name}.tmp.{os.getpid()}.{threading.get_ident()}"
+        )
+        try:
+            temporary.write_text(
+                json.dumps(identity, ensure_ascii=False, sort_keys=True),
+                encoding="utf-8",
+            )
+            os.replace(temporary, destination)
+        finally:
+            temporary.unlink(missing_ok=True)
 
     def _runtime_identity(self, node: Path) -> dict[str, object]:
         resolved_node = node.expanduser().resolve()
@@ -1008,40 +968,35 @@ if (require.main === module) {{
             raise RuntimeError("The app-level npm cache is unavailable")
         return parent
 
-    def _recover_interrupted_install(
-        self,
-        identity: dict[str, object],
-    ) -> None:
+    def _recover_interrupted_install(self) -> None:
+        """Recover the last complete base without deleting any saved environment."""
         for stage in self.root.parent.glob(".base.stage.*"):
             self._remove(stage)
         backups = sorted(self.root.parent.glob(".base.backup.*"), reverse=True)
-        if self._settle(self._probe_compatible(self.root, identity)).usable:
-            for backup in backups:
-                self._remove(backup)
+        try:
+            self.root.lstat()
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            raise EnvNotReady(self.root, exc) from exc
+        else:
             return
-        probes = {
-            backup: self._probe_compatible(backup, identity) for backup in backups
-        }
-        reusable = next(
-            (backup for backup, probe in probes.items() if probe.usable),
-            None,
-        )
-        if reusable is not None:
-            self._remove(self.root)
-            os.replace(reusable, self.root)
-        for backup, probe in probes.items():
-            # A backup nobody could read may be the last intact copy, so it
-            # waits for a round that can actually tell what it holds.
-            if backup != reusable and not probe.unreadable:
-                self._remove(backup)
-
-    def _settle(self, probe: BaseProbe) -> BaseProbe:
-        """Return a root verdict to act on, moving a stuck base aside.
-
-        Only ever applied to :attr:`root`. A backup that reads as unreadable may
-        be the last intact copy, so it keeps waiting for a round that can tell.
-        """
-        return self._unreadable.settle(probe)
+        blocked_backup: Optional[tuple[Path, OSError]] = None
+        for backup in backups:
+            try:
+                if not is_directory(backup):
+                    continue
+                os.replace(backup, self.root)
+            except OSError as exc:
+                blocked_backup = (backup, exc)
+                continue
+            logger.warning(
+                "Restored the preserved Node base from %s; it will be migrated in place",
+                backup,
+            )
+            return
+        if blocked_backup is not None:
+            raise EnvNotReady(*blocked_backup)
 
     def _probe_available(
         self,
@@ -1061,8 +1016,8 @@ if (require.main === module) {{
 
         A directory whose DACL stopped granting the running user denies every
         read inside it, so an intact base reads as missing. The probe reports
-        that as unreadable rather than folding it into "broken", which is the
-        verdict every caller answers with a rebuild.
+        that as unreadable rather than folding it into "broken". Callers wait
+        for access to return; they never quarantine or replace the directory.
         """
         return probe_base(root, lambda: self._inspect_compatible(root, identity))
 

--- a/src/amphi_agent/runtime/_python_env.py
+++ b/src/amphi_agent/runtime/_python_env.py
@@ -8,19 +8,16 @@ import re
 import shutil
 import subprocess
 import sys
-import tempfile
 import threading
-import time
 from functools import cache
 from pathlib import Path
 from typing import Mapping, MutableMapping, Optional
 
 from filelock import FileLock, Timeout as FileLockTimeout
 
-from ._errors import BundledRuntimeUnavailable
+from ._errors import BundledRuntimeUnavailable, EnvNotReady
 from ._probe import (
     BaseProbe,
-    UnreadableBaseGuard,
     is_directory,
     is_regular_file,
     probe_base,
@@ -248,10 +245,6 @@ class BundledUPythonRuntime:
     RUNTIME_DIR_NAME = "python_runtime"
     RUNTIME_MANIFEST_NAME = "runtime.json"
     PREPARE_TIMEOUT_SEC = 300
-    # Backoff doubles per attempt, so these two spend 0.2+0.4+0.8+1.6 = 3s
-    # waiting out a held handle before giving up.
-    PUBLISH_ATTEMPTS = 5
-    PUBLISH_BACKOFF_SEC = 0.2
 
     def __init__(
         self,
@@ -269,7 +262,6 @@ class BundledUPythonRuntime:
         self._process_lock = threading.Lock()
         self._python_fingerprint: Optional[tuple[Path, str]] = None
         self._ready = False
-        self._unreadable = UnreadableBaseGuard()
 
     @property
     def python_executable(self) -> Path:
@@ -343,12 +335,10 @@ class BundledUPythonRuntime:
         Path, optional
             Shared base interpreter, or ``None`` when no bundled Python exists.
 
-        Raises
-        ------
-        EnvNotReady
-            While the existing base cannot be read. Rebuilding is only ever the
-            answer to a base that reads as broken; one that stays unreadable
-            past :data:`~._probe.QUARANTINE_GRACE_SEC` is moved aside instead.
+        Existing files are never removed to answer a runtime update. When the
+        packaged interpreter changes, uv refreshes the venv metadata and
+        launchers in place while preserving site-packages and every other
+        user-installed file.
         """
         bundled_python = self.bundled_executable()
         if bundled_python is None:
@@ -365,27 +355,20 @@ class BundledUPythonRuntime:
         identity = self._runtime_identity(bundled_python)
 
         with self._process_lock:
-            try:
-                # An unreadable base falls through to the locked path rather
-                # than raising here: moving one aside is only safe while
-                # holding the cross-process lock.
-                if self._ready and self._probe(self.root, identity).usable:
-                    return self.python_executable
-                parent = self._prepare_parent()
-                try:
-                    with FileLock(parent / ".base.lock", timeout=self.PREPARE_TIMEOUT_SEC):
-                        self._recover_interrupted_install(identity)
-                        if not self._settle(self._probe(self.root, identity)).usable:
-                            self._create(uv_executable, bundled_python, identity)
-                        self._ensure_pip()
-                except FileLockTimeout as exc:
-                    raise RuntimeError(
-                        "Timed out waiting for the shared Python base"
-                    ) from exc
-                self._ready = True
+            if self._ready and self._probe(self.root, identity).usable:
                 return self.python_executable
-            finally:
-                self._unreadable.close_round()
+            parent = self._prepare_parent()
+            try:
+                with FileLock(parent / ".base.lock", timeout=self.PREPARE_TIMEOUT_SEC):
+                    self._recover_interrupted_install()
+                    self._prepare_base(uv_executable, bundled_python, identity)
+                    self._ensure_pip()
+            except FileLockTimeout as exc:
+                raise RuntimeError(
+                    "Timed out waiting for the shared Python base"
+                ) from exc
+            self._ready = True
+            return self.python_executable
 
     def executable(self) -> Optional[Path]:
         """Return the interpreter exposed to app-managed commands."""
@@ -456,7 +439,6 @@ class BundledUPythonRuntime:
         """Forget process-local readiness without deleting the shared base."""
         self._python_fingerprint = None
         self._ready = False
-        self._unreadable.forget()
         self.bundled_runtime_dir.cache_clear()
         self.bundled_executable.cache_clear()
         self.version.cache_clear()
@@ -485,13 +467,26 @@ class BundledUPythonRuntime:
             return
         target["PATH"] = f"{directory}{os.pathsep}{path}" if path else directory
 
-    def _create(
-        self,
-        uv_executable: Path,
-        bundled_python: Path,
-        identity: dict[str, str],
-    ) -> None:
-        stage = Path(tempfile.mkdtemp(prefix=".base.stage.", dir=self.root.parent))
+    def _prepare_base(self, uv_executable: Path, bundled_python: Path, identity: dict[str, str]) -> None:
+        probe = self._probe(self.root, identity)
+        if probe.usable:
+            return
+        if probe.unreadable:
+            raise EnvNotReady(probe.path, probe.error)
+        try:
+            self.root.lstat()
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            raise EnvNotReady(self.root, exc) from exc
+        else:
+            if not is_directory(self.root):
+                raise RuntimeError(
+                    f"The shared Python base at {self.root} is not a directory; preserving it unchanged"
+                )
+        self._prepare_venv(uv_executable, bundled_python, identity)
+
+    def _prepare_venv(self, uv_executable: Path, bundled_python: Path, identity: dict[str, str]) -> None:
         environment = os.environ.copy()
         self.uv_runtime.bootstrap_env(environment)
         for name in ("VIRTUAL_ENV", "UV_PROJECT", "UV_PROJECT_ENVIRONMENT"):
@@ -502,109 +497,53 @@ class BundledUPythonRuntime:
         # base leaves bytecode inside the signed bundle.
         environment = no_bytecode_environment(environment)
         try:
-            try:
-                result = subprocess.run(
-                    [
-                        str(uv_executable),
-                        "venv",
-                        "--no-project",
-                        "--no-config",
-                        "--python",
-                        str(bundled_python),
-                        "--relocatable",
-                        str(stage),
-                    ],
-                    cwd=self.root.parent,
-                    env=environment,
-                    capture_output=True,
-                    text=True,
-                    encoding="utf-8",
-                    errors="replace",
-                    timeout=self.PREPARE_TIMEOUT_SEC,
-                    **self._subprocess_kwargs(),
-                )
-            except subprocess.TimeoutExpired as exc:
-                raise RuntimeError("Timed out preparing the shared Python base") from exc
-            if result.returncode == 0:
-                (stage / self.MANIFEST_NAME).write_text(
-                    json.dumps(identity, ensure_ascii=False, sort_keys=True),
-                    encoding="utf-8",
-                )
-            if result.returncode != 0 or not self._probe(stage, identity).usable:
-                detail = (
-                    result.stderr.strip()
-                    or result.stdout.strip()
-                    or "uv created no usable environment"
-                )
-                raise RuntimeError(f"Failed to prepare the shared Python base: {detail}")
-            self._publish(stage)
-        finally:
-            self._remove(stage)
-
-    def _detach_root(self) -> Optional[Path]:
-        """Move an existing base aside and return it, or ``None`` if absent.
-
-        The move doubles as the existence probe on purpose: ``Path.exists()``
-        swallows ``PermissionError`` into ``False``, which would skip the backup
-        and let the swap below fail against a destination that is still there.
-        """
-        backup = Path(tempfile.mkdtemp(prefix=".base.backup.", dir=self.root.parent))
-        backup.rmdir()
-        try:
-            os.replace(self.root, backup)
-        except FileNotFoundError:
-            return None
-        return backup
-
-    def _publish(self, stage: Path) -> None:
-        """Swap the staged environment into place, riding out held handles.
-
-        Windows denies a directory rename while any file inside it is open
-        elsewhere -- antivirus scanning the interpreter ``uv`` just copied is
-        the usual culprit, and it clears on its own. Both renames are
-        retried: the handle can just as easily sit in the outgoing base, held
-        by a child of a daemon that was killed rather than shut down. Each
-        attempt detaches again, because a base that reappeared is exactly what
-        a bare retry cannot clear.
-        """
-        last_error: Optional[BaseException] = None
-        for attempt in range(1, self.PUBLISH_ATTEMPTS + 1):
-            backup: Optional[Path] = None
-            try:
-                backup = self._detach_root()
-                os.replace(stage, self.root)
-            except BaseException as exc:
-                # A failed restore leaves state we can no longer reason about,
-                # so it propagates and keeps the backup for the next start.
-                self._restore(backup)
-                # An interrupt still unwinds; only the filesystem is retried.
-                if attempt == self.PUBLISH_ATTEMPTS or not isinstance(exc, OSError):
-                    raise
-                last_error = exc
-                time.sleep(self.PUBLISH_BACKOFF_SEC * 2 ** (attempt - 1))
-            else:
-                if last_error is not None:
-                    logger.warning(
-                        "Published the shared Python base on attempt %d after %r",
-                        attempt,
-                        last_error,
-                    )
-                if backup is not None:
-                    self._remove(backup)
-                return
-
-    def _restore(self, backup: Optional[Path]) -> None:
-        """Put a detached base back; failure preserves it for the next start."""
-        if backup is None:
-            return
-        try:
-            os.replace(backup, self.root)
-        except OSError:
-            logger.exception(
-                "Failed to restore the previous Python base; backup preserved at %s",
-                backup,
+            result = subprocess.run(
+                [
+                    str(uv_executable),
+                    "venv",
+                    "--no-project",
+                    "--no-config",
+                    "--python",
+                    str(bundled_python),
+                    "--relocatable",
+                    "--allow-existing",
+                    str(self.root),
+                ],
+                cwd=self.root.parent,
+                env=environment,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=self.PREPARE_TIMEOUT_SEC,
+                **self._subprocess_kwargs(),
             )
-            raise
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError("Timed out preparing the shared Python base") from exc
+        if result.returncode != 0:
+            detail = (
+                result.stderr.strip()
+                or result.stdout.strip()
+                or "uv created no usable environment"
+            )
+            raise RuntimeError(f"Failed to prepare the shared Python base: {detail}")
+        self._write_manifest(identity)
+        if not self._probe(self.root, identity).usable:
+            raise RuntimeError("Failed to prepare the shared Python base: uv created no usable environment")
+
+    def _write_manifest(self, identity: dict[str, str]) -> None:
+        destination = self.root / self.MANIFEST_NAME
+        temporary = destination.with_name(
+            f".{destination.name}.tmp.{os.getpid()}.{threading.get_ident()}"
+        )
+        try:
+            temporary.write_text(
+                json.dumps(identity, ensure_ascii=False, sort_keys=True),
+                encoding="utf-8",
+            )
+            os.replace(temporary, destination)
+        finally:
+            temporary.unlink(missing_ok=True)
 
     def _runtime_identity(self, bundled_python: Path) -> dict[str, str]:
         resolved_python = bundled_python.expanduser().resolve()
@@ -799,48 +738,43 @@ class BundledUPythonRuntime:
             raise RuntimeError("The app-level Python directory is unavailable")
         return parent
 
-    def _recover_interrupted_install(self, identity: dict[str, str]) -> None:
+    def _recover_interrupted_install(self) -> None:
+        """Recover the last complete base without deleting any saved environment."""
         for stage in self.root.parent.glob(".base.stage.*"):
             self._remove(stage)
         backups = sorted(self.root.parent.glob(".base.backup.*"), reverse=True)
-        if self._settle(self._probe(self.root, identity)).usable:
-            for backup in backups:
-                self._remove(backup)
+        try:
+            self.root.lstat()
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            raise EnvNotReady(self.root, exc) from exc
+        else:
             return
-        probes = {backup: self._probe(backup, identity) for backup in backups}
-        reusable = next(
-            (backup for backup, probe in probes.items() if probe.usable),
-            None,
-        )
-        if reusable is not None:
-            # Swapping onto leftovers fails again further down with a message
-            # that points at the swap rather than at whatever held the delete.
-            if not self._remove(self.root):
-                raise RuntimeError(
-                    f"Cannot reclaim the shared Python base at {self.root}"
-                )
-            os.replace(reusable, self.root)
-        for backup, probe in probes.items():
-            # A backup nobody could read may be the last intact copy, so it
-            # waits for a round that can actually tell what it holds.
-            if backup != reusable and not probe.unreadable:
-                self._remove(backup)
-
-    def _settle(self, probe: BaseProbe) -> BaseProbe:
-        """Return a root verdict to act on, moving a stuck base aside.
-
-        Only ever applied to :attr:`root`. A backup that reads as unreadable may
-        be the last intact copy, so it keeps waiting for a round that can tell.
-        """
-        return self._unreadable.settle(probe)
+        blocked_backup: Optional[tuple[Path, OSError]] = None
+        for backup in backups:
+            try:
+                if not is_directory(backup):
+                    continue
+                os.replace(backup, self.root)
+            except OSError as exc:
+                blocked_backup = (backup, exc)
+                continue
+            logger.warning(
+                "Restored the preserved Python base from %s; it will be migrated in place",
+                backup,
+            )
+            return
+        if blocked_backup is not None:
+            raise EnvNotReady(*blocked_backup)
 
     def _probe(self, root: Path, identity: dict[str, str]) -> BaseProbe:
         """Return a tri-state verdict for one candidate base.
 
         A directory whose DACL stopped granting the running user denies every
         read inside it, so an intact base reads as missing. The probe reports
-        that as unreadable rather than folding it into "broken", which is the
-        verdict every caller answers with a rebuild.
+        that as unreadable rather than folding it into "broken". Callers wait
+        for access to return; they never quarantine or replace the directory.
         """
         return probe_base(root, lambda: self._inspect(root, identity))
 

--- a/tests/agent/runtime/test_runtime_bases.py
+++ b/tests/agent/runtime/test_runtime_bases.py
@@ -7,10 +7,10 @@ from pathlib import Path
 
 import pytest
 
-import src.amphi_agent.runtime._node_env as node_env_module
 import src.amphi_agent.runtime._python_env as python_env_module
-from src.amphi_agent.runtime._errors import BundledRuntimeUnavailable
+from src.amphi_agent.runtime._errors import BundledRuntimeUnavailable, EnvNotReady
 from src.amphi_agent.runtime._node_env import BundledNodeBaseRuntime, BundledNodeRuntime
+from src.amphi_agent.runtime._probe import BaseProbe, ProbeResult
 from src.amphi_agent.runtime._python_env import BundledUPythonRuntime, BundledUvRuntime
 from src.amphi_agent.runtime._resources import BundledRuntimeResources
 from tests._support.sandbox import IsolatedPaths
@@ -38,9 +38,9 @@ def _python_base(paths: IsolatedPaths, monkeypatch: pytest.MonkeyPatch) -> _Pyth
         argv = [str(part) for part in command]
         commands.append(argv)
         if len(argv) > 1 and argv[1] == "venv":
-            stage = Path(argv[-1])
-            bin_dir = stage / ("Scripts" if os.name == "nt" else "bin")
-            bin_dir.mkdir(parents=True)
+            base = Path(argv[-1])
+            bin_dir = base / ("Scripts" if os.name == "nt" else "bin")
+            bin_dir.mkdir(parents=True, exist_ok=True)
             (bin_dir / ("python.exe" if os.name == "nt" else "python")).write_text(
                 "shared-python",
                 encoding="utf-8",
@@ -49,7 +49,7 @@ def _python_base(paths: IsolatedPaths, monkeypatch: pytest.MonkeyPatch) -> _Pyth
                 "shared-pip",
                 encoding="utf-8",
             )
-            (stage / "pyvenv.cfg").write_text("home = bundled\n", encoding="utf-8")
+            (base / "pyvenv.cfg").write_text("home = bundled\n", encoding="utf-8")
             return subprocess.CompletedProcess(command, 0, "", "")
         if "import pip" in argv:
             return subprocess.CompletedProcess(command, 0, "", "")
@@ -211,13 +211,13 @@ def test_python_lifecycle(test_sandbox: IsolatedPaths, monkeypatch: pytest.Monke
     {
       "first_prepare": {"uv_venv_calls": 1},
       "same_identity": {"reused": true, "installed_files": "preserved"},
-      "new_identity": {"replaced": true, "old_files": "removed"}
+      "new_identity": {"migrated_in_place": true, "installed_files": "preserved"}
     }
 
     Checks:
     1. First preparation publishes one valid base without invoking a real runtime or network.
     2. A new runtime object reuses the compatible base and preserves installed files.
-    3. A changed packaged interpreter atomically replaces the incompatible base.
+    3. A changed packaged interpreter refreshes the venv without replacing its files.
     """
     bundled_python, commands, make_runtime = _python_base(test_sandbox, monkeypatch)
     first = make_runtime()
@@ -240,13 +240,36 @@ def test_python_lifecycle(test_sandbox: IsolatedPaths, monkeypatch: pytest.Monke
     bundled_python.write_text("python-v2", encoding="utf-8")
     replacement = make_runtime()
 
-    # Check 3: Identity drift installs a complete replacement and leaves no swap debris.
+    # Check 3: Identity drift rebinds the venv without deleting installed files.
     assert replacement.ensure() == replacement.python_executable
-    assert not installed.exists()
+    assert installed.read_text(encoding="utf-8") == "keep"
     assert (replacement.root / replacement.MANIFEST_NAME).read_text(encoding="utf-8") != old_manifest
     assert _venv_calls(commands) == 2
+    assert "--allow-existing" in next(
+        command for command in reversed(commands) if len(command) > 1 and command[1] == "venv"
+    )
     assert list(replacement.root.parent.glob(".base.stage.*")) == []
     assert list(replacement.root.parent.glob(".base.backup.*")) == []
+
+
+@pytest.mark.windows_runtime
+def test_python_invalid_metadata_is_repaired_in_place(
+    test_sandbox: IsolatedPaths,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A damaged identity is repaired without discarding installed files."""
+    _bundled_python, commands, make_runtime = _python_base(test_sandbox, monkeypatch)
+    first = make_runtime()
+    first.ensure()
+    installed = first.root / "installed-package.txt"
+    installed.write_text("keep", encoding="utf-8")
+    (first.root / first.MANIFEST_NAME).write_text("{", encoding="utf-8")
+
+    repaired = make_runtime()
+    assert repaired.ensure() == repaired.python_executable
+    assert installed.read_text(encoding="utf-8") == "keep"
+    assert json.loads((repaired.root / repaired.MANIFEST_NAME).read_text(encoding="utf-8"))
+    assert _venv_calls(commands) == 2
 
 
 @pytest.mark.windows_runtime
@@ -321,14 +344,14 @@ def test_python_recovery(test_sandbox: IsolatedPaths, monkeypatch: pytest.Monkey
       "backup": "restored as base",
       "installed_files": "preserved",
       "partial_stage": "removed",
-      "new_uv_venv": false
+      "runtime_update": "migrated in place"
     }
 
     Checks:
     1. An interrupted backup remains the reusable authority when the active base is absent.
-    2. Ensure restores that backup and clears abandoned staging without rebuilding.
+    2. A new runtime restores and migrates that backup without discarding its files.
     """
-    _bundled_python, commands, make_runtime = _python_base(test_sandbox, monkeypatch)
+    bundled_python, commands, make_runtime = _python_base(test_sandbox, monkeypatch)
     first = make_runtime()
     first.ensure()
     installed = first.root / "installed-package.txt"
@@ -346,30 +369,31 @@ def test_python_recovery(test_sandbox: IsolatedPaths, monkeypatch: pytest.Monkey
     assert (backup / installed_relative).read_text(encoding="utf-8") == "keep"
     assert (stage / "partial.txt").is_file()
 
+    bundled_python.write_text("python-v2", encoding="utf-8")
     recovered = make_runtime()
     assert recovered.ensure() == recovered.python_executable
 
-    # Check 2: Recovery reinstalls the complete backup without invoking uv again.
+    # Check 2: Recovery reinstalls and migrates the backup without losing its files.
     assert (recovered.root / installed_relative).read_text(encoding="utf-8") == "keep"
-    assert _venv_calls(commands) == 1
+    assert _venv_calls(commands) == 2
     assert not backup.exists()
     assert not stage.exists()
 
 
 @pytest.mark.windows_runtime
-def test_python_rollback(test_sandbox: IsolatedPaths, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Final failed Python publication:
+def test_python_migration_failure(test_sandbox: IsolatedPaths, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Final failed Python in-place migration:
 
     {
       "replacement": "failed",
-      "previous_base": "restored with its identity and installed files",
+      "previous_base": "left in place with its identity and installed files",
       "installed_files": "preserved",
       "swap_debris": []
     }
 
     Checks:
-    1. A publication error restores the compatible previous base before propagating.
-    2. Failed staging and backup directories are removed without losing installed files.
+    1. A uv refresh error propagates without replacing the previous base.
+    2. The existing manifest and installed files remain intact.
     """
     bundled_python, _commands, make_runtime = _python_base(test_sandbox, monkeypatch)
     first = make_runtime()
@@ -379,24 +403,23 @@ def test_python_rollback(test_sandbox: IsolatedPaths, monkeypatch: pytest.Monkey
     old_manifest = (first.root / first.MANIFEST_NAME).read_text(encoding="utf-8")
     bundled_python.write_text("python-v2", encoding="utf-8")
     replacement = make_runtime()
-    real_replace = os.replace
+    normal_run = python_env_module.subprocess.run
 
-    def fail_publish(source: Path, target: Path) -> None:
-        source_path = Path(source)
-        if source_path.name.startswith(".base.stage.") and Path(target) == replacement.root:
-            raise OSError("publication blocked")
-        real_replace(source, target)
+    def fail_refresh(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        argv = [str(part) for part in command]
+        if len(argv) > 1 and argv[1] == "venv":
+            return subprocess.CompletedProcess(command, 1, "", "refresh blocked")
+        return normal_run(command, **kwargs)
 
-    monkeypatch.setattr(BundledUPythonRuntime, "PUBLISH_ATTEMPTS", 1)
-    monkeypatch.setattr(python_env_module.os, "replace", fail_publish)
+    monkeypatch.setattr(python_env_module.subprocess, "run", fail_refresh)
 
-    # Check 1: A failed staged swap propagates only after restoring the previous root.
-    with pytest.raises(OSError, match="publication blocked"):
+    # Check 1: A failed refresh leaves the previous root active.
+    with pytest.raises(RuntimeError, match="refresh blocked"):
         replacement.ensure()
     assert (replacement.root / replacement.MANIFEST_NAME).read_text(encoding="utf-8") == old_manifest
     assert installed.read_text(encoding="utf-8") == "keep"
 
-    # Check 2: Rollback leaves only the complete previous base on disk.
+    # Check 2: No swap transaction is created around a user-owned environment.
     assert list(replacement.root.parent.glob(".base.stage.*")) == []
     assert list(replacement.root.parent.glob(".base.backup.*")) == []
 
@@ -408,13 +431,13 @@ def test_node_lifecycle(test_sandbox: IsolatedPaths, monkeypatch: pytest.MonkeyP
     {
       "first_prepare": {"resolver": true, "npm_shims": true},
       "same_identity": {"reused": true, "installed_packages": "preserved"},
-      "new_identity": {"replaced": true, "old_packages": "removed"}
+      "new_identity": {"migrated_in_place": true, "installed_packages": "preserved"}
     }
 
     Checks:
     1. First preparation publishes the resolver, npm shims, and package directories.
     2. A matching packaged Node reuses the base and retains installed packages.
-    3. A changed Node identity atomically installs a clean replacement.
+    3. A changed Node identity refreshes metadata without replacing packages.
     """
     bundled_node, make_runtime = _node_base(test_sandbox, monkeypatch)
     first = make_runtime()
@@ -441,12 +464,78 @@ def test_node_lifecycle(test_sandbox: IsolatedPaths, monkeypatch: pytest.MonkeyP
     bundled_node.write_text("node-v2", encoding="utf-8")
     replacement = make_runtime()
 
-    # Check 3: Identity drift replaces the entire base and cleans its staging transaction.
+    # Check 3: Identity drift updates metadata without deleting installed packages.
     assert replacement.ensure() == replacement.root
-    assert not installed.exists()
+    assert installed.read_text(encoding="utf-8") == "keep"
     assert (replacement.root / replacement.MANIFEST_NAME).read_text(encoding="utf-8") != old_manifest
     assert list(replacement.root.parent.glob(".base.stage.*")) == []
     assert list(replacement.root.parent.glob(".base.backup.*")) == []
+
+
+@pytest.mark.windows_runtime
+def test_node_invalid_metadata_is_repaired_in_place(
+    test_sandbox: IsolatedPaths,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Damaged app support files are repaired without discarding npm packages."""
+    bundled_node, make_runtime = _node_base(test_sandbox, monkeypatch)
+    first = make_runtime()
+    first.ensure()
+    installed = first.modules_dir / "kept-package" / "index.js"
+    installed.parent.mkdir(parents=True)
+    installed.write_text("keep", encoding="utf-8")
+    (first.root / first.MANIFEST_NAME).write_text("{", encoding="utf-8")
+    first.resolver_path.unlink()
+
+    repaired = make_runtime()
+    assert repaired.ensure() == repaired.root
+    assert installed.read_text(encoding="utf-8") == "keep"
+    assert repaired.resolver_path.is_file()
+    assert json.loads((repaired.root / repaired.MANIFEST_NAME).read_text(encoding="utf-8"))
+
+
+@pytest.mark.windows_runtime
+def test_unreadable_runtime_bases_are_never_quarantined(
+    test_sandbox: IsolatedPaths,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeated read failures leave both installed environments at their paths."""
+    _bundled_python, _commands, make_python = _python_base(test_sandbox, monkeypatch)
+    _bundled_node, make_node = _node_base(test_sandbox, monkeypatch)
+    python = make_python()
+    node = make_node()
+    python.ensure()
+    node.ensure()
+    python_installed = python.root / "installed-package.txt"
+    node_installed = node.modules_dir / "kept-package" / "index.js"
+    python_installed.write_text("keep", encoding="utf-8")
+    node_installed.parent.mkdir(parents=True)
+    node_installed.write_text("keep", encoding="utf-8")
+
+    denied = PermissionError("base access denied")
+    unreadable_python = make_python()
+    unreadable_node = make_node()
+    monkeypatch.setattr(
+        unreadable_python,
+        "_probe",
+        lambda root, _identity: BaseProbe(ProbeResult.UNREADABLE, root, denied),
+    )
+    monkeypatch.setattr(
+        unreadable_node,
+        "_probe_compatible",
+        lambda root, _identity: BaseProbe(ProbeResult.UNREADABLE, root, denied),
+    )
+
+    for _attempt in range(5):
+        with pytest.raises(EnvNotReady, match="base access denied"):
+            unreadable_python.ensure()
+        with pytest.raises(EnvNotReady, match="base access denied"):
+            unreadable_node.ensure()
+
+    assert python_installed.read_text(encoding="utf-8") == "keep"
+    assert node_installed.read_text(encoding="utf-8") == "keep"
+    assert list(python.root.parent.glob(".base.backup.*")) == []
+    assert list(node.root.parent.glob(".base.backup.*")) == []
 
 
 @pytest.mark.windows_runtime
@@ -697,7 +786,7 @@ def test_node_recovery(test_sandbox: IsolatedPaths, monkeypatch: pytest.MonkeyPa
     1. A complete backup remains distinguishable from an abandoned partial stage.
     2. Ensure restores the backup and preserves the shared package tree.
     """
-    _bundled_node, make_runtime = _node_base(test_sandbox, monkeypatch)
+    bundled_node, make_runtime = _node_base(test_sandbox, monkeypatch)
     first = make_runtime()
     first.ensure()
     installed = first.modules_dir / "kept-package" / "index.js"
@@ -715,6 +804,7 @@ def test_node_recovery(test_sandbox: IsolatedPaths, monkeypatch: pytest.MonkeyPa
     assert (backup / installed.relative_to(first.root)).read_text(encoding="utf-8") == "keep"
     assert (stage / "partial.txt").is_file()
 
+    bundled_node.write_text("node-v2", encoding="utf-8")
     recovered = make_runtime()
     assert recovered.ensure() == recovered.root
 
@@ -725,19 +815,19 @@ def test_node_recovery(test_sandbox: IsolatedPaths, monkeypatch: pytest.MonkeyPa
 
 
 @pytest.mark.windows_runtime
-def test_node_rollback(test_sandbox: IsolatedPaths, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Final failed Node publication:
+def test_node_migration_failure(test_sandbox: IsolatedPaths, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Final failed Node in-place migration:
 
     {
       "replacement": "failed",
-      "previous_base": "restored",
+      "previous_base": "left in place",
       "installed_packages": "preserved",
       "swap_debris": []
     }
 
     Checks:
-    1. A failed staged swap restores the previous Node base before raising.
-    2. Rollback removes the failed stage and transient backup.
+    1. A manifest refresh error propagates without replacing the previous Node base.
+    2. The existing manifest and installed packages remain intact.
     """
     bundled_node, make_runtime = _node_base(test_sandbox, monkeypatch)
     first = make_runtime()
@@ -748,22 +838,18 @@ def test_node_rollback(test_sandbox: IsolatedPaths, monkeypatch: pytest.MonkeyPa
     old_manifest = (first.root / first.MANIFEST_NAME).read_text(encoding="utf-8")
     bundled_node.write_text("node-v2", encoding="utf-8")
     replacement = make_runtime()
-    real_replace = os.replace
 
-    def fail_publish(source: Path, target: Path) -> None:
-        source_path = Path(source)
-        if source_path.name.startswith(".base.stage.") and Path(target) == replacement.root:
-            raise OSError("publication blocked")
-        real_replace(source, target)
+    def fail_manifest(_self: BundledNodeBaseRuntime, _identity: dict[str, object]) -> None:
+        raise OSError("manifest refresh blocked")
 
-    monkeypatch.setattr(node_env_module.os, "replace", fail_publish)
+    monkeypatch.setattr(BundledNodeBaseRuntime, "_write_manifest", fail_manifest)
 
-    # Check 1: Publication failure propagates with the original package tree restored.
-    with pytest.raises(OSError, match="publication blocked"):
+    # Check 1: A failed refresh leaves the previous package tree active.
+    with pytest.raises(OSError, match="manifest refresh blocked"):
         replacement.ensure()
     assert (replacement.root / replacement.MANIFEST_NAME).read_text(encoding="utf-8") == old_manifest
     assert installed.read_text(encoding="utf-8") == "keep"
 
-    # Check 2: No transaction directory remains after the restored root is active.
+    # Check 2: No swap transaction is created around a user-owned environment.
     assert list(replacement.root.parent.glob(".base.stage.*")) == []
     assert list(replacement.root.parent.glob(".base.backup.*")) == []


### PR DESCRIPTION
## Summary

- Migrate the shared Python virtual environment in place with uv venv --allow-existing so packaged runtime path, hash, signature, or version changes do not delete installed packages.
- Refresh Node runtime metadata, resolver, and npm/npx shims in place while preserving node_modules and installed package commands.
- Preserve existing bases on malformed metadata, migration failures, and repeated read failures instead of quarantining or replacing them with empty environments.
- Restore legacy interrupted-install backups before migrating them in place.
- Keep the explicit user-selected delete-data uninstall behavior unchanged.

## Validation

- uv run pytest -q
- 350 passed