### PR TITLE
fix: migrate legacy provider model limits

### DIFF
--- a/desktop/apps/electron/src/main/__tests__/task-file-guard.test.ts
+++ b/desktop/apps/electron/src/main/__tests__/task-file-guard.test.ts
@@ -9,26 +9,20 @@ import { isAllowedTaskFileWrite } from '../task-file-guard'
 const ROOT = '/Users/me/.bridgic'
 
 describe('isAllowedTaskFileWrite', () => {
-  it('accepts a session .work/.build/task.md under the bridgic root', () => {
+  it('accepts only a session .work/.build/task.md under the bridgic root', () => {
     expect(isAllowedTaskFileWrite(`${ROOT}/AmphiAgent/sessions/s1/.work/.build/task.md`, ROOT)).toBe(true)
-  })
 
-  it('rejects paths outside the bridgic root', () => {
-    expect(isAllowedTaskFileWrite('/etc/passwd', ROOT)).toBe(false)
-    expect(isAllowedTaskFileWrite('/Users/me/Desktop/x/.work/.build/task.md', ROOT)).toBe(false)
-  })
-
-  it('rejects traversal that climbs out of the root', () => {
-    expect(isAllowedTaskFileWrite(`${ROOT}/../evil/.work/.build/task.md`, ROOT)).toBe(false)
-  })
-
-  it('rejects a wrong filename or wrong parent dir', () => {
-    expect(isAllowedTaskFileWrite(`${ROOT}/s1/.work/secrets.md`, ROOT)).toBe(false)
-    expect(isAllowedTaskFileWrite(`${ROOT}/s1/notwork/task.md`, ROOT)).toBe(false)
-    expect(isAllowedTaskFileWrite(`${ROOT}/s1/notwork/.build/task.md`, ROOT)).toBe(false)
-  })
-
-  it('rejects relative / non-absolute input', () => {
-    expect(isAllowedTaskFileWrite('.work/.build/task.md', ROOT)).toBe(false)
+    const rejected = [
+      '/etc/passwd',
+      '/Users/me/Desktop/x/.work/.build/task.md',
+      `${ROOT}/../evil/.work/.build/task.md`,
+      `${ROOT}/s1/.work/secrets.md`,
+      `${ROOT}/s1/notwork/task.md`,
+      `${ROOT}/s1/notwork/.build/task.md`,
+      '.work/.build/task.md',
+    ]
+    for (const path of rejected) {
+      expect(isAllowedTaskFileWrite(path, ROOT)).toBe(false)
+    }
   })
 })

--- a/desktop/apps/electron/src/main/__tests__/update-guards.test.ts
+++ b/desktop/apps/electron/src/main/__tests__/update-guards.test.ts
@@ -12,23 +12,12 @@ function state(overrides: Partial<UpdateCheckState> = {}): UpdateCheckState {
 }
 
 describe('deciding whether an update check may start', () => {
-  it('runs when nothing is in the way', () => {
+  it('returns the blocking reason with stable precedence', () => {
     expect(updateCheckBlockedBy(state())).toBeNull()
-  })
-
-  it('reports a disabled build rather than silently doing nothing', () => {
     expect(updateCheckBlockedBy(state({ updaterEnabled: false }))).toBe('disabled')
-  })
-
-  it('refuses while a round is still open', () => {
     expect(updateCheckBlockedBy(state({ checkInFlight: true }))).toBe('busy')
-  })
-
-  it('refuses once something is staged, so it is not downloaded twice', () => {
     expect(updateCheckBlockedBy(state({ hasStagedUpdate: true }))).toBe('staged')
-  })
 
-  it('refuses during the installer handover', () => {
     // The scenario this exists for: on macOS the handover runs
     // `nativeUpdater.checkForUpdates()`, and Squirrel spends up to four minutes
     // re-fetching the archive through a loopback proxy this process owns. Any
@@ -37,23 +26,7 @@ describe('deciding whether an update check may start', () => {
     // complete a download whose `updateDownloaded()` closes that proxy out from
     // under Squirrel (MacUpdater.js:124).
     expect(updateCheckBlockedBy(state({ handoverStarted: true }))).toBe('busy')
-  })
 
-  it('still refuses during handover after the staged flag was cleared', () => {
-    // Precisely the post-error state: the `error` handler sets stagedUpdate to
-    // null and checkInFlight to false, so every other guard opens up. Only the
-    // handover flag is left to say no.
-    expect(
-      updateCheckBlockedBy({
-        updaterEnabled: true,
-        checkInFlight: false,
-        hasStagedUpdate: false,
-        handoverStarted: true,
-      }),
-    ).toBe('busy')
-  })
-
-  it('reports disabled ahead of everything else', () => {
     // A build with no feed cannot be "busy": saying so would send Settings
     // looking for a round that does not exist.
     expect(

--- a/desktop/apps/electron/src/main/__tests__/update-retry.test.ts
+++ b/desktop/apps/electron/src/main/__tests__/update-retry.test.ts
@@ -2,42 +2,29 @@ import { describe, expect, it } from 'bun:test'
 import { advanceRetry, isRetriableUpdateError, retryDelayMs } from '../update-retry'
 
 describe('deciding whether an update failure is worth retrying', () => {
-  it('gives up on a feed that has no build for this architecture', () => {
+  it('retries transient failures and rejects permanent release errors', () => {
     // Retrying cannot conjure an artifact the release never contained; Intel
     // machines hit exactly this before the arm64/x64 feeds were merged.
-    expect(isRetriableUpdateError('ERR_UPDATER_ZIP_FILE_NOT_FOUND')).toBe(false)
-    expect(isRetriableUpdateError('ERR_UPDATER_ASSET_NOT_FOUND')).toBe(false)
-  })
+    for (const code of [
+      'ERR_UPDATER_ZIP_FILE_NOT_FOUND',
+      'ERR_UPDATER_ASSET_NOT_FOUND',
+      'ERR_UPDATER_INVALID_SIGNATURE',
+      'ERR_UPDATER_INVALID_PROVIDER_CONFIGURATION',
+      'ERR_UPDATER_UNSUPPORTED_PROVIDER',
+    ]) {
+      expect(isRetriableUpdateError(code)).toBe(false)
+    }
 
-  it('gives up on a rejected signature rather than hammering the feed', () => {
-    expect(isRetriableUpdateError('ERR_UPDATER_INVALID_SIGNATURE')).toBe(false)
-  })
-
-  it('gives up on a misconfigured provider', () => {
-    expect(isRetriableUpdateError('ERR_UPDATER_INVALID_PROVIDER_CONFIGURATION')).toBe(false)
-    expect(isRetriableUpdateError('ERR_UPDATER_UNSUPPORTED_PROVIDER')).toBe(false)
-  })
-
-  it('retries a bare network failure, which carries no code at all', () => {
     // The case this whole ladder exists for: a laptop that slept or changed
     // network mid-download. electron-updater surfaces those without a `code`.
     expect(isRetriableUpdateError(undefined)).toBe(true)
-  })
-
-  it('retries a corrupted download', () => {
     // A checksum mismatch means the bytes arrived wrong, not that the release
     // is wrong -- refetching is exactly the right response.
     expect(isRetriableUpdateError('ERR_CHECKSUM_MISMATCH')).toBe(true)
-  })
-
-  it('retries an unrecognised code instead of going silent for four hours', () => {
     // Unknown reasons are treated as transient on purpose: a missed retry costs
     // the user a long wait, while a pointless one costs a bounded handful of
     // requests.
     expect(isRetriableUpdateError('ERR_SOMETHING_NOBODY_HAS_SEEN_YET')).toBe(true)
-  })
-
-  it('retries a feed that is momentarily unreachable', () => {
     // A CDN blip and a permanently wrong URL are indistinguishable here, and
     // the blip is far more common.
     expect(isRetriableUpdateError('ERR_UPDATER_CHANNEL_FILE_NOT_FOUND')).toBe(true)
@@ -45,27 +32,18 @@ describe('deciding whether an update failure is worth retrying', () => {
 })
 
 describe('spacing out update retries', () => {
-  it('starts within a minute rather than at the next four-hourly tick', () => {
+  it('uses a bounded geometric ladder below the regular check interval', () => {
     expect(retryDelayMs(0)).toBe(60_000)
-  })
-
-  it('backs off geometrically so a persistent outage is not hammered', () => {
     const ladder = [0, 1, 2, 3].map(retryDelayMs)
 
     expect(ladder).toEqual([60_000, 120_000, 240_000, 480_000])
     for (let i = 1; i < ladder.length; i++) {
       expect(ladder[i]!).toBeGreaterThan(ladder[i - 1]!)
     }
-  })
-
-  it('stops rather than retrying forever', () => {
     // Past the ladder the regular timer takes over again. Without this the app
     // would keep a retry loop alive for its whole tray-resident lifetime.
     expect(retryDelayMs(4)).toBeNull()
     expect(retryDelayMs(99)).toBeNull()
-  })
-
-  it('spends less than the regular check interval on the whole ladder', () => {
     // Otherwise the retries would outlive the 4h tick they are meant to bridge,
     // and the two schedules would start racing each other.
     let total = 0
@@ -80,12 +58,9 @@ describe('spacing out update retries', () => {
 })
 
 describe('carrying the ladder across failure rounds', () => {
-  it('advances one rung per failure', () => {
+  it('advances, resets after exhaustion, and starts a fresh round', () => {
     expect(advanceRetry(0)).toEqual({ delayMs: 60_000, nextAttempt: 1 })
     expect(advanceRetry(2)).toEqual({ delayMs: 240_000, nextAttempt: 3 })
-  })
-
-  it('rewinds to the start once the ladder is spent', () => {
     // The bug this pins: leaving the counter at its maximum armed the backoff
     // exactly once per process. On a feed that is down for a while, every later
     // transient failure -- including one hours afterwards -- found the ladder
@@ -93,9 +68,6 @@ describe('carrying the ladder across failure rounds', () => {
     // behaviour this module exists to replace.
     expect(advanceRetry(4)).toEqual({ delayMs: null, nextAttempt: 0 })
     expect(advanceRetry(99)).toEqual({ delayMs: null, nextAttempt: 0 })
-  })
-
-  it('lets a fresh round get the full ladder again', () => {
     let attempt = 0
     for (let i = 0; i < 4; i++) attempt = advanceRetry(attempt).nextAttempt
     const spent = advanceRetry(attempt)

--- a/desktop/apps/electron/src/main/__tests__/zoom-keys.test.ts
+++ b/desktop/apps/electron/src/main/__tests__/zoom-keys.test.ts
@@ -9,27 +9,15 @@ import { ZOOM_LEVEL_STEP } from '@app/shared/types'
 import { pickZoomDelta } from '../zoom-keys'
 
 describe('pickZoomDelta', () => {
-  it('treats un-shifted "=" as zoom in — that is the key users actually press', () => {
+  it('handles supplemental zoom keys without duplicating menu accelerators', () => {
     expect(pickZoomDelta('=', 'Equal', false)).toBe(ZOOM_LEVEL_STEP)
-  })
-
-  it('ignores shifted "=" (that is "+", owned by the menu accelerator)', () => {
     // 认了就会与 CmdOrCtrl+Plus 重复触发,一次按键跳两级。
     expect(pickZoomDelta('+', 'Equal', true)).toBeNull()
     expect(pickZoomDelta('=', 'Equal', true)).toBeNull()
-  })
-
-  it('handles the numeric keypad', () => {
     expect(pickZoomDelta('+', 'NumpadAdd', false)).toBe(ZOOM_LEVEL_STEP)
     expect(pickZoomDelta('-', 'NumpadSubtract', false)).toBe(-ZOOM_LEVEL_STEP)
-  })
-
-  it('leaves the menu-owned keys alone', () => {
     expect(pickZoomDelta('-', 'Minus', false)).toBeNull()
     expect(pickZoomDelta('0', 'Digit0', false)).toBeNull()
-  })
-
-  it('ignores unrelated keys and missing fields', () => {
     expect(pickZoomDelta('w', 'KeyW', false)).toBeNull()
     expect(pickZoomDelta(undefined, undefined, false)).toBeNull()
   })

--- a/desktop/apps/electron/src/main/handlers/__tests__/fs-watch-core.test.ts
+++ b/desktop/apps/electron/src/main/handlers/__tests__/fs-watch-core.test.ts
@@ -6,33 +6,18 @@ import { describe, expect, test } from 'bun:test'
 import { reconcileWatchSet } from '../fs-watch-core'
 
 describe('reconcileWatchSet', () => {
-  test('empty → empty is a no-op', () => {
-    expect(reconcileWatchSet([], [])).toEqual({ toAdd: [], toRemove: [] })
-  })
-
-  test('all-new desired paths are added', () => {
-    expect(reconcileWatchSet([], ['/a', '/b'])).toEqual({ toAdd: ['/a', '/b'], toRemove: [] })
-  })
-
-  test('vanished paths are removed', () => {
-    expect(reconcileWatchSet(['/a', '/b'], ['/a'])).toEqual({ toAdd: [], toRemove: ['/b'] })
-  })
-
-  test('mixed add + remove', () => {
-    const r = reconcileWatchSet(['/a', '/b'], ['/b', '/c'])
-    expect(r.toAdd).toEqual(['/c'])
-    expect(r.toRemove).toEqual(['/a'])
-  })
-
-  test('idempotent: equal sets yield empty diffs', () => {
-    expect(reconcileWatchSet(['/a', '/b'], ['/b', '/a'])).toEqual({ toAdd: [], toRemove: [] })
-  })
-
-  test('deduplicates inputs (same path twice → watched once)', () => {
-    expect(reconcileWatchSet([], ['/a', '/a'])).toEqual({ toAdd: ['/a'], toRemove: [] })
-  })
-
-  test('drops empty / blank paths', () => {
-    expect(reconcileWatchSet([''], ['', '/a'])).toEqual({ toAdd: ['/a'], toRemove: [] })
+  test('computes normalized additions and removals', () => {
+    const cases: [string[], string[], { toAdd: string[]; toRemove: string[] }][] = [
+      [[], [], { toAdd: [], toRemove: [] }],
+      [[], ['/a', '/b'], { toAdd: ['/a', '/b'], toRemove: [] }],
+      [['/a', '/b'], ['/a'], { toAdd: [], toRemove: ['/b'] }],
+      [['/a', '/b'], ['/b', '/c'], { toAdd: ['/c'], toRemove: ['/a'] }],
+      [['/a', '/b'], ['/b', '/a'], { toAdd: [], toRemove: [] }],
+      [[], ['/a', '/a'], { toAdd: ['/a'], toRemove: [] }],
+      [[''], ['', '/a'], { toAdd: ['/a'], toRemove: [] }],
+    ]
+    for (const [current, desired, expected] of cases) {
+      expect(reconcileWatchSet(current, desired)).toEqual(expected)
+    }
   })
 })

--- a/desktop/apps/electron/src/main/python-client/__tests__/compatibility.test.ts
+++ b/desktop/apps/electron/src/main/python-client/__tests__/compatibility.test.ts
@@ -12,62 +12,39 @@ import { describe, expect, it } from 'bun:test'
 import { CompatibilityState, compareBackendVersion, isCompatible } from '../compatibility'
 
 describe('compareBackendVersion', () => {
-  it('passes only on exact equality', () => {
+  it('distinguishes exact, missing, older, and newer versions', () => {
     expect(compareBackendVersion('0.1.0', '0.1.0')).toEqual({
       state: CompatibilityState.Compatible,
     })
-  })
-
-  it('reports unknown when the daemon never gave a version', () => {
-    expect(compareBackendVersion('0.1.0', null)).toEqual({
-      state: CompatibilityState.Unknown,
-      expected: '0.1.0',
-    })
-    expect(compareBackendVersion('0.1.0', undefined)).toEqual({
-      state: CompatibilityState.Unknown,
-      expected: '0.1.0',
-    })
-  })
-
-  it('treats an empty version string as unknown, not as a mismatch against ""', () => {
     // An older runtime.json writes "" for a present-but-unset field. Reporting
     // `incompatible: actual=""` would put an empty version in the user-facing
     // message and send them looking for a daemon that claims to be nothing.
-    expect(compareBackendVersion('0.1.0', '')).toEqual({
-      state: CompatibilityState.Unknown,
-      expected: '0.1.0',
-    })
-  })
+    for (const missing of [null, undefined, '']) {
+      expect(compareBackendVersion('0.1.0', missing)).toEqual({
+        state: CompatibilityState.Unknown,
+        expected: '0.1.0',
+      })
+    }
 
-  it('reports an older daemon as incompatible', () => {
-    expect(compareBackendVersion('0.1.0', '0.0.9')).toEqual({
-      state: CompatibilityState.Incompatible,
-      expected: '0.1.0',
-      actual: '0.0.9',
-    })
-  })
-
-  it('reports a NEWER daemon as incompatible too', () => {
     // Happens when the GUI is downgraded, or when a dev runs an old packaged
     // build against a freshly built daemon. Neither combination was shipped.
-    expect(compareBackendVersion('0.1.0', '0.2.0')).toEqual({
-      state: CompatibilityState.Incompatible,
-      expected: '0.1.0',
-      actual: '0.2.0',
-    })
+    for (const actual of ['0.0.9', '0.2.0']) {
+      expect(compareBackendVersion('0.1.0', actual)).toEqual({
+        state: CompatibilityState.Incompatible,
+        expected: '0.1.0',
+        actual,
+      })
+    }
   })
 })
 
 describe('isCompatible', () => {
-  it('is true only for the compatible verdict', () => {
+  it('passes compatible and unevaluated verdicts only', () => {
     expect(isCompatible({ state: CompatibilityState.Compatible })).toBe(true)
     expect(isCompatible({ state: CompatibilityState.Unknown, expected: '1.0.0' })).toBe(false)
     expect(
       isCompatible({ state: CompatibilityState.Incompatible, expected: '1.0.0', actual: '0.9.0' }),
     ).toBe(false)
-  })
-
-  it('treats a null verdict as "gate not evaluated" and passes', () => {
     // Development builds have no packaged manifest; blocking them would make
     // `bun run dev` unusable before anyone has run a full build.
     expect(isCompatible(null)).toBe(true)

--- a/desktop/apps/electron/src/main/python-client/__tests__/runtime-file.test.ts
+++ b/desktop/apps/electron/src/main/python-client/__tests__/runtime-file.test.ts
@@ -247,19 +247,10 @@ describe('tokenRotated', () => {
   if (candidate.token === null) throw new Error('test fixture must carry a token')
   const current = { ...candidate, token: candidate.token }
 
-  it('is false when runtime.json still carries the same token', () => {
+  it('detects only a concrete replacement token', () => {
     expect(tokenRotated(current, mkRuntime({ token: 'tok_abc' }))).toBe(false)
-  })
-
-  it('is true when runtime.json carries a NEW token (daemon restarted)', () => {
     expect(tokenRotated(current, mkRuntime({ token: 'tok_NEW_after_restart' }))).toBe(true)
-  })
-
-  it('is false when runtime is null (file missing / mid-rewrite — not a rotation)', () => {
     expect(tokenRotated(current, null)).toBe(false)
-  })
-
-  it('is false when runtime token is null (degenerate — keep the good token)', () => {
     expect(tokenRotated(current, mkRuntime({ token: null }))).toBe(false)
   })
 })

--- a/desktop/apps/electron/src/renderer/atoms/__tests__/sessions.test.ts
+++ b/desktop/apps/electron/src/renderer/atoms/__tests__/sessions.test.ts
@@ -61,19 +61,10 @@ describe('pickInitialSession (boot-time restore target)', () => {
     { id: 'b', title: 'B', createdAt: 0, updatedAt: 0 },
   ]
 
-  it('returns the last session id when it still exists', () => {
+  it('restores only a remembered session that still exists', () => {
     expect(pickInitialSession(metas, 'b')).toBe('b')
-  })
-
-  it('returns null when the last session was deleted on the daemon', () => {
     expect(pickInitialSession(metas, 'gone')).toBeNull()
-  })
-
-  it('returns null when there is no remembered session', () => {
     expect(pickInitialSession(metas, null)).toBeNull()
-  })
-
-  it('returns null when the session list is empty', () => {
     expect(pickInitialSession([], 'a')).toBeNull()
   })
 })
@@ -81,23 +72,14 @@ describe('pickInitialSession (boot-time restore target)', () => {
 describe('nextPersistedSessionId (boot-time restore source — "reopen = exact last view")', () => {
   const drafts = new Set(['draft-1'])
 
-  it('persists null while on a draft (新会话/Landing) so reopen returns to Landing, NOT the last real session', () => {
+  it('persists drafts, real sessions, and boot transients correctly', () => {
     // The reported bug: 点新会话后刷新跳回旧会话。Locking: a draft active id must
     // overwrite the remembered real id with null.
     expect(nextPersistedSessionId('draft-1', drafts, 'session_real')).toBeNull()
-  })
-
-  it('persists the real session id when a non-draft session is active', () => {
     expect(nextPersistedSessionId('session_real', drafts, null)).toBe('session_real')
-  })
-
-  it('keeps the remembered id untouched while active is null (boot transient before restore)', () => {
     // Must NOT clobber the id useSessionBootstrap is about to read.
     expect(nextPersistedSessionId(null, drafts, 'session_real')).toBe('session_real')
     expect(nextPersistedSessionId(null, drafts, null)).toBeNull()
-  })
-
-  it('is idempotent: a real active id already remembered yields the same value (caller skips write)', () => {
     expect(nextPersistedSessionId('session_real', drafts, 'session_real')).toBe('session_real')
   })
 })
@@ -107,28 +89,17 @@ describe('bootPendingAtom (闪 Landing 防抖占位)', () => {
     store.set(backendSnapshotAtom, { state, endpoint: null, lastError: null, compatibility: null })
   }
 
-  it('pending while bootstrap has not landed (default backend state)', () => {
+  it('stays pending only until bootstrap lands or the daemon is unavailable', () => {
     const store = makeStore()
     expect(store.get(bootPendingAtom)).toBe(true)
-  })
-
-  it('clears once bootstrap marks landed — center may now show Landing/Pipeline', () => {
-    const store = makeStore()
     store.set(markBootLandedAtom)
     expect(store.get(bootPendingAtom)).toBe(false)
-  })
-
-  it('releases the placeholder when the daemon is Unavailable (never lands) so Landing can show', () => {
-    const store = makeStore()
-    setBackendState(store, BackendState.Unavailable)
-    expect(store.get(bootPendingAtom)).toBe(false)
-  })
-
-  it('stays cleared after landing even if backend state keeps changing', () => {
-    const store = makeStore()
-    store.set(markBootLandedAtom)
     setBackendState(store, BackendState.Discovering)
     expect(store.get(bootPendingAtom)).toBe(false)
+
+    const unavailableStore = makeStore()
+    setBackendState(unavailableStore, BackendState.Unavailable)
+    expect(unavailableStore.get(bootPendingAtom)).toBe(false)
   })
 })
 

--- a/desktop/apps/electron/src/renderer/components/amphi/__tests__/CenterViews.test.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/__tests__/CenterViews.test.tsx
@@ -145,23 +145,11 @@ describe('filterWorkflows', () => {
     { id: 'wf_3', name: 'Weekly Report' },
   ]
 
-  it('returns every row for a blank query', () => {
+  it('filters names and descriptions with normalized query text', () => {
     expect(filterWorkflows(rows, '   ').map((r) => r.id)).toEqual(['wf_1', 'wf_2', 'wf_3'])
-  })
-
-  it('matches on name', () => {
     expect(filterWorkflows(rows, '发票').map((r) => r.id)).toEqual(['wf_2'])
-  })
-
-  it('matches on description too', () => {
     expect(filterWorkflows(rows, '主题相关性').map((r) => r.id)).toEqual(['wf_1'])
-  })
-
-  it('ignores case and surrounding spaces, and tolerates a missing description', () => {
     expect(filterWorkflows(rows, '  WEEKLY ').map((r) => r.id)).toEqual(['wf_3'])
-  })
-
-  it('returns nothing when no row matches', () => {
     expect(filterWorkflows(rows, '不存在的关键词')).toEqual([])
   })
 })

--- a/desktop/apps/electron/src/renderer/components/amphi/__tests__/skill-conflict.test.ts
+++ b/desktop/apps/electron/src/renderer/components/amphi/__tests__/skill-conflict.test.ts
@@ -10,16 +10,10 @@ import { describe, it, expect } from 'bun:test'
 import { formatUpdatedAt, hasDescChanged, isNewer } from '../SkillConflictRow'
 
 describe('isNewer', () => {
-  it('returns true when a is lexically after b (ISO-8601)', () => {
+  it('compares ISO stamps and treats missing values as non-newer', () => {
     expect(isNewer('2026-06-20T09:05:00', '2026-03-12T14:20:00')).toBe(true)
-  })
-
-  it('returns false when a is older or equal', () => {
     expect(isNewer('2026-03-12T14:20:00', '2026-06-20T09:05:00')).toBe(false)
     expect(isNewer('2026-06-20T09:05:00', '2026-06-20T09:05:00')).toBe(false)
-  })
-
-  it('returns false when either side is null (a missing stamp never wins)', () => {
     expect(isNewer(null, '2026-06-20T09:05:00')).toBe(false)
     expect(isNewer('2026-06-20T09:05:00', null)).toBe(false)
     expect(isNewer(null, null)).toBe(false)
@@ -27,30 +21,18 @@ describe('isNewer', () => {
 })
 
 describe('hasDescChanged', () => {
-  it('detects a differing description', () => {
+  it('detects meaningful description changes', () => {
     expect(hasDescChanged('new text', 'old text')).toBe(true)
-  })
-
-  it('treats a null existing description as a change when incoming has text', () => {
     expect(hasDescChanged('text', null)).toBe(true)
-  })
-
-  it('returns false when both sides are identical', () => {
     expect(hasDescChanged('same', 'same')).toBe(false)
     expect(hasDescChanged(null, null)).toBe(false)
   })
 })
 
 describe('formatUpdatedAt', () => {
-  it('renders an ISO stamp as YYYY-MM-DD HH:mm', () => {
+  it('formats ISO stamps without seconds and handles null', () => {
     expect(formatUpdatedAt('2026-06-20T09:05:00')).toBe('2026-06-20 09:05')
-  })
-
-  it('drops seconds and any trailing timezone', () => {
     expect(formatUpdatedAt('2026-06-20T09:05:42Z')).toBe('2026-06-20 09:05')
-  })
-
-  it('renders an em dash for null', () => {
     expect(formatUpdatedAt(null)).toBe('—')
   })
 })

--- a/desktop/apps/electron/src/renderer/components/composer/__tests__/canSendNow.test.ts
+++ b/desktop/apps/electron/src/renderer/components/composer/__tests__/canSendNow.test.ts
@@ -11,25 +11,13 @@ import { canSendNow } from '../canSendNow'
 const SESSION = 's-1'
 
 describe('canSendNow', () => {
-  it('会话就绪且空闲时可发送', () => {
+  it('只允许已有会话的空闲状态发送', () => {
     expect(canSendNow(SESSION, false, false)).toBe(true)
-  })
-
-  it('streaming 期间不可发送 —— 输入框此时是可用的,闸门只在这里', () => {
     // 回归:把 streaming 从 ChatInputZone 的 disabled 里摘掉后,这条是唯一
     // 阻止消息发给 serial-chat daemon 的守卫。删了它 = 用户发出去被拒。
     expect(canSendNow(SESSION, false, true)).toBe(false)
-  })
-
-  it('parked 审批(disabled)期间不可发送', () => {
     expect(canSendNow(SESSION, true, false)).toBe(false)
-  })
-
-  it('没有会话时不可发送', () => {
     expect(canSendNow(null, false, false)).toBe(false)
-  })
-
-  it('任一条件不满足即拒 —— 组合情形', () => {
     expect(canSendNow(null, true, true)).toBe(false)
     expect(canSendNow(SESSION, true, true)).toBe(false)
     expect(canSendNow(null, false, true)).toBe(false)

--- a/desktop/apps/electron/src/renderer/components/markdown/__tests__/normalizeMathFences.test.ts
+++ b/desktop/apps/electron/src/renderer/components/markdown/__tests__/normalizeMathFences.test.ts
@@ -9,72 +9,42 @@ import { describe, expect, it } from 'bun:test'
 import { normalizeMathFences } from '../normalizeMathFences'
 
 describe('normalizeMathFences — 拆开会被吞掉的跨行围栏', () => {
-  it('$$ 紧跟内容 + 跨行(模型最常见的矩阵写法)', () => {
+  it('拆开粘连的开闭围栏并保留合法缩进', () => {
     const input = '$$\\begin{pmatrix}\na & b \\\\\nc & d\n\\end{pmatrix}$$'
     expect(normalizeMathFences(input)).toBe(
       '$$\n\\begin{pmatrix}\na & b \\\\\nc & d\n\\end{pmatrix}\n$$',
     )
-  })
-
-  it('只有开围栏紧跟内容时,也拆', () => {
     expect(normalizeMathFences('$$\\begin{vmatrix}\na\n$$')).toBe('$$\n\\begin{vmatrix}\na\n$$')
-  })
-
-  it('只有闭围栏被粘住时,也拆', () => {
     expect(normalizeMathFences('$$\na\n\\end{vmatrix}$$')).toBe('$$\na\n\\end{vmatrix}\n$$')
-  })
-
-  it('保留缩进(≤3 空格仍是 markdown 块级上下文)', () => {
     expect(normalizeMathFences('  $$\\begin{pmatrix}\na\n$$')).toBe('  $$\n\\begin{pmatrix}\na\n$$')
   })
 })
 
 describe('normalizeMathFences — 不得误伤当前渲染正常的写法', () => {
-  it('完整单行公式原样不动(它走行内 math,拆了会变 display 样式)', () => {
-    const input = '$$x = \\frac{-b \\pm \\sqrt{b^2-4ac}}{2a}$$'
-    expect(normalizeMathFences(input)).toBe(input)
-  })
-
-  it('单行公式 + 后置文字,不动', () => {
-    const input = '$$a$$ 后面的文字'
-    expect(normalizeMathFences(input)).toBe(input)
-  })
-
-  it('一行里两个完整公式,不动', () => {
-    const input = '$$a$$ 中间 $$b$$'
-    expect(normalizeMathFences(input)).toBe(input)
-  })
-
-  it('已经合规的块级围栏,不动', () => {
-    const input = '$$\n\\begin{pmatrix}\na & b\n\\end{pmatrix}\n$$'
-    expect(normalizeMathFences(input)).toBe(input)
-  })
-
-  it('行内单 $ 公式,不动', () => {
-    const input = '质能方程 $E = mc^2$ 众所周知'
-    expect(normalizeMathFences(input)).toBe(input)
-  })
-
-  it('完全没有 $$ 的文档,逐字返回', () => {
-    const input = '# 标题\n\n普通段落 `code` **粗体**'
-    expect(normalizeMathFences(input)).toBe(input)
+  it('逐字保留单行、合规块级、行内和普通 Markdown', () => {
+    const unchanged = [
+      '$$x = \\frac{-b \\pm \\sqrt{b^2-4ac}}{2a}$$',
+      '$$a$$ 后面的文字',
+      '$$a$$ 中间 $$b$$',
+      '$$\n\\begin{pmatrix}\na & b\n\\end{pmatrix}\n$$',
+      '质能方程 $E = mc^2$ 众所周知',
+      '# 标题\n\n普通段落 `code` **粗体**',
+    ]
+    for (const input of unchanged) {
+      expect(normalizeMathFences(input)).toBe(input)
+    }
   })
 })
 
 describe('normalizeMathFences — 代码块内一律不碰', () => {
-  it('``` 围栏里的 $$ 写法不被改写(否则会毁掉讲解 $$ 语法的示例)', () => {
+  it('跳过两类代码围栏但继续处理代码块外内容', () => {
     const input = '```md\n$$\\begin{pmatrix}\na\n\\end{pmatrix}$$\n```'
     expect(normalizeMathFences(input)).toBe(input)
-  })
+    const tildeInput = '~~~\n$$\\begin{x}\na\n\\end{x}$$\n~~~'
+    expect(normalizeMathFences(tildeInput)).toBe(tildeInput)
 
-  it('~~~ 围栏同样跳过', () => {
-    const input = '~~~\n$$\\begin{x}\na\n\\end{x}$$\n~~~'
-    expect(normalizeMathFences(input)).toBe(input)
-  })
-
-  it('代码块之外的照常处理', () => {
-    const input = '```\n$$\\begin{a}\n```\n\n$$\\begin{pmatrix}\nb\n\\end{pmatrix}$$'
-    const out = normalizeMathFences(input)
+    const mixedInput = '```\n$$\\begin{a}\n```\n\n$$\\begin{pmatrix}\nb\n\\end{pmatrix}$$'
+    const out = normalizeMathFences(mixedInput)
     // 代码块内那行原样
     expect(out).toContain('```\n$$\\begin{a}\n```')
     // 代码块外的被拆开
@@ -104,23 +74,15 @@ describe('normalizeMathFences — 真实回归用例', () => {
     '$$\\sum_{i=1}^{n} i = \\frac{n(n+1)}{2}$$',
   ].join('\n')
 
-  it('两个跨行矩阵都被拆开,单行求和公式不动', () => {
+  it('修复真实回复，同时保留标题、单行公式和幂等性', () => {
     const out = normalizeMathFences(REAL)
     expect(out).toContain('$$\n\\begin{pmatrix}\na & b \\\\\nc & d\n\\end{pmatrix}\n$$')
     expect(out).toContain('$$\n\\det(A) = \\begin{vmatrix}')
     expect(out).toContain('\\end{vmatrix}\n$$')
     // 单行的求和公式保持原样(它本来就渲染正常)
     expect(out).toContain('$$\\sum_{i=1}^{n} i = \\frac{n(n+1)}{2}$$')
-  })
-
-  it('markdown 标题不受影响', () => {
-    const out = normalizeMathFences(REAL)
     expect(out).toContain('### 线性代数')
     expect(out).toContain('### 求和与乘积')
-  })
-
-  it('幂等 —— 跑两遍与跑一遍结果相同', () => {
-    const once = normalizeMathFences(REAL)
-    expect(normalizeMathFences(once)).toBe(once)
+    expect(normalizeMathFences(out)).toBe(out)
   })
 })

--- a/desktop/apps/electron/src/renderer/lib/__tests__/cron.test.ts
+++ b/desktop/apps/electron/src/renderer/lib/__tests__/cron.test.ts
@@ -18,64 +18,33 @@ describe('pad2', () => {
 })
 
 describe('describeCronCN', () => {
-  it('每分钟 / 每分钟第 N 秒', () => {
+  it('描述常用周期，并对可能误读的表达式保守回退', () => {
     expect(describeCronCN('0 * * * * *')).toBe('每分钟')
     expect(describeCronCN('30 * * * * *')).toBe('每分钟的第 30 秒')
-  })
-
-  it('每小时 / 每小时第 N 分', () => {
     expect(describeCronCN('0 0 * * * *')).toBe('每小时')
     expect(describeCronCN('0 5 * * * *')).toBe('每小时的第 5 分')
-  })
-
-  it('step 语法:每秒 / 每 N 秒·分·时', () => {
     expect(describeCronCN('* * * * * *')).toBe('每秒')
     expect(describeCronCN('*/30 * * * * *')).toBe('每 30 秒')
     expect(describeCronCN('0 */5 * * * *')).toBe('每 5 分钟')
     expect(describeCronCN('0 0 */2 * * *')).toBe('每 2 小时')
-  })
 
-  it('每 N 小时带非零分钟偏移兜底返回原文,不吞 :MM', () => {
     // 回归:`0 30 */2 * * *` 在每 2 小时的第 30 分触发,描成「每 2 小时」会让人误以为整点跑。
     expect(describeCronCN('0 30 */2 * * *')).toBe('0 30 */2 * * *')
-  })
-
-  it('无法归类的语法(range/list)兜底返回原文,不误读', () => {
     // 回归:曾把工作日误读成「每周一」、每 2 小时误读成「每天 00:00」。
     expect(describeCronCN('0 0 9 * * 1-5')).toBe('0 0 9 * * 1-5')
     expect(describeCronCN('0 15,45 * * * *')).toBe('0 15,45 * * * *')
-  })
-
-  it('日/月 与 周 同时约束(cron OR 语义)兜底返回原文,不漏读周约束', () => {
     // 「N 日 或 周五」若只描成「每月 N 日」会静默丢掉周约束 —— 违反不误读不变式。
     expect(describeCronCN('0 0 9 15 * 5')).toBe('0 0 9 15 * 5')
     expect(describeCronCN('0 0 9 15 6 5')).toBe('0 0 9 15 6 5')
     expect(describeCronCN('0 0 14 1 1,4,7,10 5')).toBe('0 0 14 1 1,4,7,10 5')
-  })
 
-  it('每天 时:分', () => {
     expect(describeCronCN('0 0 9 * * *')).toBe('每天 09:00')
     expect(describeCronCN('0 30 8 * * *')).toBe('每天 08:30')
-  })
-
-  it('每周几 时:分', () => {
     expect(describeCronCN('0 0 17 * * 5')).toBe('每周五 17:00')
     expect(describeCronCN('0 0 9 * * 0')).toBe('每周日 09:00')
-  })
-
-  it('每月 N 日 时:分', () => {
     expect(describeCronCN('0 0 2 15 * *')).toBe('每月 15 日 02:00')
-  })
-
-  it('每季度(月列表) N 日 时:分', () => {
     expect(describeCronCN('0 0 14 1 1,4,7,10 *')).toBe('每季度（1月、4月、7月、10月）1 日 14:00')
-  })
-
-  it('每年 月 N 日 时:分', () => {
     expect(describeCronCN('0 0 14 1 1 *')).toBe('每年 1月1 日 14:00')
-  })
-
-  it('非 6 字段:原样 / —', () => {
     expect(describeCronCN('abc')).toBe('abc')
     expect(describeCronCN('')).toBe('—')
   })
@@ -95,33 +64,25 @@ const ST = (o: Partial<CronState>): CronState => ({
 })
 
 describe('buildCron', () => {
-  it('分/时/日/周/月', () => {
+  it('构造所有内置周期和自定义表达式', () => {
     expect(buildCron(ST({ period: CronPeriod.Minute, second: '30' }))).toBe('30 * * * * *')
     expect(buildCron(ST({ period: CronPeriod.Hour, minute: '5' }))).toBe('0 5 * * * *')
     expect(buildCron(ST({ period: CronPeriod.Day, hour: '9', minute: '0' }))).toBe('0 0 9 * * *')
     expect(buildCron(ST({ period: CronPeriod.Week, dayOfWeek: '5', hour: '17', minute: '0' }))).toBe('0 0 17 * * 5')
     expect(buildCron(ST({ period: CronPeriod.Month, dayOfMonth: '15', hour: '2', minute: '0' }))).toBe('0 0 2 15 * *')
-  })
-  it('季度展开成 4 个月列表', () => {
     expect(buildCron(ST({ period: CronPeriod.Quarter, quarterStart: '1', dayOfMonth: '1', hour: '14', minute: '0' }))).toBe('0 0 14 1 1,4,7,10 *')
-  })
-  it('年 / 自定义', () => {
     expect(buildCron(ST({ period: CronPeriod.Year, month: '1', dayOfMonth: '1', hour: '14', minute: '0' }))).toBe('0 0 14 1 1 *')
     expect(buildCron(ST({ period: CronPeriod.Custom, custom: '0 0 2 * * 1' }))).toBe('0 0 2 * * 1')
   })
 })
 
 describe('parseCronToState', () => {
-  it('反解析各模式', () => {
+  it('反解析、回退并保持内置周期 round-trip', () => {
     expect(parseCronToState('0 0 17 * * 5')).toMatchObject({ period: CronPeriod.Week, dayOfWeek: '5', hour: '17', minute: '0' })
     expect(parseCronToState('0 30 8 * * *')).toMatchObject({ period: CronPeriod.Day, hour: '8', minute: '30' })
     expect(parseCronToState('30 * * * * *')).toMatchObject({ period: CronPeriod.Minute, second: '30' })
     expect(parseCronToState('0 0 14 1 1,4,7,10 *')).toMatchObject({ period: CronPeriod.Quarter, quarterStart: '1', dayOfMonth: '1' })
-  })
-  it('非 6 字段 → custom', () => {
     expect(parseCronToState('nonsense')).toMatchObject({ period: CronPeriod.Custom })
-  })
-  it('round-trip 保 period(分/时/日/周/月/季/年)', () => {
     for (const period of [CronPeriod.Minute, CronPeriod.Hour, CronPeriod.Day, CronPeriod.Week, CronPeriod.Month, CronPeriod.Quarter, CronPeriod.Year]) {
       const cron = buildCron(ST({ period, hour: '3', minute: '7', second: '9', dayOfWeek: '2', dayOfMonth: '4', month: '5', quarterStart: '2' }))
       expect(parseCronToState(cron).period).toBe(period)

--- a/desktop/apps/electron/src/renderer/lib/__tests__/file-tree.test.ts
+++ b/desktop/apps/electron/src/renderer/lib/__tests__/file-tree.test.ts
@@ -30,38 +30,30 @@ describe('rebaseTree', () => {
 describe('graftTree', () => {
   const base: DirTreeNode[] = [folder('fapiao'), file('用户画像.xlsx')]
 
-  test('grafts a loaded level into the target node, immutably', () => {
-    const grafted = graftTree(base, 'fapiao', { children: [file('fapiao/行程单.pdf')] })
-    expect(grafted[0]?.children?.[0]?.relPath).toBe('fapiao/行程单.pdf')
+  test('grafts success and failure states immutably along the target chain', () => {
+    const topLevel = graftTree(base, 'fapiao', { children: [file('fapiao/行程单.pdf')] })
+    expect(topLevel[0]?.children?.[0]?.relPath).toBe('fapiao/行程单.pdf')
     // 原树不被修改(immutability)。
     expect(base[0]?.children).toBeUndefined()
     // 未涉及的兄弟节点引用复用。
-    expect(grafted[1]).toBe(base[1])
-  })
+    expect(topLevel[1]).toBe(base[1])
 
-  test('grafts deep targets through the ancestor chain only', () => {
-    const tree = [folder('a', [folder('a/b')])]
-    const grafted = graftTree(tree, 'a/b', { children: [file('a/b/c.txt')] })
-    expect(grafted[0]?.children?.[0]?.children?.[0]?.relPath).toBe('a/b/c.txt')
-  })
+    const deepTree = [folder('a', [folder('a/b')])]
+    const deep = graftTree(deepTree, 'a/b', { children: [file('a/b/c.txt')] })
+    expect(deep[0]?.children?.[0]?.children?.[0]?.relPath).toBe('a/b/c.txt')
 
-  test('marks unreadable on load failure (drops stale children)', () => {
-    const tree = [folder('a', [file('a/x.txt')])]
-    const grafted = graftTree(tree, 'a', { unreadable: true })
-    expect(grafted[0]?.unreadable).toBe(true)
-    expect(grafted[0]?.children).toBeUndefined()
-  })
+    const staleTree = [folder('a', [file('a/x.txt')])]
+    const failed = graftTree(staleTree, 'a', { unreadable: true })
+    expect(failed[0]?.unreadable).toBe(true)
+    expect(failed[0]?.children).toBeUndefined()
 
-  test('clears stale unreadable when a later load succeeds', () => {
-    const tree: DirTreeNode[] = [
+    const unreadableTree: DirTreeNode[] = [
       { name: 'a', kind: 'folder', relPath: 'a', sizeBytes: null, unreadable: true },
     ]
-    const grafted = graftTree(tree, 'a', { children: [] })
-    expect(grafted[0]?.unreadable).toBeUndefined()
-    expect(grafted[0]?.children).toEqual([])
-  })
+    const recovered = graftTree(unreadableTree, 'a', { children: [] })
+    expect(recovered[0]?.unreadable).toBeUndefined()
+    expect(recovered[0]?.children).toEqual([])
 
-  test('unknown relPath leaves the tree unchanged', () => {
     expect(graftTree(base, 'nope/nothing', { children: [] })).toEqual(base)
   })
 })
@@ -78,39 +70,25 @@ describe('findNode', () => {
 })
 
 describe('pruneExpanded', () => {
-  test('keeps a top-level expanded folder that still exists', () => {
-    const nodes = [folder('a'), file('b.txt')]
-    expect([...pruneExpanded(new Set(['a']), nodes)]).toEqual(['a'])
-  })
+  test('keeps only expansions that loaded tree levels can validate', () => {
+    expect([...pruneExpanded(new Set(['a']), [folder('a'), file('b.txt')])]).toEqual(['a'])
+    expect([...pruneExpanded(new Set(['a', 'gone']), [folder('a')])]).toEqual(['a'])
 
-  test('drops a top-level entry the (loaded) root no longer lists — vanished', () => {
-    const nodes = [folder('a')]
-    expect([...pruneExpanded(new Set(['a', 'gone']), nodes)]).toEqual(['a'])
-  })
-
-  test('drops an entry that became a file or unreadable', () => {
-    const nodes = [
+    const invalidNodes = [
       file('nowfile'),
       { name: 'noperm', kind: 'folder' as const, relPath: 'noperm', sizeBytes: null, unreadable: true as const },
     ]
-    expect([...pruneExpanded(new Set(['nowfile', 'noperm']), nodes)]).toEqual([])
-  })
+    expect([...pruneExpanded(new Set(['nowfile', 'noperm']), invalidNodes)]).toEqual([])
 
-  test('KEEPS a deep entry whose parent level is not loaded yet (reload window)', () => {
     // Root re-read dropped deeper levels: `a` has no children loaded → we
     // cannot yet judge `a/b`, so it must survive until the self-heal reloads.
-    const nodes = [folder('a')]
-    expect([...pruneExpanded(new Set(['a', 'a/b']), nodes)]).toEqual(['a', 'a/b'])
-  })
+    expect([...pruneExpanded(new Set(['a', 'a/b']), [folder('a')])]).toEqual(['a', 'a/b'])
 
-  test('drops a deep entry once its parent IS loaded and no longer lists it', () => {
-    const nodes = [folder('a', [file('a/keep.txt')])] // parent loaded, no a/b
-    expect([...pruneExpanded(new Set(['a', 'a/b']), nodes)]).toEqual(['a'])
-  })
+    const missingDeep = [folder('a', [file('a/keep.txt')])] // parent loaded, no a/b
+    expect([...pruneExpanded(new Set(['a', 'a/b']), missingDeep)]).toEqual(['a'])
 
-  test('keeps a deep entry the loaded parent still lists as a folder', () => {
-    const nodes = [folder('a', [folder('a/b')])]
-    expect([...pruneExpanded(new Set(['a', 'a/b']), nodes)]).toEqual(['a', 'a/b'])
+    const presentDeep = [folder('a', [folder('a/b')])]
+    expect([...pruneExpanded(new Set(['a', 'a/b']), presentDeep)]).toEqual(['a', 'a/b'])
   })
 })
 

--- a/desktop/apps/electron/src/renderer/lib/__tests__/schedule.test.ts
+++ b/desktop/apps/electron/src/renderer/lib/__tests__/schedule.test.ts
@@ -48,43 +48,29 @@ const pendingRunRow: ScheduleRun = {
 }
 
 describe('getScheduleStatus', () => {
-  it('needsAction 优先级最高', () => {
+  it('按 needsAction、running、paused、active 的优先级派生', () => {
     expect(getScheduleStatus(mk({ needsAction: 1, running: true, paused: true }))).toBe(
       ScheduleStatus.NeedsAction,
     )
-  })
-  it('running 次之', () => {
     expect(getScheduleStatus(mk({ running: true, paused: true }))).toBe(ScheduleStatus.Running)
-  })
-  it('paused 再次', () => {
     expect(getScheduleStatus(mk({ paused: true }))).toBe(ScheduleStatus.Paused)
-  })
-  it('默认 active', () => {
     expect(getScheduleStatus(mk({}))).toBe(ScheduleStatus.Active)
   })
 })
 
 describe('getPendingRun', () => {
-  it('取 needsAction 那次运行', () => {
+  it('只返回 needsAction 的运行', () => {
     const s = mk({ needsAction: 1, runs: [pendingRunRow] })
     expect(getPendingRun(s)?.sessionId).toBe('sess-1')
-  })
-  it('无挂起运行时 undefined', () => {
     expect(getPendingRun(mk({}))).toBeUndefined()
   })
 })
 
 describe('shouldRefreshSchedulesOnCompletion', () => {
-  it('有待审批(needsAction>0)→ 应重拉', () => {
+  it('只在存在待审批或运行中的计划时重拉', () => {
     expect(shouldRefreshSchedulesOnCompletion([mk({ needsAction: 1 })])).toBe(true)
-  })
-  it('有运行中 → 应重拉(等 run 落地成 completed)', () => {
     expect(shouldRefreshSchedulesOnCompletion([mk({ running: true })])).toBe(true)
-  })
-  it('既无待审批也无运行中 → 不重拉(普通聊天完成不触发 listSchedules)', () => {
     expect(shouldRefreshSchedulesOnCompletion([mk({}), mk({ id: 's2', paused: true })])).toBe(false)
-  })
-  it('空列表 → 不重拉', () => {
     expect(shouldRefreshSchedulesOnCompletion([])).toBe(false)
   })
 })

--- a/desktop/packages/shared/src/types/__tests__/settings.test.ts
+++ b/desktop/packages/shared/src/types/__tests__/settings.test.ts
@@ -19,18 +19,12 @@ import {
 } from '../settings'
 
 describe('clampZoomLevel', () => {
-  it('keeps in-range levels untouched', () => {
+  it('keeps valid levels, clamps bounds, and rejects non-finite input', () => {
     for (const level of [ZOOM_LEVEL_MIN, -0.5, 0, 1.5, ZOOM_LEVEL_MAX]) {
       expect(clampZoomLevel(level)).toBe(level)
     }
-  })
-
-  it('clamps out-of-range levels to the usable window', () => {
     expect(clampZoomLevel(40)).toBe(ZOOM_LEVEL_MAX)
     expect(clampZoomLevel(-40)).toBe(ZOOM_LEVEL_MIN)
-  })
-
-  it('falls back to 100% for non-finite input', () => {
     // 脏配置(手改 / 导入)里 zoomLevel 可能是 null → NaN。放任它进
     // setZoomLevel 会让整窗渲染异常,且用户无从恢复。
     expect(clampZoomLevel(Number.NaN)).toBe(0)
@@ -39,30 +33,21 @@ describe('clampZoomLevel', () => {
 })
 
 describe('zoomPercent', () => {
-  it('maps level 0 to exactly 100%', () => {
+  it('maps representative and clamped levels to percentages', () => {
     expect(zoomPercent(0)).toBe(100)
-  })
-
-  it('uses a ~110% first step, matching browser zoom feel', () => {
     // 步长取 0.5(而非整数 1)就是为了这一档:整数步一上来跳到 120%,
     // 对"字号偏小"这个诉求太粗。
     expect(zoomPercent(0.5)).toBe(110)
-  })
-
-  it('clamps before converting, so dirty input never yields absurd percentages', () => {
     expect(zoomPercent(999)).toBe(zoomPercent(ZOOM_LEVEL_MAX))
   })
 })
 
 describe('DEFAULT_SETTINGS', () => {
-  it('starts at 100% and carries the current version', () => {
+  it('carries current defaults without the removed font slice', () => {
     expect(DEFAULT_SETTINGS.zoomLevel).toBe(0)
     expect(DEFAULT_SETTINGS.version).toBe(SETTINGS_VERSION)
     expect(DEFAULT_SETTINGS.ui.telemetryOptIn).toBe(true)
     expect(DEFAULT_SETTINGS.layout.rightPanelWidth).toBe(320)
-  })
-
-  it('no longer carries the dead font slice', () => {
     // font.family / font.size 曾被写进 --font-family / --font-size,但 CSS 读的是
     // --font-sans、且没有任何规则读 --font-size —— 死配置,已随 v2 迁移删除。
     expect('font' in DEFAULT_SETTINGS).toBe(false)

--- a/src/amphi_service/auth/_seed.py
+++ b/src/amphi_service/auth/_seed.py
@@ -1,13 +1,55 @@
-from ...amphi_store import ProviderRepository, UserRepository
+from typing import Any, Dict
+
+from ...amphi_store import ProviderCredential, ProviderRepository, UserRepository
+from ..protocol.llms._providers_catalog import catalog_model_limits
 from ._current_user import LOCAL_USER_ID
 
 
 async def seed_local_user() -> None:
-    """Ensure the local user exists and mirror its active product provider."""
+    """Ensure the local user exists and reconcile its product providers."""
+    def migrated_model_limits(provider: ProviderCredential) -> Dict[str, Dict[str, Any]]:
+        """Fill legacy model metadata without replacing stored ceilings."""
+        models = (
+            provider.enabled_models
+            if isinstance(provider.enabled_models, list)
+            else []
+        )
+        stored = (
+            provider.model_limits
+            if isinstance(provider.model_limits, dict)
+            else {}
+        )
+        migrated = dict(stored)
+        for model_id in models:
+            packaged = catalog_model_limits(provider.provider_id, model_id)
+            existing = stored.get(model_id)
+            existing = existing if isinstance(existing, dict) else {}
+            if packaged is not None:
+                migrated[model_id] = {**packaged, **existing}
+        return migrated
+
     users = UserRepository()
     await users.ensure_seeded(LOCAL_USER_ID)
 
-    providers = await ProviderRepository().list_for_user(LOCAL_USER_ID)
+    repository = ProviderRepository()
+    providers = await repository.list_for_user(LOCAL_USER_ID)
+    migrated = False
+    for provider in providers:
+        model_limits = migrated_model_limits(provider)
+        if model_limits == provider.model_limits:
+            continue
+        await repository.upsert(
+            LOCAL_USER_ID,
+            provider.provider_id,
+            auth_mode=provider.auth_mode,
+            api_key=None,
+            base_url=None,
+            model_limits=model_limits,
+        )
+        migrated = True
+    if migrated:
+        providers = await repository.list_for_user(LOCAL_USER_ID)
+
     active = next((row for row in providers if row.is_active and row.is_enabled), None)
     if active is None:
         await users.set_active_provider(

--- a/tests/service/test_provider_migration.py
+++ b/tests/service/test_provider_migration.py
@@ -1,0 +1,76 @@
+from src.amphi_service.auth import seed_local_user
+from src.amphi_service.protocol.llms import catalog_model_limits
+from src.amphi_store import ProviderRepository, Repository, UserRepository
+from tests._support.sandbox import IsolatedPaths
+
+
+async def test_legacy_provider_models_receive_packaged_limits(test_sandbox: IsolatedPaths) -> None:
+    """Legacy providers gain packaged limits without losing stored metadata."""
+    model_id = "gpt-5.5"
+    unknown_model_id = "unknown-model"
+    expected = catalog_model_limits("openai", model_id)
+    assert expected is not None
+
+    await Repository.close()
+    Repository.connect(test_sandbox.state_db)
+    try:
+        await Repository.init_schema()
+        await UserRepository().ensure_seeded("local")
+        repository = ProviderRepository()
+        await repository.upsert(
+            "local",
+            "openai",
+            auth_mode="api_key",
+            api_key="legacy-key",
+            base_url=None,
+            models=[model_id, unknown_model_id],
+        )
+        await repository.set_active("local", "openai")
+
+        engine = Repository._engine
+        assert engine is not None
+        async with engine.begin() as connection:
+            await connection.exec_driver_sql(
+                "ALTER TABLE provider_credentials DROP COLUMN model_limits"
+            )
+
+        await Repository.init_schema()
+        before = (await repository.list_for_user("local"))[0]
+        assert before.model_limits == {}
+
+        await seed_local_user()
+
+        after = (await repository.list_for_user("local"))[0]
+        assert after.enabled_models == [model_id, unknown_model_id]
+        assert after.model_limits == {model_id: expected}
+
+        await seed_local_user()
+        repeated = (await repository.list_for_user("local"))[0]
+        assert repeated.model_limits == after.model_limits
+
+        stored_context = expected["context"] + 1
+        await repository.upsert(
+            "local",
+            "openai",
+            auth_mode="api_key",
+            api_key="provider-key",
+            base_url=None,
+            models=[model_id],
+            model_limits={
+                model_id: {
+                    "context": stored_context,
+                    "source": "provider",
+                },
+            },
+        )
+
+        await seed_local_user()
+
+        provider = (await repository.list_for_user("local"))[0]
+        assert provider.model_limits[model_id] == {
+            **expected,
+            "context": stored_context,
+            "source": "provider",
+        }
+    finally:
+        await Repository.close()


### PR DESCRIPTION
## Summary

- Backfill missing `model_limits` for existing provider records from the packaged model catalog during startup.
- Preserve stored provider and user overrides while filling only missing model metadata.
- Keep unknown/custom models untouched and make the migration idempotent.
- Consolidate redundant table-driven tests across the Python and desktop suites, reducing the suite from 1,860 to 1,749 cases without removing behavioral coverage.

## Verification

- `uv run pytest -q`: 390 passed
- Desktop test suite: 1,353 passed, 6 skipped, 0 failed
- `bun run typecheck`: passed
- `bun run lint`: passed
- `git diff --check`: passed