### PR TITLE
fix(desktop): stop a long file link from overflowing the message list

### DIFF
--- a/desktop/apps/electron/src/renderer/components/markdown/FileLink.tsx
+++ b/desktop/apps/electron/src/renderer/components/markdown/FileLink.tsx
@@ -12,6 +12,13 @@
  *  - Grouping uses the named `group/filelink`: a paragraph may contain several file links, and an anonymous group would make
  *    hovering any one of them light up the icons of every link.
  *  - Opening still goes through `requestFileOpenAtom` (confirmation dialog + remembering + failure toast); no separate path is started here.
+ *  - The anchor carries `break-all`, and it is load-bearing, not cosmetic. The wrapper is an
+ *    `inline-flex` container, so the anchor is a flex item whose `min-width: auto` resolves to its
+ *    min-content width. An ancestor's `overflow-wrap: break-word` does not reduce that intrinsic
+ *    size (only `word-break: break-all` / `overflow-wrap: anywhere` do), so without this a long
+ *    path cannot shrink and pushes a horizontal scrollbar onto the whole message list. Markdown
+ *    bodies happen to be covered by `MarkdownMessage`'s own `[&_a]:break-all`; every other caller
+ *    depends on this one.
  */
 import { useSetAtom } from 'jotai'
 import type { ReactNode } from 'react'
@@ -54,10 +61,11 @@ export function FileLink({ target, children }: FileLinkProps) {
   }
 
   return (
-    <span className="group/filelink inline-flex items-baseline gap-1">
+    <span className="group/filelink inline-flex max-w-full items-baseline gap-1">
       <Tooltip content={target.path}>
         <a
           href={target.path}
+          className="break-all"
           onClick={(e) => {
             e.preventDefault()
             e.stopPropagation()


### PR DESCRIPTION
UI-only fix, split out of #29 (closed). One file, +9/-1.

## Problem

A long path in a `FileLink` did not wrap. The box grew past the message bubble and pushed a horizontal scrollbar onto the entire message list.

## Cause

`FileLink`'s wrapper is an `inline-flex` container, so the anchor is a flex item whose `min-width: auto` resolves to its **min-content width**. The `Tooltip` in between is `display: contents` and produces no box, so nothing intervenes.

Ancestors only set `overflow-wrap: break-word`, and per spec that does **not** reduce intrinsic min-content size — only `word-break: break-all` (or `overflow-wrap: anywhere`) does. So the anchor could not shrink.

Markdown bodies happened to be immune because `MarkdownMessage` applies its own `[&_a]:break-all`. Every other caller had nothing.

## Fix

- `break-all` on the anchor — this is load-bearing, not cosmetic; the file header now says so, since it looks removable.
- `max-w-full` on the wrapper, capping the shrink-to-fit width as a second line of defence.

## Out of scope, deliberately

A line that merely starts with `/` is still parsed as one absolute path, so prose typed after a path remains part of the link target and its basename. That is a parsing problem, not a styling one, and is tracked separately.

## Verification

`bun run test` 1463 pass / 0 fail, `typecheck`, `lint`, `check:chinese` all pass — but none of them can prove a CSS fix, so it was measured in a running dev build against the reported message:

| Measurement | Result |
|---|---|
| anchor height / line-height | 92px / 23.1px → **4 lines, wrapped** |
| anchor width / box width | 712px / 744px → fits |
| `document.scrollWidth > clientWidth` | `false` → no horizontal scroll |
| overflowing ancestors (anchor → `<body>`) | `[]` |
| computed `word-break` | `break-all` |
| hover icon buttons | 2 × 12x12, unsquashed (they have no `shrink-0`, so this was worth checking) |
| still a `FileLink`? | yes — parsing untouched, as intended |