### PR TITLE
fix(i18n): stop leaking the wrong language into user-visible agent text

### DIFF
--- a/desktop/apps/electron/src/renderer/components/amphi/ToolViews.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/ToolViews.tsx
@@ -165,7 +165,6 @@ function EditDiffView({ input }: { input: unknown }) {
 function termLineColor(ln: string): string {
   if (ln.startsWith('$')) return '#7DD3A8'
   if (ln.startsWith('—')) return '#3A3D4D'
-  if (ln.includes('报告')) return '#E8EAEF'
   return '#AEB2C0'
 }
 

--- a/desktop/scripts/check-chinese.ts
+++ b/desktop/scripts/check-chinese.ts
@@ -51,9 +51,6 @@ const ALLOWED: Record<string, string> = {
   // file RESOLVES to derive from the i18n catalogs, never from literals.
   'desktop/apps/electron/src/renderer/atoms/human-request.ts': 'historical zh synonyms users free-type on the acceptance card; rendered labels derive from both catalogs',
 
-  // Raw tool output uses this heading as a visual cue, not as product-owned display copy.
-  'desktop/apps/electron/src/renderer/components/amphi/ToolViews.tsx': 'raw tool-output heading matcher',
-
   // A historical persisted provider default must be recognized after an upgrade.
   'desktop/apps/electron/src/renderer/atoms/models-presets.ts': 'legacy GLM display name stored by earlier app versions',
 

--- a/src/amphi_agent/_cognitive.py
+++ b/src/amphi_agent/_cognitive.py
@@ -9,7 +9,7 @@ from bridgic.amphibious import CognitiveWorker, StepToolCall
 from bridgic.core.agentic.tool_specs import ToolSpec
 from bridgic.core.model.types import Message, Role
 
-from ..amphi_service.i18n import DEFAULT_LOCALE, backend_i18n, detect_locale
+from ..amphi_service.i18n import backend_i18n, detect_locale
 from ..amphi_store import SessionTurnRecord
 from ._context import AmphiContext, AmphiOTAContext, _view
 from ._skills import Skill, SkillGroup
@@ -162,9 +162,12 @@ def _shell_environment_summary(workspace: Optional[Any]) -> str:
 
 def render_input(user_input: Any, path_map: Optional[Dict[str, str]] = None) -> str:
     """A raw turn input → prompt text, blocks inlined in order (mention → its
-    ALREADY-resolved mount-gated path, else ``@label``). Pure: no DB, no mutation —
-    the one renderer shared by sync routing (``init_state``) and the async
-    ``user_input_block`` (which resolves ``path_map`` first, then delegates here)."""
+    ALREADY-resolved mount-gated path, else ``@label``). No DB, no mutation — the one
+    renderer shared by sync routing (``init_state``) and the async ``user_input_block``
+    (which resolves ``path_map`` first, then delegates here).
+
+    Not a pure function of its arguments: the intent sentences below read the active
+    locale when the input itself carries no language (see there for why)."""
     if isinstance(user_input, str):
         return user_input
     read_input = (
@@ -177,11 +180,26 @@ def render_input(user_input: Any, path_map: Optional[Dict[str, str]] = None) -> 
         return str(read_input("input") or read_input("text") or "")
     path_map = path_map or {}
     # Intent sentences (the /build and workflow-run preambles) are injected into the
-    # model prompt and re-rendered on every resume of the same persisted turn, so
-    # their language must be a deterministic function of the persisted blocks — the
-    # ambient locale is request-scoped and can differ between the original turn and
-    # a later resume, splitting one turn's prompt across two languages. Derived from
-    # the text blocks (the user's own prose), falling back to the flattened input.
+    # model prompt as if the user had written them, so their language decides the whole
+    # turn's language: the persona's CRITICAL rule tells the model to match the user's
+    # input language, and it cannot tell a synthesized preamble from real prose.
+    # Read from the text blocks and NOTHING else: they are the only thing here the user
+    # actually typed. The flattened input is not a substitute — it splices in the slash
+    # label and every @mention label, which are named by whoever created that Workflow or
+    # folder. A CJK-named Workflow, or a mention of a CJK folder, would otherwise hand
+    # `detect_locale` a CJK character (it treats any CJK as decisive, before its
+    # path-stripping ever runs) and pick the language of a request the user never wrote.
+    #
+    # A slash-only turn therefore has no prose at all, and that is the normal case: a bare
+    # `/build`, or a Workflow run with nothing typed after it. It used to fall back to the
+    # product default (Chinese), which handed every non-Chinese user a Chinese request and
+    # flipped the entire turn's visible text to Chinese. The client's locale is the right
+    # fallback and is already "the user's language, else the language they picked in the
+    # app" — the same resolution every other display string follows.
+    # It is request-scoped, so a resume can in principle render this one sentence in a
+    # different language than the original turn; in practice the locale is re-derived
+    # from the same session, and a rare mismatch on one preamble is a far smaller defect
+    # than a guaranteed wrong language for every user outside zh.
     def _block_value(block: Any, name: str) -> Any:
         return block.get(name) if isinstance(block, dict) else getattr(block, name, None)
 
@@ -189,8 +207,8 @@ def render_input(user_input: Any, path_map: Optional[Dict[str, str]] = None) -> 
         str(_block_value(b, "value") or "")
         for b in blocks
         if _block_value(b, "type") == "text"
-    ) or str(read_input("input") or read_input("text") or "")
-    intent_locale = detect_locale(prose) or DEFAULT_LOCALE
+    )
+    intent_locale = detect_locale(prose) or backend_i18n.current_locale()
     parts: List[str] = []
     for b in blocks:
         read = b.get if isinstance(b, dict) else lambda name, default=None: getattr(b, name, default)
@@ -928,7 +946,7 @@ class MainThink(CognitiveWorker):
 
     async def user_input_block(self, ota_context: AmphiOTAContext, context: AmphiContext) -> str:
         """This turn's request rendered to prompt text — resolves the session's
-        ownership-gated mount table (the async concern), then delegates to the pure
+        ownership-gated mount table (the async concern), then delegates to
         ``render_input``. Single source for the block→text containment logic."""
         user_input = ota_context.user_input
         mention_ids = [b.id for b in getattr(user_input, "blocks", None) or [] if b.type == "mention"]

--- a/src/amphi_agent/security/_classifier.py
+++ b/src/amphi_agent/security/_classifier.py
@@ -177,14 +177,14 @@ def _numbered_bullets(items: List[str], ids: List[str]) -> str:
 
 def _build_system_prompt(policy: Policy) -> str:
     """Build the classifier system prompt from the externalised policy
-    (:class:`Policy`). **Contains the four static policy sections only** — the workspace
-    roots, which change per session, are not concatenated here (they go on the user side),
-    making the system prompt a stable prefix that hits prompt caching; as long as the
-    policy content is unchanged the bytes
-    are unchanged and later calls hit the cache.
+    (:class:`Policy`). **Carries the four static policy sections plus the active locale,
+    and nothing else** — the workspace roots, which change per session, are not
+    concatenated here (they go on the user side), so the prompt stays a prefix stable
+    enough for prompt caching: with the policy and the locale unchanged the bytes are
+    unchanged and later calls hit the cache.
 
-    The one per-request value it does carry is the active locale, named as the fallback
-    for ``reason``'s language. ``reason`` is rendered verbatim on the approval card, so it
+    The locale is named as the fallback for ``reason``'s language. ``reason`` is
+    rendered verbatim on the approval card, so it
     follows the user's own language exactly as the agent's replies do (``_prompt.py``'s
     CRITICAL language rule) — but the requests are not always readable (a scheduled or
     resumed Run carries none, and paths / commands / quoted logs carry no language of

--- a/src/amphi_agent/security/_classifier.py
+++ b/src/amphi_agent/security/_classifier.py
@@ -54,7 +54,7 @@ from bridgic.core.model.types import Message, Role
 
 from src.amphi_service.i18n import backend_i18n
 
-from .._prompt import AGENT_NAME
+from .._prompt import AGENT_NAME, _ui_language
 from ._audit import write_classify_record
 from ._policy import Policy, load_policy, soft_deny_ids, soft_deny_title
 from ._reasoning import reasoning_off
@@ -181,7 +181,17 @@ def _build_system_prompt(policy: Policy) -> str:
     roots, which change per session, are not concatenated here (they go on the user side),
     making the system prompt a stable prefix that hits prompt caching; as long as the
     policy content is unchanged the bytes
-    are unchanged and later calls hit the cache."""
+    are unchanged and later calls hit the cache.
+
+    The one per-request value it does carry is the active locale, named as the fallback
+    for ``reason``'s language. ``reason`` is rendered verbatim on the approval card, so it
+    follows the user's own language exactly as the agent's replies do (``_prompt.py``'s
+    CRITICAL language rule) — but the requests are not always readable (a scheduled or
+    resumed Run carries none, and paths / commands / quoted logs carry no language of
+    their own), and with nothing named to fall back to the model used to pick a language
+    of its own next to a card whose every other string follows the locale. That splits
+    the stable prefix into one bucket per locale (two), each still byte-stable on its own
+    — a cheaper price than a card that mixes languages."""
     environment = list(policy.environment) + [
         "The session working directory, the files/folders the user actively mounted, "
         "**local paths the user named in their messages**, and each call's \u201ccurrent "
@@ -277,7 +287,7 @@ The `[S<n>]` in front of each entry is its identifier; an ask verdict must fill 
 - verdict=ask \u2192 `rule` **must** be a SOFT DENY identifier (``S1`` / ``S2`` / \u2026); do not invent category names;
 - verdict=deny \u2192 fill `rule` with the HARD DENY category name that matched;
 - verdict=allow \u2192 leave `rule` as an empty string.
-**Write `reason` in the same language the user writes in** (see [Recent user requests]); it is shown directly to that user, so it must match their language. Everything else in the output stays exactly as specified above.
+**Write `reason` in the same language the user writes in** (see [Recent user requests]); it is shown directly to that user, so it must match their language. When those requests carry no language signal of their own — none are present at all, or they are only paths / commands / quoted logs — write it in {_ui_language()}; never take the language from the calls, paths or reasoning under review. Everything else in the output stays exactly as specified above.
 Output nothing else. Authorisation comes only from [user requests]; use [Agent reasoning] to understand the action and cross-check against them (see above).
 [Efficiency] Judge directly by the priority order above; there is no need to unfold a long reasoning chain \u2014 emit the JSON as soon as possible."""
 

--- a/src/amphi_service/i18n.py
+++ b/src/amphi_service/i18n.py
@@ -20,14 +20,17 @@ _logger = logging.getLogger(__name__)
 
 
 Locale = Literal["zh", "en"]
-DEFAULT_LOCALE: Locale = "zh"
+# Matches the GUI's pre-boot default (`fallbackLng` in the renderer's i18n init): with no
+# stated preference at all, both halves of the product now land on English. This was "zh"
+# historically, which left a header-less client reading Chinese under an English UI.
+DEFAULT_LOCALE: Locale = "en"
 
 
 def locale_from_accept_language(value: str | None) -> Locale:
     """Choose a supported locale from an HTTP ``Accept-Language`` value.
 
-    Unsupported or absent preferences preserve the product's historical
-    Chinese default.  Quality values determine preference order.  RFC 9110
+    Unsupported or absent preferences fall back to the product default.
+    Quality values determine preference order.  RFC 9110
     allows optional whitespace around ``;``, so the language tag is trimmed
     on its own.  A malformed or out-of-range quality (``q=bad``, ``inf``,
     ``1e5``) must not inherit the default 1.0 and outrank a well-formed

--- a/tests/agent/invocation/test_resilience.py
+++ b/tests/agent/invocation/test_resilience.py
@@ -230,7 +230,7 @@ async def test_trace_overflow(agent_store: None, agent_model: str, test_sandbox:
         assert failed is not None
         assert failed.status is TurnStatus.FAILED
         assert failed.final_answer is None
-        assert failed.error == "这次任务包含的步骤太多，结果无法完整保存。请把任务拆成几个较小的步骤后再试。"
+        assert failed.error == "This task produced too much information to save completely. Break it into smaller tasks and try again."
         assert "OTA context exceeded" not in failed.error
 
         # Check 2: The fallback contains no oversized trace or stale dynamic tool surface.

--- a/tests/agent/prompt/test_message_structure.py
+++ b/tests/agent/prompt/test_message_structure.py
@@ -5,7 +5,9 @@ from bridgic.amphibious import ActionResult, ActionStepResult, OTARecord
 from bridgic.core.model.types import Role, ToolCallBlock, ToolResultBlock
 
 from src.amphi_agent import AmphiContext, AmphiOTAContext, MainThink, Session
+from src.amphi_agent._cognitive import render_input
 from src.amphi_agent._workspace import Workspace
+from src.amphi_service.i18n import backend_i18n, use_locale
 from src.amphi_store import SessionMountRecord, SessionRecord, SessionTurnRecord, TurnStatus, UserInput
 from tests._support.sandbox import IsolatedPaths
 
@@ -226,6 +228,86 @@ async def test_structured_input(test_sandbox: IsolatedPaths) -> None:
     for messages in (build_messages, workflow_messages):
         assert [message.role for message in messages] == [Role.SYSTEM, Role.USER]
         assert messages[1].content.endswith(f"<current_time>\n{PROMPT_TIME}\n</current_time>")
+
+
+def test_intent_language_falls_back_to_the_client_locale() -> None:
+    """Final intent-sentence language:
+
+    {
+      "slash_only_under_en": "English",
+      "slash_only_under_zh": "Chinese",
+      "prose_present": "the user's own prose still decides",
+      "cjk_labels_under_en": "English"
+    }
+
+    Checks:
+    1. A slash carrying no readable prose renders its intent in the client's locale, not
+       in the product default — an English client must never be handed a Chinese request
+       it did not write.
+    2. The same input under a Chinese client renders the Chinese intent.
+    3. Prose the user actually typed still decides the language, whatever the locale is.
+    4. Slash and mention labels are not prose and never decide the language.
+    """
+    # Only text blocks count as prose, so a slash-only turn — a bare /build, or a
+    # Workflow run with nothing typed after it — carries no language of its own.
+    build_only = SimpleNamespace(
+        input="/build",
+        blocks=[SimpleNamespace(type="slash", id="build", label="build", resource=None)],
+    )
+    workflow_only = SimpleNamespace(
+        input="/Daily Digest",
+        blocks=[
+            SimpleNamespace(type="slash", id="wf-a", label="Daily Digest", resource="workflow")
+        ],
+    )
+    workflow_with_prose = SimpleNamespace(
+        input="/Daily Digest for the current week",
+        blocks=[
+            SimpleNamespace(type="slash", id="wf-a", label="Daily Digest", resource="workflow"),
+            SimpleNamespace(type="text", value=" for the current week"),
+        ],
+    )
+
+    def expected(message_id: str, locale: str) -> str:
+        return backend_i18n.text(message_id, locale=locale, label="Daily Digest", workflow_id="wf-a")
+
+    # Check 1: A slash carrying no readable prose renders its intent in the client's locale.
+    with use_locale("en"):
+        assert render_input(build_only) == expected("agent.input.build_intent", "en")
+        assert render_input(workflow_only) == expected("agent.input.workflow_run_intent", "en")
+
+    # Check 2: The same input under a Chinese client renders the Chinese intent.
+    with use_locale("zh"):
+        assert render_input(build_only) == expected("agent.input.build_intent", "zh")
+        assert render_input(workflow_only) == expected("agent.input.workflow_run_intent", "zh")
+
+    # Check 3: Prose the user actually typed still decides the language, whatever the locale.
+    with use_locale("zh"):
+        assert render_input(workflow_with_prose) == (
+            expected("agent.input.workflow_run_intent", "en") + " for the current week"
+        )
+
+    # Check 4: A label is not prose. Whoever named the Workflow or the folder does not get
+    # to pick the language of a request the user did not write — the CJK data below is the
+    # point of the case, not display copy.
+    cjk_workflow = SimpleNamespace(
+        input="/生成报告",
+        blocks=[SimpleNamespace(type="slash", id="wf-b", label="生成报告", resource="workflow")],
+    )
+    cjk_mention = SimpleNamespace(
+        input="/build @项目",
+        blocks=[
+            SimpleNamespace(type="slash", id="build", label="build", resource=None),
+            SimpleNamespace(type="mention", id="m-1", label="项目", group="", path=""),
+        ],
+    )
+    with use_locale("en"):
+        assert render_input(cjk_workflow) == backend_i18n.text(
+            "agent.input.workflow_run_intent", locale="en", label="生成报告", workflow_id="wf-b"
+        )
+        assert render_input(cjk_mention).startswith(
+            backend_i18n.text("agent.input.build_intent", locale="en")
+        )
 
 
 async def test_session_replay() -> None:

--- a/tests/agent/security/test_safety_classifier.py
+++ b/tests/agent/security/test_safety_classifier.py
@@ -8,6 +8,7 @@ from bridgic.core.model.types import Message, Response, Role
 
 from src.amphi_agent.security import ClassifyItem, LlmSafetyClassifier
 from src.amphi_agent.security._reasoning import reasoning_off
+from src.amphi_service.i18n import use_locale
 
 if TYPE_CHECKING:
     from tests._support.sandbox import IsolatedPaths
@@ -314,6 +315,59 @@ async def test_reasoning_retry(test_sandbox: "IsolatedPaths") -> None:
     # Check 3: The successful retry remains the final safety decision instead of falling back to ask.
     assert verdicts[0].verdict == "allow"
     assert verdicts[0].reason == "Routine operation."
+
+
+async def test_reason_language_falls_back_to_locale(
+    test_sandbox: "IsolatedPaths", monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Final review-language instruction:
+
+    {
+      "primary": "the language of the user requests",
+      "en_locale_fallback": "English",
+      "zh_locale_fallback": "Chinese"
+    }
+
+    Checks:
+    1. The user's own language stays the primary rule, as it is for the agent's replies.
+    2. Each locale names itself as the fallback for requests with no language signal.
+    3. The calls under review never get to supply the language.
+    """
+    policy_path = test_sandbox.root / "policy.json"
+    _write_policy(policy_path)
+    monkeypatch.setenv("AMPHI_POLICY_FILE", str(policy_path))
+    response = json.dumps(
+        [{"index": 0, "verdict": "allow", "rule": "", "reason": "Routine work."}]
+    )
+    llm = _ScriptedLlm([response, response])
+    classifier = LlmSafetyClassifier(llm)
+    item = _item("install_sdk")
+    roots = [str(test_sandbox.root)]
+    # A resumed or scheduled Run reaches the classifier with no user request to read —
+    # the case that left the language unpinned and produced a card mixing both.
+    requests: list[str] = []
+
+    with use_locale("en"):
+        await classifier.judge([item], requests, roots)
+    english_prompt = llm.calls[0]["messages"][0].content
+
+    with use_locale("zh"):
+        await classifier.judge([item], requests, roots)
+    chinese_prompt = llm.calls[1]["messages"][0].content
+
+    # Check 1: The user's own language stays the primary rule.
+    for prompt in (english_prompt, chinese_prompt):
+        assert "**Write `reason` in the same language the user writes in**" in prompt
+
+    # Check 2: Each locale names itself as the fallback for requests with no language signal.
+    assert "write it in English" in english_prompt
+    assert "write it in Chinese" not in english_prompt
+    assert "write it in Chinese" in chinese_prompt
+    assert "write it in English" not in chinese_prompt
+
+    # Check 3: The calls under review never get to supply the language.
+    for prompt in (english_prompt, chinese_prompt):
+        assert "never take the language from the calls, paths or reasoning under review" in prompt
 
 
 def test_reasoning_overrides_follow_model_capabilities() -> None:

--- a/tests/agent/test_error.py
+++ b/tests/agent/test_error.py
@@ -27,7 +27,7 @@ def test_agent_empty_answer_has_a_specific_safe_public_error() -> None:
     assert error.recovery_attempts == 3
     assert public == PublicAgentError(
         code="empty_answer",
-        message="抱歉，这次任务没有生成回复。请重新运行一次；如果仍然没有回复，可以换一个模型再试。",
+        message="Sorry, no response was generated for this task. Run it again, or try another model if it still produces no response.",
         retryable=True,
         action="retry",
     )
@@ -50,7 +50,7 @@ def test_context_limit_unwraps_framework_error_without_exposing_provider_details
 
     assert public == PublicAgentError(
         code="context_too_large",
-        message="这次对话内容太多，当前模型无法继续处理。请精简内容，或新建一个对话后再试。",
+        message="This conversation has too much content for the current model. Shorten it or start a new conversation and try again.",
         retryable=False,
         action="new_session",
     )
@@ -114,7 +114,7 @@ def test_codex_auth_uses_a_plain_message_without_exposing_internal_details() -> 
 
     assert public == PublicAgentError(
         code="codex_auth_expired",
-        message="当前模型的登录已失效。请重新登录后再试。",
+        message="The selected model's sign-in has expired. Sign in again and try again.",
         retryable=False,
         action="relogin",
     )
@@ -128,7 +128,7 @@ def test_known_model_not_found_error_uses_the_plain_public_message() -> None:
 
     assert public == PublicAgentError(
         code="model_not_found",
-        message="当前选择的模型无法使用。请前往模型设置，选择其他模型后再试。",
+        message="The selected model cannot be used right now. Choose another model in settings and try again.",
         retryable=False,
         action="open_model_settings",
     )


### PR DESCRIPTION
## Scope

Three commits, one defect class: user-visible text produced in a language the user never chose. Found from two field screenshots (a Chinese classifier reason on an English approval card; a whole English-workflow run turning Chinese), traced to three independent root causes.

## 1. `db68624` — classifier `reason` had no language fallback

The safety classifier's `reason` renders verbatim on the approval card. Its language was steered only by *"write it in the same language the user writes in"* — but the request window is often unreadable (scheduled/resumed runs carry no user message; paths, commands and quoted logs carry no language), so the model picked a language of its own next to a card whose every other string followed the locale.

Kept the user's-language rule primary, named the active locale as the fallback via the existing `_ui_language()`, and forbade taking the language from the calls under review. One cache bucket per locale; each still byte-stable.

## 2. `462cb56` — intent preambles synthesized in a language the user never wrote

`/build` and workflow-run slashes synthesize an intent sentence that enters the prompt **as the user's own request**, so its language decides the whole turn's language (the persona's CRITICAL rule matches the user's input, and the model cannot tell a synthesized preamble from real prose). Two paths fabricated it wrong:

- **Slash-only turns** (bare `/build`, or a Workflow run with nothing typed) fell back to the hardcoded product default — every non-Chinese user got a Chinese request and the whole turn flipped Chinese. Real DB rows confirm run inputs are frequently `' '` or a bare filename.
- **The flattened-input fallback** spliced in slash/@mention labels, so a CJK-named Workflow decided the language even for an English client (`detect_locale` treats any CJK as decisive before its path-stripping runs).

Now the language is read from text blocks only — the one thing the user actually typed — falling back to the client's locale. The resume-determinism trade-off is recorded at the decision site. Also removed the now-empty ToolViews.tsx `check:chinese` allowlist entry orphaned by the first commit.

## 3. `e96b319` — backend default locale switched to English

`DEFAULT_LOCALE` was `"zh"` while the GUI's pre-boot default has always been English (`fallbackLng: 'en'`): the two halves disagreed precisely when nothing was known about the user. Backend now defaults to `"en"`; every stated preference wins exactly as before. Error-contract tests that implicitly pinned the old default now pin the new one via the English catalog values.

## Verified out of scope (audited, already correct)

`_describe.py` summaries, `_engine.py` rule-layer labels, fail-closed fallbacks, `_scheduler.py` locale persistence, i18n catalog parity (zh/en 1775 keys each, no gaps, no CJK in en values). The synthesized intent never persists (`UserInput.from_runtime` stores raw text + blocks), so old sessions pick up the fix on their next turn; already-generated classifier reasons in history remain frozen (free text, no id — explicitly out of scope).

## Known items deliberately left open

- `/help` preamble is still hardcoded English (no `agent.input.help_intent` catalog entry); self-mitigated by its own trailing language clause.
- A workflow run's pinned input re-renders each round, so its preamble locale can in principle flip after a mid-run language switch; the pre-existing behavior was *always Chinese*, strictly worse. Root fix needs a persisted per-run locale (store schema change).
- `detect_locale(' a.txt')` → `en`: a bare `名.扩展名` filename counts as two Latin words and can outvote a zh locale (mirror of bug 2, pre-existing in `detect_locale`).
- basedpyright reports `_classifier.py` `_parse`'s `not isinstance(content, str)` guard unreachable — pre-existing, untouched.

## Test plan

- [x] `test_reason_language_falls_back_to_locale` — three-layer contract (user language → locale → never from reviewed content); RED before, GREEN after
- [x] `test_intent_language_falls_back_to_the_client_locale` — 4 checks incl. CJK labels under an en locale; RED before, GREEN after
- [x] `uv run pytest -q --timeout=300 --timeout-method=thread` → 352 passed
- [x] `bun run test` → 1452 pass / 6 skip / 0 fail; `typecheck` / `lint` / `check:chinese` clean
- [x] Replayed real persisted `user_input` rows from a live `state.db` through `render_input` under both locales

## Reviewer notes

- `_ui_language` is module-private, now imported across packages (precedent: `_cognitive.py` imports `_view`); say the word to promote it.
- The language-fallback wording now exists in two places (`_prompt.py:91` and the classifier prompt) with no shared constant — flagged for a follow-up if drift becomes a concern.
- Independent `/code-review` (xhigh) ran on the middle commit's working tree; its confirmed findings (flattened-input hole, orphaned allowlist entry, docstring contradiction) are all fixed in `462cb56`.