### PR TITLE
chore(release): bump version to 0.1.4

### DIFF
--- a/desktop/apps/electron/package.json
+++ b/desktop/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amphi",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Bridgic Agent desktop app",
   "repository": {
     "type": "git",

--- a/desktop/apps/electron/src/shared/app-meta.ts
+++ b/desktop/apps/electron/src/shared/app-meta.ts
@@ -84,7 +84,7 @@ export const APP_BUNDLE_ID = 'ai.bridgic.agent'
 export const APP_DEEPLINK_SCHEME = 'amphi'
 
 /** App version — keep in sync with root and apps/electron package.json. */
-export const APP_VERSION = '0.1.3'
+export const APP_VERSION = '0.1.4'
 
 /** GitHub page used for user-confirmed issue reports from the desktop app. */
 export const APP_NEW_ISSUE_URL = 'https://github.com/bitsky-tech/bridgic-agent/issues/new'

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bridgic-agent-desktop",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "license": "SEE LICENSE IN ../LICENSE",
   "description": "Bridgic Agent — Electron GUI client for the Bridgic Agent backend daemon",

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -11,7 +11,7 @@ The command-line entry is ``python -m src <subcommand>`` (see
 :mod:`.amphi_cli`).
 """
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 
 
 __all__ = ["__version__"]


### PR DESCRIPTION
Summary:
- bump all four release version sources from 0.1.3 to 0.1.4 via `bun --cwd=desktop run set-version 0.1.4`
- keep the release commit based exactly on origin/main at 091ead4959edcd9663c7f8ab17cbcf8b13336208
- no other change: the diff is four lines across `src/__init__.py`, `desktop/package.json`, `desktop/apps/electron/package.json`, and `desktop/apps/electron/src/shared/app-meta.ts`

Validation (run locally on the bumped tree):
- desktop lint passed
- desktop typecheck passed
- desktop test: 1346 passed, 6 skipped, 0 failed
- check:chinese, check:locales (1751 keys at parity), check:naming, check:doc-links all passed
- backend pytest: 440 passed

Follow-up after merge:
- tag `0.1.4` on main to publish the release; a tag push builds the full matrix and always runs the Windows installer smoke suite
- verify the release carries the merged `latest-mac.yml` alongside both macOS architectures' assets and the Windows `latest.yml`