### PR TITLE
fix(desktop): render user input verbatim instead of linkifying bare paths

### DIFF
--- a/desktop/apps/electron/src/renderer/components/amphi/CompletedInteractionCard.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/CompletedInteractionCard.tsx
@@ -55,7 +55,11 @@ export function CompletedInteractionCard({ block, sessionId }: { block: Complete
           </div>
           <div className="px-3.5 py-3.5">
             <div className="mb-1 text-xs font-semibold text-text-tertiary">{t('session.interaction.card.newMessageLabel')}</div>
-            <MarkdownMessage content={block.response} className="text-sm leading-6 text-text-primary" />
+            {/* The user's own words, rendered verbatim like the chat bubble and the task_confirm
+                feedback line below. Never Markdown: a path they typed must not become a link. */}
+            <div className="whitespace-pre-wrap break-words text-sm leading-6 text-text-primary">
+              {block.response}
+            </div>
           </div>
         </div>
       )
@@ -192,7 +196,10 @@ export function CompletedInteractionCard({ block, sessionId }: { block: Complete
                     <div className="mb-1 flex items-center gap-1 text-xs font-semibold text-status-success">
                       {Icons.check(11)} {t('session.interaction.card.answerLabel')}
                     </div>
-                    <MarkdownMessage content={pair.answer} className="text-sm leading-6 text-text-primary" />
+                    {/* The answer is the user's; the question above it is the Agent's and stays Markdown. */}
+                    <div className="whitespace-pre-wrap break-words text-sm leading-6 text-text-primary">
+                      {pair.answer}
+                    </div>
                   </div>
                 </div>
               </li>

--- a/desktop/apps/electron/src/renderer/components/amphi/CompletedInteractionCard.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/CompletedInteractionCard.tsx
@@ -114,10 +114,13 @@ export function CompletedInteractionCard({ block, sessionId }: { block: Complete
                 <span className="mt-0.5 inline-flex h-6 items-center justify-center rounded-md bg-accent-blue-subtle px-2 text-xs font-semibold text-text-accent">
                   {t('session.interaction.card.ruleBadge', { n: index + 1 })}
                 </span>
-                <MarkdownMessage
-                  content={humanizeAcceptanceRuleText(rule.text)}
-                  className="min-w-0 text-sm leading-6 text-text-primary"
-                />
+                {/* Verbatim, because a rule's text is not reliably the Agent's. Rejecting a
+                    proposed rule and typing a replacement substitutes the user's own words
+                    (resolveAcceptanceReviewSubmission -> confirmedAcceptanceRules), and a
+                    replayed card only ever sees the resulting string. */}
+                <div className="min-w-0 whitespace-pre-wrap break-words text-sm leading-6 text-text-primary">
+                  {humanizeAcceptanceRuleText(rule.text)}
+                </div>
               </li>
             ))}
           </ol>
@@ -196,7 +199,12 @@ export function CompletedInteractionCard({ block, sessionId }: { block: Complete
                     <div className="mb-1 flex items-center gap-1 text-xs font-semibold text-status-success">
                       {Icons.check(11)} {t('session.interaction.card.answerLabel')}
                     </div>
-                    {/* The answer is the user's; the question above it is the Agent's and stays Markdown. */}
+                    {/* Verbatim. The answer is the user's free-typed text, OR the label of the
+                        option they picked, which is the Agent's copy (resolveAnswer returns
+                        `free || picked[0]`) — and `response` is stored as one string, so a
+                        replayed card cannot tell which. Rendering an Agent label literally shows
+                        its `**markup**`; rendering user text as Markdown turns a path they typed
+                        into a link. The first is cosmetic, the second is the bug this fixes. */}
                     <div className="whitespace-pre-wrap break-words text-sm leading-6 text-text-primary">
                       {pair.answer}
                     </div>

--- a/desktop/apps/electron/src/renderer/components/amphi/Pipeline.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/Pipeline.tsx
@@ -52,7 +52,6 @@ import { useSmoothStream } from '@/hooks/useSmoothStream'
 import { useInfiniteScrollSentinel } from '@/hooks/useInfiniteScrollSentinel'
 import { useAutoHideScrollbar } from '@/hooks/useAutoHideScrollbar'
 import { MarkdownMessage } from '@/components/markdown/MarkdownMessage'
-import { LocalPathText } from '@/components/markdown/LocalResourceView'
 import { MessageThinking } from './MessageThinking'
 import { MessageToolCall } from './MessageToolCall'
 import { MessageContent } from './MessageContent'
@@ -605,7 +604,7 @@ function TextMessageBody({
     if (hasBlocks) return <UserMessageBlocks blocks={blocks} />
     return (
       <div className="text-base text-text-primary leading-[1.65] whitespace-pre-wrap break-words">
-        <LocalPathText text={content} />
+        {content}
       </div>
     )
   }

--- a/desktop/apps/electron/src/renderer/components/amphi/StructuredInput.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/StructuredInput.tsx
@@ -1,13 +1,10 @@
 import type { MessageBlock } from '@/atoms/agent'
 import type { ChatBlock } from '@shared/types'
 import { Quote } from 'lucide-react'
-import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { cn } from '@/lib/cn'
 import { getMentionBadgeClass, getMentionPrefix, SLASH_BADGE_CLASS } from '@/components/composer/segments'
 import { messageQuoteFromBlock } from '@/components/composer/messageQuote'
-import { LocalPathTextParts } from '@/components/markdown/LocalResourceView'
-import { splitLocalPathTextChunks } from '@/components/markdown/localResource'
 
 type StructuredInputBlock = MessageBlock | ChatBlock
 
@@ -16,39 +13,15 @@ export interface StructuredInputProps {
   className?: string
 }
 
-/** Render persisted composer input while preserving mention and slash tokens. */
+/** Render persisted composer input while preserving mention and slash tokens.
+ *
+ *  Text is rendered verbatim: what the user typed is never re-interpreted, so a pasted path stays
+ *  the characters they wrote rather than becoming a link or an inline preview. Guessing where a path
+ *  ends is not decidable from the text alone — paths may contain spaces, so `/tmp/a.docx make a deck`
+ *  parsed as one path and swallowed the request into the link target. */
 export function StructuredInput({ blocks, className }: StructuredInputProps) {
   const { t } = useTranslation()
   const badge = 'inline-flex items-center align-baseline px-1.5 py-0.5 mx-0.5 rounded-sm text-xs select-none'
-  const localPathParts = useMemo(
-    () => splitLocalPathTextChunks(blocks.map((block) => {
-      if (messageQuoteFromBlock(block)) {
-        // The quote renders as a separate card. A line barrier prevents text on
-        // either side from becoming one synthetic path during analysis.
-        return { value: '\n\uFFFC\n', resourceEligible: false }
-      }
-      if (block.type === 'text') {
-        return {
-          value: 'value' in block ? block.value : block.text,
-          resourceEligible: true,
-        }
-      }
-      if (block.type === 'mention') {
-        return {
-          value: `${getMentionPrefix(block.group)}${block.label}`,
-          resourceEligible: false,
-        }
-      }
-      if (block.type === 'slash') {
-        return {
-          value: `/${block.resource ? block.label : block.id}`,
-          resourceEligible: false,
-        }
-      }
-      return { value: '\uFFFC', resourceEligible: false }
-    })),
-    [blocks],
-  )
   return (
     <span className={cn('whitespace-pre-wrap break-words', className)}>
       {blocks.map((block, index) => {
@@ -90,11 +63,7 @@ export function StructuredInput({ blocks, className }: StructuredInputProps) {
           )
         }
         if (block.type === 'text') {
-          return (
-            <span key={index}>
-              <LocalPathTextParts parts={localPathParts[index] ?? []} />
-            </span>
-          )
+          return <span key={index}>{'value' in block ? block.value : block.text}</span>
         }
         return null
       })}

--- a/desktop/apps/electron/src/renderer/components/amphi/__tests__/CompletedInteractionCard.test.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/__tests__/CompletedInteractionCard.test.tsx
@@ -218,4 +218,64 @@ describe('CompletedInteractionCard', () => {
     await act(async () => root.unmount())
     host.remove()
   })
+
+  // What the user typed is theirs; the card must not reinterpret it. A path they
+  // wrote stays the characters they wrote, matching the plain chat bubble and the
+  // task_confirm feedback line, which never went through Markdown either.
+  it('renders a replied message verbatim, never as a link', async () => {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const root = createRoot(host)
+    const response = '/tmp/report.pdf'
+
+    await act(async () => {
+      root.render(
+        <CompletedInteractionCard
+          block={{
+            type: 'confirmation',
+            kind: 'confirmation_message',
+            question: '需要哪个文件？',
+            response,
+          }}
+        />,
+      )
+    })
+
+    expect(host.textContent).toContain(response)
+    expect(host.querySelector('a')).toBeNull()
+    expect(host.querySelector('img')).toBeNull()
+
+    await act(async () => root.unmount())
+    host.remove()
+  })
+
+  it('renders a question answer verbatim while the agent-authored context keeps Markdown', async () => {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const root = createRoot(host)
+
+    await act(async () => {
+      root.render(
+        <CompletedInteractionCard
+          block={{
+            type: 'confirmation',
+            prompt: '/tmp/context.pdf',
+            question: '用哪个文件？',
+            response: '/tmp/answer.pdf',
+          }}
+        />,
+      )
+    })
+
+    // The answer is the user's own text.
+    const answerRow = host.querySelector('ol[aria-label="已确认的问答"] > li')
+    expect(answerRow?.textContent).toContain('/tmp/answer.pdf')
+    expect(answerRow?.querySelector('a')).toBeNull()
+    // The agent-authored context above it still renders as Markdown, links included.
+    const context = host.querySelector('section[aria-label="确认背景"]')
+    expect(context?.querySelector('a')?.getAttribute('href')).toBe('/tmp/context.pdf')
+
+    await act(async () => root.unmount())
+    host.remove()
+  })
 })

--- a/desktop/apps/electron/src/renderer/components/amphi/__tests__/CompletedInteractionCard.test.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/__tests__/CompletedInteractionCard.test.tsx
@@ -219,6 +219,37 @@ describe('CompletedInteractionCard', () => {
     host.remove()
   })
 
+  // Rejecting a proposed rule and typing a replacement puts the user's own words into
+  // rule.text (resolveAcceptanceReviewSubmission -> confirmedAcceptanceRules), and a
+  // replayed card cannot tell those apart from the agent's original wording. So the
+  // whole list is verbatim.
+  it('renders acceptance rules verbatim, so a user-typed replacement is not a link', async () => {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const root = createRoot(host)
+    const replacement = '/Users/me/Desktop/template v2.docx'
+
+    await act(async () => {
+      root.render(
+        <CompletedInteractionCard
+          block={{
+            type: 'confirmation',
+            kind: 'accept_rule',
+            question: 'Acceptance aligned',
+            response: replacement,
+            rules: [{ id: 'AC-001', text: replacement }],
+          }}
+        />,
+      )
+    })
+
+    expect(host.textContent).toContain(replacement)
+    expect(host.querySelector('a')).toBeNull()
+
+    await act(async () => root.unmount())
+    host.remove()
+  })
+
   // What the user typed is theirs; the card must not reinterpret it. A path they
   // wrote stays the characters they wrote, matching the plain chat bubble and the
   // task_confirm feedback line, which never went through Markdown either.
@@ -234,7 +265,7 @@ describe('CompletedInteractionCard', () => {
           block={{
             type: 'confirmation',
             kind: 'confirmation_message',
-            question: '需要哪个文件？',
+            question: 'Which file should I use?',
             response,
           }}
         />,
@@ -260,7 +291,7 @@ describe('CompletedInteractionCard', () => {
           block={{
             type: 'confirmation',
             prompt: '/tmp/context.pdf',
-            question: '用哪个文件？',
+            question: 'Which file?',
             response: '/tmp/answer.pdf',
           }}
         />,

--- a/desktop/apps/electron/src/renderer/components/amphi/__tests__/MessageBubble.test.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/__tests__/MessageBubble.test.tsx
@@ -117,6 +117,37 @@ describe('Pipeline', () => {
     host.remove()
   })
 
+  // A reply to request_human carries no blocks (human-request.ts sends text only), so it renders
+  // through the plain-content branch rather than StructuredInput. A path typed there is still just
+  // the characters the user wrote, never a link.
+  it('renders a bare path in a blockless user message as plain text', async () => {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const root = createRoot(host)
+    const store = createStore()
+    const text = '/Users/me/Documents/chapter 2.docx  use section 2.1 for the deck'
+    store.set(activeSessionIdAtom, 'blockless-session')
+    store.set(messageFamily('blockless-session'), [{
+      id: 'user-1', turnId: 'turn-1', role: AgentRole.User, text,
+      toolCalls: [], done: true, createdAt: 1,
+    }])
+
+    await act(async () => {
+      root.render(
+        <Provider store={store}>
+          <Pipeline />
+        </Provider>,
+      )
+    })
+
+    expect(host.textContent).toContain(text)
+    expect(host.querySelector('[class*="filelink"]')).toBeNull()
+    expect(host.querySelector('a[href*=".docx"]')).toBeNull()
+
+    await act(async () => root.unmount())
+    host.remove()
+  })
+
   it('shows primary-conversation actions and snapshots the paired Turn for feedback', async () => {
     const host = document.createElement('div')
     document.body.appendChild(host)

--- a/desktop/apps/electron/src/renderer/components/amphi/__tests__/StructuredInput.test.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/__tests__/StructuredInput.test.tsx
@@ -53,13 +53,18 @@ describe('StructuredInput', () => {
 
   it('still renders mention and slash tokens as badges', async () => {
     const blocks: MessageBlock[] = [
-      { type: 'text', text: 'see ' },
+      { type: 'slash', id: 'build', label: 'build' },
+      { type: 'text', text: ' see ' },
       { type: 'mention', group: 'file', label: 'report.md', id: 'report' },
-      { type: 'text', text: ' /tmp/a.png' },
+      { type: 'text', text: '\n/tmp/a.png' },
     ]
     const host = await render(<StructuredInput blocks={blocks} />)
 
+    expect(host.querySelector('[data-input-token="slash"]')?.textContent).toContain('build')
     expect(host.querySelector('[data-input-token="mention"]')?.textContent).toContain('report.md')
+    // The trailing path is on a line of its own, which is exactly the shape the old
+    // scanner upgraded. It must stay text now.
     expect(host.querySelector('a')).toBeNull()
+    expect(host.querySelector('img')).toBeNull()
   })
 })

--- a/desktop/apps/electron/src/renderer/components/amphi/__tests__/StructuredInput.test.tsx
+++ b/desktop/apps/electron/src/renderer/components/amphi/__tests__/StructuredInput.test.tsx
@@ -1,0 +1,65 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+import type { MessageBlock } from '@/atoms/agent'
+import type { ReactNode } from 'react'
+
+GlobalRegistrator.register()
+;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+afterEach(() => {
+  document.body.replaceChildren()
+})
+afterAll(async () => {
+  await GlobalRegistrator.unregister()
+})
+
+const { act } = await import('react')
+const { createRoot } = await import('react-dom/client')
+const { Provider } = await import('jotai')
+const { i18n } = await import('@/lib/i18n')
+const { StructuredInput } = await import('../StructuredInput')
+
+async function render(node: ReactNode): Promise<HTMLDivElement> {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  await act(async () => {
+    createRoot(host).render(<Provider>{node}</Provider>)
+  })
+  return host
+}
+
+describe('StructuredInput', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('zh')
+  })
+
+  // A pasted path followed by the request typed after it used to be swallowed whole: the entire
+  // line parsed as one absolute path, so the prose became part of the link target and its basename.
+  it('keeps a path with prose after it as plain text', async () => {
+    const text = '/Users/me/Documents/chapter 2.docx  turn section 2.1 into a deck, ignore the rest.'
+    const host = await render(<StructuredInput blocks={[{ type: 'text', text }]} />)
+
+    expect(host.querySelector('a')).toBeNull()
+    expect(host.textContent).toBe(text)
+  })
+
+  it('keeps a standalone path line as plain text instead of a link or preview', async () => {
+    const blocks: MessageBlock[] = [{ type: 'text', text: '/tmp/screenshot.png' }]
+    const host = await render(<StructuredInput blocks={blocks} />)
+
+    expect(host.querySelector('a')).toBeNull()
+    expect(host.querySelector('img')).toBeNull()
+    expect(host.textContent).toBe('/tmp/screenshot.png')
+  })
+
+  it('still renders mention and slash tokens as badges', async () => {
+    const blocks: MessageBlock[] = [
+      { type: 'text', text: 'see ' },
+      { type: 'mention', group: 'file', label: 'report.md', id: 'report' },
+      { type: 'text', text: ' /tmp/a.png' },
+    ]
+    const host = await render(<StructuredInput blocks={blocks} />)
+
+    expect(host.querySelector('[data-input-token="mention"]')?.textContent).toContain('report.md')
+    expect(host.querySelector('a')).toBeNull()
+  })
+})

--- a/desktop/apps/electron/src/renderer/components/markdown/LocalResourceView.tsx
+++ b/desktop/apps/electron/src/renderer/components/markdown/LocalResourceView.tsx
@@ -1,13 +1,11 @@
-/** Local image/media preview plus the plain-text path renderer shared by user and Agent messages. */
-import { Fragment, type ReactNode, useState } from 'react'
+/** Local image/media preview for paths appearing in Agent Markdown output. */
+import { type ReactNode, useState } from 'react'
 import { useSetAtom } from 'jotai'
 import { openImageAtom } from '@/atoms/lightbox'
 import { FileLink } from './FileLink'
 import {
   parseLocalResourceReference,
-  splitLocalPathText,
   toLocalResourceDisplayUrl,
-  type LocalPathTextPart,
   type LocalResourceReference,
 } from './localResource'
 
@@ -75,28 +73,6 @@ export function LocalResourcePreview({ reference, children }: LocalResourcePrevi
       {fallback}
     </audio>
   )
-}
-
-/** Render already-contextualized plain-text parts. */
-export function LocalPathTextParts({ parts }: { parts: readonly LocalPathTextPart[] }) {
-  return (
-    <>
-      {parts.map((part, index) => {
-        if (part.type === 'text') return <Fragment key={index}>{part.value}</Fragment>
-        const preview = (
-          <LocalResourcePreview reference={part.reference}>{part.value}</LocalResourcePreview>
-        )
-        return part.reference.kind === 'file'
-          ? <Fragment key={index}>{preview}</Fragment>
-          : <span key={index} className="my-2 block max-w-full">{preview}</span>
-      })}
-    </>
-  )
-}
-
-/** Plain-text renderer used for user messages: preserve prose exactly, upgrade only whole path lines. */
-export function LocalPathText({ text }: { text: string }) {
-  return <LocalPathTextParts parts={splitLocalPathText(text)} />
 }
 
 /** Parse and render a local Markdown source, or return null for ordinary URLs. */

--- a/desktop/apps/electron/src/renderer/components/markdown/__tests__/LocalResourceView.test.tsx
+++ b/desktop/apps/electron/src/renderer/components/markdown/__tests__/LocalResourceView.test.tsx
@@ -24,7 +24,6 @@ const { act } = await import('react')
 const { createRoot } = await import('react-dom/client')
 const { Provider } = await import('jotai')
 const { MarkdownMessage } = await import('../MarkdownMessage')
-const { LocalPathText } = await import('../LocalResourceView')
 
 async function render(node: ReactNode): Promise<{ host: HTMLDivElement; root: Root }> {
   const host = document.createElement('div')
@@ -155,20 +154,6 @@ describe('Markdown local resources', () => {
     await act(async () => image?.dispatchEvent(new Event('error')))
     expect(host.querySelector('img')).toBeNull()
     expect(host.querySelector('a')?.getAttribute('href')).toBe('/tmp/missing.png')
-    await act(async () => root.unmount())
-  })
-})
-
-describe('plain user-message local resources', () => {
-  it('upgrades only a standalone path line', async () => {
-    const { host, root } = await render(
-      <div className="whitespace-pre-wrap">
-        <LocalPathText text={'不要转换 /tmp/inline.png\n/tmp/standalone.png'} />
-      </div>,
-    )
-    expect(host.textContent).toContain('不要转换 /tmp/inline.png')
-    expect(host.querySelectorAll('img')).toHaveLength(1)
-    assertInternalSource(host.querySelector('img')?.getAttribute('src') ?? null, 'file:///tmp/standalone.png')
     await act(async () => root.unmount())
   })
 })

--- a/desktop/apps/electron/src/renderer/components/markdown/__tests__/localResource.test.ts
+++ b/desktop/apps/electron/src/renderer/components/markdown/__tests__/localResource.test.ts
@@ -4,8 +4,6 @@ import {
   localResourceKind,
   parseLocalResourceReference,
   rewriteBareLocalPaths,
-  splitLocalPathText,
-  splitLocalPathTextChunks,
   toLocalResourceDisplayUrl,
 } from '../localResource'
 
@@ -93,63 +91,6 @@ describe('bare local paths in Markdown', () => {
       '```',
     ].join('\n')
     expect(rewriteBareLocalPaths(markdown)).toBe(markdown)
-  })
-
-  it('upgrades only complete lines in plain user text and preserves separators', () => {
-    const parts = splitLocalPathText('说明 /tmp/a.png\n/tmp/a.png\n下一行')
-    expect(parts.map((part) => part.type)).toEqual([
-      'text',
-      'text',
-      'resource',
-      'text',
-      'text',
-    ])
-    expect(parts.map((part) => part.value).join('')).toBe(
-      '说明 /tmp/a.png\n/tmp/a.png\n下一行',
-    )
-  })
-
-  it('leaves fenced and indented paths in plain user text untouched', () => {
-    const text = [
-      '```text',
-      '```not-a-close',
-      '/tmp/in-code.png',
-      '```',
-      '    /tmp/indented.png',
-    ].join('\n')
-    const parts = splitLocalPathText(text)
-    expect(parts.every((part) => part.type === 'text')).toBe(true)
-    expect(parts.map((part) => part.value).join('')).toBe(text)
-  })
-
-  it('preserves whitespace around a plain user path', () => {
-    const text = '  /tmp/a.png  '
-    const parts = splitLocalPathText(text)
-    expect(parts.map((part) => part.value).join('')).toBe(text)
-    expect(parts.map((part) => part.type)).toEqual(['text', 'resource', 'text'])
-  })
-
-  it('uses complete structured-message context across mention and text chunks', () => {
-    const inline = splitLocalPathTextChunks([
-      { value: '查看 ', resourceEligible: true },
-      { value: '@报告', resourceEligible: false },
-      { value: ' /tmp/inline.png', resourceEligible: true },
-    ])
-    expect(inline.flat().some((part) => part.type === 'resource')).toBe(false)
-
-    const fenced = splitLocalPathTextChunks([
-      { value: '```text\n', resourceEligible: true },
-      { value: '@报告', resourceEligible: false },
-      { value: '\n/tmp/in-code.png\n```', resourceEligible: true },
-    ])
-    expect(fenced.flat().some((part) => part.type === 'resource')).toBe(false)
-
-    const standalone = splitLocalPathTextChunks([
-      { value: '查看 ', resourceEligible: true },
-      { value: '@报告', resourceEligible: false },
-      { value: '\n/tmp/standalone.png', resourceEligible: true },
-    ])
-    expect(standalone[2]?.some((part) => part.type === 'resource')).toBe(true)
   })
 })
 

--- a/desktop/apps/electron/src/renderer/components/markdown/localResource.ts
+++ b/desktop/apps/electron/src/renderer/components/markdown/localResource.ts
@@ -7,10 +7,14 @@
  * elements use the internal URL while file links keep their original OS path and still go through
  * FileLink/openPath.
  *
- * Bare paths are deliberately recognised only when they occupy a complete line. That makes a user
- * or Agent pasting `/Users/me/report.pdf` useful without turning paths embedded in prose, logs, or
- * code into surprising UI. Fenced and indented code are excluded before Markdown is parsed (which
- * also preserves UNC backslashes that Markdown would otherwise consume as escapes).
+ * Bare paths are recognised only in Agent Markdown output, and only when they occupy a complete
+ * line, so that a path the Agent reports becomes useful without turning paths embedded in prose,
+ * logs, or code into surprising UI. Fenced and indented code are excluded before Markdown is parsed
+ * (which also preserves UNC backslashes that Markdown would otherwise consume as escapes).
+ *
+ * User input is never scanned: it renders verbatim. A path may contain spaces, so a line such as
+ * `/tmp/a.docx make a deck from this` has no decidable boundary — the whole line parsed as one path
+ * and swallowed the request into the link target.
  */
 import { createLocalResourceUrl } from '@shared/local-resource'
 import type { FileOpenTarget } from '@/atoms/fileOpen'
@@ -216,116 +220,4 @@ export function rewriteBareLocalPaths(markdown: string): string {
       return `${leading}${rewriteReferenceLine(reference)}`
     })
     .join('')
-}
-
-export type LocalPathTextPart =
-  | { type: 'text'; value: string }
-  | { type: 'resource'; value: string; reference: LocalResourceReference }
-
-export interface LocalPathTextChunk {
-  /** Visible text contributed to the complete structured message. */
-  value: string
-  /** False for mention/slash chips and other non-text blocks. */
-  resourceEligible: boolean
-}
-
-/** Split plain user-message text while preserving newlines; only complete path lines become resources. */
-export function splitLocalPathText(text: string): LocalPathTextPart[] {
-  let fence: MarkdownFence | null = null
-
-  return text.split(/(\r?\n)/).flatMap((value): LocalPathTextPart[] => {
-    if (/^\r?\n$/.test(value)) return [{ type: 'text', value }]
-    if (fence !== null) {
-      if (closesFence(value, fence)) fence = null
-      return [{ type: 'text', value }]
-    }
-    const opening = openingFence(value)
-    if (opening) {
-      fence = opening
-      return [{ type: 'text', value }]
-    }
-    if (/^(?: {4}|\t)/.test(value)) return [{ type: 'text', value }]
-
-    const leading = value.match(/^[ \t]*/)?.[0] ?? ''
-    const trailing = value.match(/[ \t]*$/)?.[0] ?? ''
-    const candidate = value.slice(leading.length, value.length - trailing.length)
-    const reference = parseLocalResourceReference(candidate)
-    if (!reference) return [{ type: 'text', value }]
-
-    const parts: LocalPathTextPart[] = []
-    if (leading) parts.push({ type: 'text', value: leading })
-    parts.push({ type: 'resource', value: candidate, reference })
-    if (trailing) parts.push({ type: 'text', value: trailing })
-    return parts
-  })
-}
-
-/**
- * Split text blocks with the context of the complete structured user message.
- *
- * Composer mentions and slash commands divide one visible line into multiple
- * persisted blocks. Analysing those blocks independently would make the suffix
- * of `look at @report /tmp/a.png` appear to be a standalone path and would lose
- * fenced-code state across a chip. Flattening first preserves the real line and
- * fence semantics; a resource is upgraded only when its full span belongs to one
- * eligible text block. Cross-block paths remain ordinary text rather than being
- * reconstructed speculatively.
- */
-export function splitLocalPathTextChunks(
-  chunks: readonly LocalPathTextChunk[],
-): LocalPathTextPart[][] {
-  const flattened = chunks.map((chunk) => chunk.value).join('')
-  const resourceSpans: Array<{
-    start: number
-    end: number
-    reference: LocalResourceReference
-  }> = []
-
-  let flatOffset = 0
-  for (const part of splitLocalPathText(flattened)) {
-    const end = flatOffset + part.value.length
-    if (part.type === 'resource') {
-      resourceSpans.push({ start: flatOffset, end, reference: part.reference })
-    }
-    flatOffset = end
-  }
-
-  let chunkStart = 0
-  return chunks.map((chunk) => {
-    const chunkEnd = chunkStart + chunk.value.length
-    if (!chunk.resourceEligible) {
-      chunkStart = chunkEnd
-      return [{ type: 'text', value: chunk.value }]
-    }
-
-    const contained = resourceSpans.filter(
-      (span) => span.start >= chunkStart && span.end <= chunkEnd,
-    )
-    if (contained.length === 0) {
-      chunkStart = chunkEnd
-      return [{ type: 'text', value: chunk.value }]
-    }
-
-    const parts: LocalPathTextPart[] = []
-    let cursor = chunkStart
-    for (const span of contained) {
-      if (span.start > cursor) {
-        parts.push({
-          type: 'text',
-          value: chunk.value.slice(cursor - chunkStart, span.start - chunkStart),
-        })
-      }
-      parts.push({
-        type: 'resource',
-        value: chunk.value.slice(span.start - chunkStart, span.end - chunkStart),
-        reference: span.reference,
-      })
-      cursor = span.end
-    }
-    if (cursor < chunkEnd) {
-      parts.push({ type: 'text', value: chunk.value.slice(cursor - chunkStart) })
-    }
-    chunkStart = chunkEnd
-    return parts
-  })
 }


### PR DESCRIPTION
## Problem

A user message whose line merely **started** with `/` was parsed as one absolute path. Pasting a path and typing the request after it on the same line:

```
/Users/me/Documents/chapter 2.docx  turn section 2.1 into a deck
```

made the entire line — prose included — the link target *and* the basename shown in the reveal / copy-path affordances. Two visible symptoms:

1. **Wrongly clickable.** The whole sentence became a `FileLink`.
2. **No wrapping.** The message overflowed and the chat pane grew a horizontal scrollbar.

`localResource.ts` guarded this with "a bare path is only recognised when it occupies a complete line", but that only covers a path at the *end* of prose (already tested). Prose *after* a path fell straight through.

## Approach

Where a path ends is not decidable from the text alone — paths may contain spaces, so no split rule separates `/tmp/qr code.png` from `/tmp/a.docx make a deck`. Rather than ship a heuristic, **user input is no longer scanned at all**: it renders verbatim, exactly as typed.

Removed: `splitLocalPathText`, `splitLocalPathTextChunks`, `LocalPathTextPart`, `LocalPathTextChunk`, `LocalPathText`, `LocalPathTextParts`.

Worth noting that `@` is already this product's structured way to reference a file: it carries a mount, survives `↑` recall as a chip, and is the only form the backend resolves. Bare-path detection was a second, weaker, guess-based path to the same goal.

### Why this also fixes the wrapping

`FileLink` renders an `inline-flex` box whose anchor is a flex item (the `Tooltip` wrapper is `display: contents`, so it produces no box). A flex item's `min-width: auto` resolves to its min-content width, and the ancestor only sets `overflow-wrap: break-word`, which per spec does **not** reduce that intrinsic size. The Markdown path escapes this via its own `[&_a]:break-all` (`MarkdownMessage.tsx`); the user-message path had nothing. With no `FileLink` in user messages, the atomic inline-flex box is gone.

## Blast radius

Traced end to end. Everything below is display-only; **nothing on the wire or in the backend changes.**

Five surfaces render user-authored text, and all five now show it verbatim:

| Surface | Trigger |
|---|---|
| `Pipeline.tsx:569` → `StructuredInput` | ordinary user message (has blocks) |
| `Pipeline.tsx:608` → plain content | reply to a legacy id-less `request_human` card — `human-request.ts:318` sends `text` only |
| `CenterViews.tsx:728` → `StructuredInput` | input echo in a Workflow run record |
| `WorkflowRunDetailModal.tsx:397` → `StructuredInput` | input echo in the Workflow run detail modal |
| `CompletedInteractionCard.tsx` `response` / `pair.answer` | answer to `request_human` — the **main** path: `accept_rule` / `choice_answer` resolve over WS and fold the answer into a `confirmation` block, and typing into the composer while a request is pending goes the same way (`agent.ts` sets `response: text`) |

Consistency is the point: fixing only the chat bubble would leave the same text rendered as plain text in one surface and as a link in another.

Agent-authored copy in that same card deliberately keeps Markdown — `prompt`, `question`, accept_rule texts, `goal`, `taskMarkdown`, `summary`. The split matches the existing `task_confirm` `feedback` line, which already rendered the user's words verbatim.

### Unaffected, and why

- **The send path never touched these functions.** `segmentsToText` / `segmentsToBlocks` are pure segment → wire transforms; a text segment goes out as `{type:'text', value}` untouched. The payload is byte-identical to before.
- **The backend does not scan text for paths.** `render_input` (`src/amphi_agent/_cognitive.py:190`) appends a `text` block's `value` verbatim and resolves paths only from structured `mention` blocks (`path_map[id]` + `path`, `realpath`, fail-closed containment check). `SessionFileHandler` mirrors that same rule. No frontend change can weaken it.
- **`request_human` answers travel as `request_id` + stable option ids.** `human-request.ts:285` already states the invariant: *"display copy stays local, so relabeling/relocalizing an option can never change what executes."*
- Consequently the old bug was **purely visual** — the Agent always received the raw text.
- Persistence and replay: `_user_blocks` only renames `value` → `text` and passes `mention.path` through.
- `↑` history recall reads block structure, not rendered DOM.
- `HumanRequestBanner` (the pending card) renders only Agent-authored content — prompt, question, option label / description / preview — so it is untouched.
- `ProcessTimeline`'s one-line `detail` was already a plain string, never Markdown.
- Agent Markdown output: `rewriteBareLocalPaths`, `LocalResourcePreview`, `FileLink` all behave exactly as before — a path the Agent reports is still a link, an image path still previews inline, media still gets a player.

## Trade-off

Pasting an image path into a user message no longer previews it inline, and media paths no longer get a player. Weighed against keeping a media-extension allowlist: that would have preserved the preview, but `LocalResourceView.tsx:30` falls back to `FileLink` when an image fails to load, so `/tmp/a.png replace with b.png` (prose ending in an extension) would have degraded straight back into the original bug. A closed rule with no fallback path was preferred over a narrower one with a tail.

## Test plan

Automated (`desktop/`, all green):

- [x] `bun run test` — 1464 pass / 0 fail
  - New `StructuredInput.test.tsx` (3 cases), written first and confirmed RED before the fix (`expect(querySelector('a')).toBeNull()` received `HTMLAnchorElement`).
  - New case in `MessageBubble.test.tsx` covering the blockless branch, which deleting `LocalPathText` had left with no coverage. Verified by mutation: reinstating an anchor there turns it red.
  - Two new cases in `CompletedInteractionCard.test.tsx`, also confirmed RED first. The second one asserts both halves of the split: the answer has no anchor, while the Agent-authored `prompt` beside it still renders `href="/tmp/context.pdf"`.
  - Removed the 5 cases covering the deleted user-message behaviour.
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run check:chinese`

Manual, in a running dev build against the original reproducing message:

- [x] Path + prose on one line renders as plain text — `insideAnchor: false`, `insideFileLink: false`, no anchor inside.
- [x] It wraps: 133px tall at a 23.1px line-height (~6 lines), 743px wide inside a 744px bubble.
- [x] No horizontal overflow: `document.scrollWidth === clientWidth`, and no ancestor between the node and `<body>` scrolls horizontally.
- [x] Standalone path lines (`.png`, `.docx`, a directory, a Windows path) all stay plain text.
- [x] `@` mention and `/` slash chips, quoted-message cards, and `↑` recall unaffected.
- [x] Agent output regression: `.pptx` / `.mp4` links in the same session still render as links, still open, still expose reveal / copy-path on hover with the full-path tooltip.