### PR TITLE
fix(agent): keep file reads inline and control round limits in code

### DIFF
--- a/desktop/apps/electron/src/renderer/lib/amphiClient.ts
+++ b/desktop/apps/electron/src/renderer/lib/amphiClient.ts
@@ -434,7 +434,6 @@ export interface MeProfile {
   display_name: string | null
   current_model: string | null
   base_url: string | null
-  default_max_rounds: number
   default_temperature: number
   api_key_set: boolean
   protocol: 'openai' | 'anthropic' | 'openai-codex'

--- a/src/amphi_agent/_agent.py
+++ b/src/amphi_agent/_agent.py
@@ -3449,6 +3449,10 @@ class AmphiAgent(AmphibiousAutoma[AmphiOTAContext, AmphiContext]):
 
         day_dir = base_dir / datetime.now().strftime("%Y-%m-%d")
         for step in getattr(result, "results", None) or []:
+            # File reads bound their own output; persisting it would make later
+            # reads paginate a copy of the presentation instead of the source.
+            if getattr(step, "tool_name", None) == "read_file":
+                continue
             failed = getattr(step, "success", True) is False
             value = (
                 getattr(step, "error", None)

--- a/src/amphi_agent/_agent.py
+++ b/src/amphi_agent/_agent.py
@@ -92,7 +92,7 @@ from ..amphi_service.protocol._ws_messages import (
 
 logger = logging.getLogger(__name__)
 
-# Constants
+# Each ThinkUnit invocation gets this many observe-think-act rounds.
 DEFAULT_MAX_ROUNDS = 200
 MAX_THINK_UNITS_PER_TURN = 50
 MAX_EMPTY_ANSWER_RECOVERY_ATTEMPTS = 3
@@ -149,9 +149,6 @@ class AmphiAgent(AmphibiousAutoma[AmphiOTAContext, AmphiContext]):
 
     Parameters
     ----------
-    max_rounds : int
-        Hard cap on the observe-think-act rounds per stage for one turn
-        (applied as each stage's ThinkUnit ``max_attempts`` in on_agent).
     verbose : bool
         When True, the framework prints its internal run summary.
     """
@@ -169,9 +166,8 @@ class AmphiAgent(AmphibiousAutoma[AmphiOTAContext, AmphiContext]):
     # Saved Workflow runtime.
     execute = think_unit(WorkflowThink(), max_attempts=DEFAULT_MAX_ROUNDS)
 
-    def __init__(self, max_rounds: int = DEFAULT_MAX_ROUNDS, verbose: bool = False) -> None:
+    def __init__(self, verbose: bool = False) -> None:
         super().__init__(verbose=verbose)
-        self._max_rounds = max_rounds
         self._agent_result: Optional[AgentResult] = None
         self.no_display_tools = set([
             "switch",
@@ -257,7 +253,7 @@ class AmphiAgent(AmphibiousAutoma[AmphiOTAContext, AmphiContext]):
 
             answer = yield ThinkUnit(
                 current_stage,
-                max_attempts=self._max_rounds,
+                max_attempts=DEFAULT_MAX_ROUNDS,
                 until=lambda c, s=current_status: (
                     c.think_status != s
                     or c.interaction_status is not None

--- a/src/amphi_agent/_invocation.py
+++ b/src/amphi_agent/_invocation.py
@@ -12,7 +12,7 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, AsyncIterator, Callable, Optional
 
-from ._agent import AmphiAgent
+from ._agent import DEFAULT_MAX_ROUNDS, AmphiAgent
 from ._browser import BrowserHost
 from ._context import AmphiContext, AmphiOTAContext, ContextUsageSnapshot
 from ._error import PublicAgentError
@@ -682,7 +682,6 @@ class AgentInvocation:
         ):
             execution_mode = previous_turns[-1].execution_mode
         execution_mode = execution_mode or user.execution_mode
-        max_rounds = user.default_max_rounds
         ota_context = AmphiOTAContext(user_input=user_input, stream=stream)
         title_task: Optional[asyncio.Task[Optional[str]]] = None
         prepared_children: list[tuple[SessionRecord, SubAgentCall]] = []
@@ -777,7 +776,7 @@ class AgentInvocation:
                 llm_provider=llm_provider,
                 execution_mode=execution_mode,
             )
-            agent = AmphiAgent(max_rounds=max_rounds, verbose=False)
+            agent = AmphiAgent(verbose=False)
 
             # Name a new root Session alongside its first Agent turn. Title generation
             # only needs the opening user input, so waiting for ``agent.arun`` would
@@ -819,7 +818,7 @@ class AgentInvocation:
                             status=TurnStatus.CANCELLED,
                             model=model,
                             execution_mode=execution_mode,
-                            max_rounds=max_rounds,
+                            max_rounds=DEFAULT_MAX_ROUNDS,
                             duration_ms=elapsed_ms(),
                         ),
                     )
@@ -838,7 +837,7 @@ class AgentInvocation:
                         error=error_message,
                         model=model,
                         execution_mode=execution_mode,
-                        max_rounds=max_rounds,
+                        max_rounds=DEFAULT_MAX_ROUNDS,
                         duration_ms=elapsed_ms(),
                     )
                 finally:
@@ -855,7 +854,7 @@ class AgentInvocation:
                         outcome=outcome,
                         model=model,
                         execution_mode=execution_mode,
-                        max_rounds=max_rounds,
+                        max_rounds=DEFAULT_MAX_ROUNDS,
                         duration_ms=elapsed_ms(),
                     )
                 except BaseException:

--- a/src/amphi_agent/tools/_filesystem.py
+++ b/src/amphi_agent/tools/_filesystem.py
@@ -1,3 +1,4 @@
+import json
 import os
 import re
 from pathlib import Path
@@ -19,6 +20,7 @@ FILE_SYSTEM_TOOL_NAMES = frozenset({
 # read from crowding out the rest of the context.
 DEFAULT_MAX_LINES: int = 2000
 MAX_LINE_LENGTH: int = 2000
+READ_FILE_MAX_CHARS: int = 16 * 1024
 MAX_FILE_BYTES: int = 5 * 1024 * 1024  # 5 MB
 # Search-tool caps — bound output so a sloppy pattern can't flood the prompt.
 GLOB_MAX_RESULTS: int = 100
@@ -133,19 +135,20 @@ def _check_read_before_modify(abs_path: str) -> None:
 async def read_file(file_path: str, offset: int = 0, limit: int = 0) -> str:
     """Read a file from the workspace and return its content with line numbers.
 
-    Output is ``cat -n`` style (line numbers) so a later edit_file can quote a
-    uniquely-locatable ``old_string``. Reading a file also marks it safe to
-    modify (write_file / edit_file require a prior read).
+    Output includes the absolute source path, actual line range, total line count, and
+    numbered content. The complete response is capped at 16384 characters;
+    individual lines are capped at 2000 characters and marked when truncated.
+    Reading also records the file for a later edit_file operation.
 
     Args:
         file_path: Path relative to the Session work directory shown in
             ``<Workspace>``, or an absolute path.
         offset: 1-based line to start at; 0 starts at the first line.
-        limit: Max lines to return; 0 uses the default cap of 2000.
+        limit: Max lines to return; 0 uses 2000. The character cap may return fewer.
 
     Returns:
-        The numbered content (with a marker when truncated), or a notice for an
-        empty file / out-of-range offset.
+        The actual read range and numbered content, with the applicable limit
+        and omitted content counts, or an empty-file / out-of-range notice.
     """
     abs_path = _resolve_file(file_path)
     if not os.path.exists(abs_path):
@@ -167,20 +170,59 @@ async def read_file(file_path: str, offset: int = 0, limit: int = 0) -> str:
     start = max(offset - 1, 0) if offset > 0 else 0
     if start >= len(lines):
         return f"(Offset {offset} is past the end of the file [{len(lines)} lines].)"
-    end = min(start + (limit if limit > 0 else DEFAULT_MAX_LINES), len(lines))
+    line_limit = limit if limit > 0 else DEFAULT_MAX_LINES
+    requested_end = min(start + line_limit, len(lines))
+    source = json.dumps(abs_path, ensure_ascii=False)
+
+    def render_metadata(end: int) -> Tuple[str, str]:
+        header = (
+            f"File: {source}\n"
+            f"Lines: {start + 1}-{end} of {len(lines)} "
+            f"({len(lines) - end} lines remaining).\n\n"
+        )
+        notice = ""
+        if end < len(lines):
+            reached_limit = (
+                f"{READ_FILE_MAX_CHARS}-character response limit"
+                if end < requested_end else f"{line_limit}-line read limit"
+            )
+            notice = (
+                f"\n\n[Output truncated: reached the {reached_limit}. "
+                f"Remaining file lines not shown: {len(lines) - end}.]"
+            )
+        return header, notice
 
     rendered: List[str] = []
-    for idx, line in enumerate(lines[start:end], start=start + 1):
+    rendered_chars = 0
+    for idx in range(start, requested_end):
+        line = lines[idx]
         if line.endswith("\n"):
             line = line[:-1]
         if len(line) > MAX_LINE_LENGTH:
-            line = line[:MAX_LINE_LENGTH] + "...[line truncated]"
-        rendered.append(f"{idx:6d}\t{line}")
-    if end < len(lines):
-        rendered.append(
-            f"... [{len(lines) - end} more lines; pass offset/limit to read further]"
-        )
-    return "\n".join(rendered)
+            original_length = len(line)
+            line = line[:MAX_LINE_LENGTH] + (
+                f"...[line truncated: {original_length} characters exceed the "
+                f"{MAX_LINE_LENGTH}-character line limit; "
+                f"{original_length - MAX_LINE_LENGTH} characters not shown]"
+            )
+        numbered = f"{idx + 1:6d}\t{line}"
+        added_chars = len(numbered) + (1 if rendered else 0)
+        if rendered_chars + added_chars > READ_FILE_MAX_CHARS:
+            break
+        rendered.append(numbered)
+        rendered_chars += added_chars
+
+    # Fit the actual metadata after collecting content: a complete file needs
+    # no truncation notice. Count incrementally and join the body only once.
+    while rendered:
+        end = start + len(rendered)
+        header, notice = render_metadata(end)
+        if len(header) + rendered_chars + len(notice) <= READ_FILE_MAX_CHARS:
+            return header + "\n".join(rendered) + notice
+        rendered_chars -= len(rendered.pop())
+        if rendered:
+            rendered_chars -= 1
+    raise ValueError("File path is too long to include content within the read output limit.")
 
 
 async def write_file(file_path: str, content: str) -> str:

--- a/src/amphi_service/handler/_me_handler.py
+++ b/src/amphi_service/handler/_me_handler.py
@@ -182,7 +182,6 @@ def me_profile(user: User) -> dict:
         "display_name": user.display_name,
         "current_model": user.current_model,
         "base_url": user.base_url,
-        "default_max_rounds": user.default_max_rounds,
         "default_temperature": user.default_temperature,
         "api_key_set": bool(user.api_key),
         "protocol": getattr(user, "protocol", "openai"),

--- a/src/amphi_store/_user.py
+++ b/src/amphi_store/_user.py
@@ -21,7 +21,6 @@ class User(SQLModel, table=True):
     api_key: Optional[str] = Field(default=None)
     base_url: Optional[str] = Field(default=None)
     current_model: str = Field(description="The model used when the user submits a chat.")
-    default_max_rounds: int = Field(default=50)
     default_temperature: float = Field(default=0.0)
     # NEW (Phase 2): which wire protocol the active LLM client should speak.
     # Mirrored from the active ``ProviderCredential.protocol`` so the

--- a/tests/agent/core/test_large_result.py
+++ b/tests/agent/core/test_large_result.py
@@ -3,37 +3,42 @@ from __future__ import annotations
 from pathlib import Path
 from types import SimpleNamespace
 
-from bridgic.amphibious import OTARecord, StepToolCall
+import pytest
+from bridgic.amphibious import ActionResult, ActionStepResult, OTARecord, StepToolCall
 from bridgic.amphibious._type import ThinkResult
 from bridgic.core.agentic.tool_specs import FunctionToolSpec
 
 from src.amphi_agent import AmphiAgent, AmphiContext, AmphiOTAContext, Session
+from src.amphi_agent import _agent
+from src.amphi_agent._agent import TOOL_RESULT_INLINE_CHAR_LIMIT
 from src.amphi_agent._state import CallVerdict, RoundPermission
 from src.amphi_agent._workspace import Workspace
 from src.amphi_agent.security import Permission
+from src.amphi_agent.tools._filesystem import READ_FILE_MAX_CHARS, read_file
 from src.amphi_store import SessionRecord
 from tests._support.sandbox import IsolatedPaths
 
 
-async def test_large_tool_result(test_sandbox: IsolatedPaths) -> None:
-    """Final ordinary-tool result:
-
-    {
-      "inline_result": "file pointer",
-      "stored_file": "inside the owning Session tool-result directory",
-      "stored_content": "complete original output",
-      "stream_output": "same bounded pointer"
-    }
-
-    Checks:
-    1. An allowed ordinary tool executes successfully with an oversized output.
-    2. The model-visible result becomes a file reference inside the owning Session.
-    3. The stored file is complete and the live event exposes only the bounded reference.
-    """
+@pytest.mark.parametrize("tool_name", ["large_report", "read_file"])
+async def test_large_tool_result(test_sandbox: IsolatedPaths, monkeypatch: pytest.MonkeyPatch, tool_name: str) -> None:
+    """Real tool execution streams the same result given to the model; only ordinary tools spool."""
     payload = "report-line\n" * 2000
 
     async def large_report() -> str:
         return payload
+
+    arguments = {}
+    tool = large_report
+    expected = payload
+    if tool_name == "read_file":
+        target = test_sandbox.root / "requirements.txt"
+        target.write_text(payload, encoding="utf-8")
+        arguments = {"file_path": str(target)}
+        tool = read_file
+        expected = await read_file(str(target))
+        # Exercise the exemption through the full action path even if limits diverge.
+        monkeypatch.setattr(_agent, "TOOL_RESULT_INLINE_CHAR_LIMIT", 1024)
+        assert 1024 < len(expected) <= READ_FILE_MAX_CHARS
 
     events: list[tuple[str, dict[str, object]]] = []
     stream = SimpleNamespace(
@@ -41,8 +46,8 @@ async def test_large_tool_result(test_sandbox: IsolatedPaths) -> None:
     )
     call = StepToolCall(
         call_id="call-large",
-        tool="large_report",
-        tool_arguments=[],
+        tool=tool_name,
+        tool_arguments=[{"name": name, "value": value} for name, value in arguments.items()],
     )
     record = OTARecord(
         think_result=ThinkResult(
@@ -57,7 +62,7 @@ async def test_large_tool_result(test_sandbox: IsolatedPaths) -> None:
             CallVerdict(
                 id=call.call_id,
                 tool=call.tool,
-                arguments={},
+                arguments=arguments,
                 verdict=Permission.ALLOW.value,
             ),
         ],
@@ -77,19 +82,27 @@ async def test_large_tool_result(test_sandbox: IsolatedPaths) -> None:
     ota_context = AmphiOTAContext(
         user_input="Generate a large report.",
         ota_record=[record],
-        tools=[FunctionToolSpec.from_raw(large_report)],
+        tools=[FunctionToolSpec.from_raw(tool)],
         stream=stream,
     )
 
     result = await AmphiAgent().action_tool_call(ota_context, context)
 
-    # Check 1: The admitted ordinary tool completes rather than being denied or truncated.
+    # Both tools execute successfully and publish the same result exposed to the model.
     assert len(result.results) == 1
     step = result.results[0]
     assert step.tool_id == call.call_id
     assert step.success is True
+    result_events = [data for event, data in events if event == "tool_result"]
+    assert len(result_events) == 1
+    assert result_events[0]["output"] == step.tool_result
 
-    # Check 2: The next model round receives a bounded pointer in this Session's directory.
+    if tool_name == "read_file":
+        assert step.tool_result == expected
+        assert not list(workspace.tool_result_dir.rglob("*.txt"))
+        return
+
+    # Ordinary outputs keep a complete on-disk copy and return a bounded pointer.
     pointer = str(step.tool_result)
     assert "Tool result exceeded inline limit" in pointer
     assert payload not in pointer
@@ -97,9 +110,31 @@ async def test_large_tool_result(test_sandbox: IsolatedPaths) -> None:
     stored_path = Path(path_line.removeprefix("Path: "))
     assert stored_path.is_relative_to(workspace.tool_result_dir.resolve())
 
-    # Check 3: Disk preserves the full output while streaming publishes the same pointer.
     assert stored_path.read_text(encoding="utf-8") == payload
-    result_events = [data for event, data in events if event == "tool_result"]
-    assert len(result_events) == 1
-    assert result_events[0]["output"] == pointer
     assert payload not in str(result_events[0]["output"])
+
+
+def test_read_file_is_exempt_in_mixed_results(test_sandbox: IsolatedPaths) -> None:
+    """A read result stays inline even above the generic limit, without exempting its siblings."""
+    payload = "x" * (TOOL_RESULT_INLINE_CHAR_LIMIT + 1)
+    read = ActionStepResult(
+        tool_id="read", tool_name="read_file", tool_arguments={}, tool_result=payload,
+    )
+    report = ActionStepResult(
+        tool_id="report", tool_name="large_report", tool_arguments={}, tool_result=payload,
+    )
+    small = ActionStepResult(
+        tool_id="small", tool_name="small_report", tool_arguments={}, tool_result="small result",
+    )
+    workspace = Workspace("mixed-results", session_root=test_sandbox.sessions / "mixed-results")
+    context = AmphiContext(workspace=workspace)
+
+    AmphiAgent._save_large_tool_results(ActionResult(results=[read, report, small]), context)
+
+    assert read.tool_result == payload
+    assert small.tool_result == "small result"
+    assert "Tool result exceeded inline limit" in report.tool_result
+    files = list(workspace.tool_result_dir.rglob("*.txt"))
+    assert len(files) == 1
+    assert files[0].name.startswith("large_report_")
+    assert files[0].read_text(encoding="utf-8") == payload

--- a/tests/agent/invocation/test_resilience.py
+++ b/tests/agent/invocation/test_resilience.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import pytest
 
-from src.amphi_agent import AgentInvocation, InvocationDisposition, InvocationTraceLimitError
+from src.amphi_agent import DEFAULT_MAX_ROUNDS, AgentInvocation, InvocationDisposition, InvocationTraceLimitError
 from src.amphi_agent._state import AgentState, AwaitingFeedback, AwaitingSubAgent, SubAgentCall
 from src.amphi_agent.runtime._environment import AppCommandEnvironmentSnapshot, app_command_environment
 from src.amphi_service.runtime._session_events import SessionEventBroker
@@ -21,12 +21,76 @@ from src.amphi_store import (
     SubAgentMode,
     TurnStatus,
     UserInput,
+    UserRepository,
 )
 from tests._support.sandbox import IsolatedPaths
 from tests.service.flows._scripted_llm import ScriptedLlm
 
 
 USER_ID = "local"
+
+
+async def test_code_round_limit(agent_store: None, agent_model: str, test_sandbox: IsolatedPaths, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The real Invocation crosses 50 rounds and exhausts its first ThinkUnit at the code limit."""
+    class StaticLlms:
+        def __init__(self, llm: ScriptedLlm) -> None:
+            self._llm = llm
+
+        async def resolve(self, _user: Any, _model: str) -> ScriptedLlm:
+            return self._llm
+
+    environment = {
+        **test_sandbox.process_environment(),
+        "PATH": os.environ.get("PATH", ""),
+    }
+    snapshot = AppCommandEnvironmentSnapshot(
+        environment=MappingProxyType(environment),
+        managed_environment=MappingProxyType(dict(environment)),
+        uv_executable=None,
+        uv_version=None,
+        python_executable=Path(sys.executable),
+        python_version=sys.version.split()[0],
+        node_executable=None,
+        node_version=None,
+    )
+    monkeypatch.setattr(app_command_environment, "snapshot", lambda: snapshot)
+
+    await UserRepository().set_execution_mode(USER_ID, "full")
+    record = SessionRecord(
+        id="code-round-limit", user_id=USER_ID, title="Check the code round limit",
+        workspace_root=str(test_sandbox.sessions / "code-round-limit"),
+    )
+    await SessionRepository().save(record)
+    work_dir = Path(record.workspace_root) / ".work"
+    work_dir.mkdir(parents=True)
+    (work_dir / "input.txt").write_text("Read this line.\n", encoding="utf-8")
+    assert DEFAULT_MAX_ROUNDS == 200
+    llm = ScriptedLlm(model=agent_model)
+    for index in range(DEFAULT_MAX_ROUNDS + 1):
+        llm.enqueue_tool("read_file", {"file_path": "input.txt"}, call_id=f"read-{index}")
+    llm.enqueue_text("Finished after the code-controlled boundary.")
+    invocation = AgentInvocation(StaticLlms(llm), SessionEventBroker(), SystemEventBroker())
+    try:
+        result = await (await invocation.arun(record.id, "Exercise the configured loop limit."))
+        assert result.outcome.disposition is InvocationDisposition.COMPLETED
+        assert result.outcome.answer == "Finished after the code-controlled boundary."
+        assert len(llm.turn_calls) == DEFAULT_MAX_ROUNDS + 2
+        turn = await SessionTurnRepository().latest(record.id, USER_ID)
+        assert turn is not None
+        rounds = turn.ota_records or []
+        assert len(rounds) == DEFAULT_MAX_ROUNDS + 2
+        steps = [step for row in rounds for step in (row.get("action_result") or {}).get("results", [])]
+        assert len(steps) == DEFAULT_MAX_ROUNDS + 1
+        assert all(step["success"] for step in steps)
+        # Existing empty-answer recovery starts only after the complete 200-round unit.
+        recoveries = [
+            index + 1 for index, row in enumerate(rounds)
+            if "The previous round ended without a user-visible response." in (row.get("observation_result") or "")
+        ]
+        assert recoveries == [DEFAULT_MAX_ROUNDS]
+        llm.assert_finished()
+    finally:
+        await invocation.shutdown()
 
 
 async def test_cancel_parked_tree(agent_store: None, agent_model: str, test_sandbox: IsolatedPaths) -> None:

--- a/tests/agent/tools/test_filesystem_tools.py
+++ b/tests/agent/tools/test_filesystem_tools.py
@@ -1,9 +1,22 @@
+import json
 import os
+import re
 import time
 
 import pytest
+from bridgic.amphibious import ActionResult, ActionStepResult
 
-from src.amphi_agent.tools._filesystem import edit_file, glob, grep, read_file, write_file
+from src.amphi_agent import AmphiAgent
+from src.amphi_agent.tools import _filesystem
+from src.amphi_agent.tools._filesystem import (
+    DEFAULT_MAX_LINES,
+    READ_FILE_MAX_CHARS,
+    edit_file,
+    glob,
+    grep,
+    read_file,
+    write_file,
+)
 from tests.agent.tools._harness import ToolHarness
 
 
@@ -31,7 +44,13 @@ async def test_file_lifecycle(tool_harness: ToolHarness) -> None:
 
     # Check 2: Reading returns numbered content and records the file for a targeted edit.
     numbered = await read_file("notes/item.txt")
-    assert numbered.splitlines() == ["     1\tAlpha", "     2\tBeta"]
+    assert numbered.splitlines() == [
+        f"File: {json.dumps(str(target), ensure_ascii=False)}",
+        "Lines: 1-2 of 2 (0 lines remaining).",
+        "",
+        "     1\tAlpha",
+        "     2\tBeta",
+    ]
 
     # Check 3: A targeted edit changes only the requested text in the persisted file.
     edited = await edit_file("notes/item.txt", "Beta", "Gamma")
@@ -130,30 +149,171 @@ async def test_read_window(tool_harness: ToolHarness) -> None:
     }
 
     Checks:
-    1. Offset and limit return the requested numbered window with a remainder marker.
+    1. Offset and limit return the actual numbered window and remaining line count.
     2. Oversized individual lines are bounded without losing their line number.
     3. Empty files and offsets past EOF return explicit non-error results.
     """
     await write_file("window.txt", "one\ntwo\nthree\nfour\n")
 
-    # Check 1: Offset and limit return the requested numbered window with a remainder marker.
+    # Check 1: The result reports read facts without prescribing the next tool call.
     window = await read_file("window.txt", offset=2, limit=2)
     assert window.splitlines() == [
+        f"File: {json.dumps(str(tool_harness.workspace.work_dir / 'window.txt'), ensure_ascii=False)}",
+        "Lines: 2-3 of 4 (1 lines remaining).",
+        "",
         "     2\ttwo",
         "     3\tthree",
-        "... [1 more lines; pass offset/limit to read further]",
+        "",
+        "[Output truncated: reached the 2-line read limit. Remaining file lines not shown: 1.]",
     ]
 
     # Check 2: Oversized individual lines are bounded without losing their line number.
     await write_file("long.txt", "x" * 2_100)
     long_line = await read_file("long.txt")
-    assert long_line.startswith("     1\t" + "x" * 2_000)
-    assert long_line.endswith("...[line truncated]")
+    assert long_line.split("\n\n", 1)[1].startswith("     1\t" + "x" * 2_000)
+    assert long_line.endswith(
+        "...[line truncated: 2100 characters exceed the 2000-character line limit; "
+        "100 characters not shown]"
+    )
+    assert "Remaining file lines not shown" not in long_line
 
     # Check 3: Empty files and offsets past EOF return explicit non-error results.
     await write_file("empty.txt", "")
     assert await read_file("empty.txt") == "(File exists but is empty.)"
     assert await read_file("window.txt", offset=20) == "(Offset 20 is past the end of the file [4 lines].)"
+
+
+@pytest.mark.parametrize("limit", [0, 500, 100_000])
+async def test_large_file_pages(tool_harness: ToolHarness, limit: int) -> None:
+    """Read every source line once without spooling or accumulating line prefixes."""
+    target = tool_harness.workspace.work_dir / "requirements.txt"
+    lines = [f'Requirement {index}: 中文内容 with "quoted" details ' * 2 for index in range(1464)]
+    target.write_text("\n".join(lines), encoding="utf-8")
+    collected: list[str] = []
+    offset = 1
+    page_count = 0
+
+    while len(collected) < len(lines):
+        output = await read_file("requirements.txt", offset=offset, limit=limit)
+        assert len(output) <= READ_FILE_MAX_CHARS
+        assert output.startswith(f"File: {json.dumps(str(target), ensure_ascii=False)}\n")
+        assert "pass offset/limit" not in output
+        assert "next_offset" not in output
+        rows = re.findall(r"^\s*(\d+)\t(.*)$", output, re.MULTILINE)
+        assert rows
+        indices = [int(index) for index, _ in rows]
+        assert indices == list(range(offset, offset + len(rows)))
+        end = indices[-1]
+        assert f"Lines: {offset}-{end} of 1464 ({1464 - end} lines remaining)." in output
+        assert [content for _, content in rows] == lines[offset - 1:end]
+        if end < len(lines):
+            assert output.endswith(
+                f"[Output truncated: reached the {READ_FILE_MAX_CHARS}-character response limit. "
+                f"Remaining file lines not shown: {1464 - end}.]"
+            )
+        else:
+            assert "[Output truncated:" not in output
+
+        step = ActionStepResult(
+            tool_id=f"read-{offset}", tool_name="read_file",
+            tool_arguments={"file_path": "requirements.txt", "offset": offset, "limit": limit},
+            tool_result=output,
+        )
+        AmphiAgent._save_large_tool_results(ActionResult(results=[step]), tool_harness.context)
+        assert step.tool_result == output
+        collected.extend(content for _, content in rows)
+        offset = end + 1
+        page_count += 1
+
+    assert page_count > 1
+    assert collected == lines
+    assert target.read_text(encoding="utf-8") == "\n".join(lines)
+    assert not list(tool_harness.workspace.tool_result_dir.rglob("*.txt"))
+    assert await read_file("requirements.txt", offset=offset) == (
+        "(Offset 1465 is past the end of the file [1464 lines].)"
+    )
+
+
+async def test_read_line_limit_and_long_lines(tool_harness: ToolHarness, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Line and character limits both report the actual source range and truncation."""
+    await write_file("blank.txt", "\n" * (DEFAULT_MAX_LINES + 1))
+    # Isolate the line cap from platform-dependent absolute path lengths.
+    with monkeypatch.context() as patch:
+        patch.setattr(_filesystem, "READ_FILE_MAX_CHARS", READ_FILE_MAX_CHARS * 2)
+        blank = await read_file("blank.txt")
+    assert len(re.findall(r"^\s*\d+\t", blank, re.MULTILINE)) == DEFAULT_MAX_LINES
+    assert f"Lines: 1-{DEFAULT_MAX_LINES} of {DEFAULT_MAX_LINES + 1} (1 lines remaining)." in blank
+    assert blank.endswith(
+        f"[Output truncated: reached the {DEFAULT_MAX_LINES}-line read limit. "
+        "Remaining file lines not shown: 1.]"
+    )
+    assert len(blank) <= READ_FILE_MAX_CHARS * 2
+
+    await write_file("long.txt", ("中" * 2100 + "\n") * 100)
+    output = await read_file("long.txt", offset=90, limit=10)
+    rows = re.findall(r"^\s*(\d+)\t(.*)$", output, re.MULTILINE)
+    assert 0 < len(rows) < 10
+    assert rows[0][0] == "90"
+    assert all(content == "中" * 2000 + (
+        "...[line truncated: 2100 characters exceed the 2000-character line limit; "
+        "100 characters not shown]"
+    ) for _, content in rows)
+    assert output.endswith(
+        f"[Output truncated: reached the {READ_FILE_MAX_CHARS}-character response limit. "
+        f"Remaining file lines not shown: {100 - int(rows[-1][0])}.]"
+    )
+    assert len(output) <= READ_FILE_MAX_CHARS
+
+
+async def test_read_reports_absolute_source_path(tool_harness: ToolHarness) -> None:
+    """Relative and absolute inputs identify the same complete source path."""
+    target = tool_harness.workspace.work_dir / "notes" / "requirements.txt"
+    await write_file("notes/requirements.txt", "first\nsecond\n")
+    relative = await read_file("notes/../notes/requirements.txt", limit=1)
+    absolute = await read_file(str(target), limit=1)
+    assert relative == absolute
+    assert json.loads(relative.splitlines()[0].removeprefix("File: ")) == str(target)
+    assert relative.endswith(
+        "[Output truncated: reached the 1-line read limit. Remaining file lines not shown: 1.]"
+    )
+    assert "pass offset/limit" not in relative
+    assert "next_offset" not in relative
+
+
+@pytest.mark.parametrize("extra_characters", [0, 1])
+async def test_read_complete_response_at_character_boundary(tool_harness: ToolHarness, extra_characters: int) -> None:
+    """A complete response at the cap needs no space reserved for a truncation notice."""
+    target = tool_harness.workspace.work_dir / "boundary.txt"
+    header = (
+        f"File: {json.dumps(str(target), ensure_ascii=False)}\n"
+        "Lines: 1-17 of 17 (0 lines remaining).\n\n"
+    )
+    lines = ["x" * 1000] * 15 + ["", "tail"]
+    numbered = "\n".join(f"{index:6d}\t{line}" for index, line in enumerate(lines, 1))
+    padding = READ_FILE_MAX_CHARS - len(header + numbered) + extra_characters
+    assert 0 < padding < 2000
+    lines[15] = "y" * padding
+    target.write_text("\n".join(lines), encoding="utf-8")
+    complete = header + "\n".join(f"{index:6d}\t{line}" for index, line in enumerate(lines, 1))
+    assert len(complete) == READ_FILE_MAX_CHARS + extra_characters
+
+    output = await read_file(str(target))
+    if extra_characters == 0:
+        assert output == complete
+    else:
+        assert len(output) <= READ_FILE_MAX_CHARS
+        rows = re.findall(r"^\s*(\d+)\t(.*)$", output, re.MULTILINE)
+        assert rows
+        end = int(rows[-1][0])
+        assert end < len(lines)
+        assert [content for _, content in rows] == lines[:end]
+        assert output.endswith(
+            f"[Output truncated: reached the {READ_FILE_MAX_CHARS}-character response limit. "
+            f"Remaining file lines not shown: {len(lines) - end}.]"
+        )
+        remaining = await read_file(str(target), offset=end + 1)
+        remaining_rows = re.findall(r"^\s*(\d+)\t(.*)$", remaining, re.MULTILINE)
+        assert [content for _, content in rows + remaining_rows] == lines
 
 
 async def test_file_search(tool_harness: ToolHarness) -> None:

--- a/tests/service/handlers/test_me_handler.py
+++ b/tests/service/handlers/test_me_handler.py
@@ -25,7 +25,6 @@ async def test_profile(service_client: httpx.AsyncClient) -> None:
         "display_name": None,
         "current_model": "",
         "base_url": None,
-        "default_max_rounds": 50,
         "default_temperature": 0.0,
         "api_key_set": False,
         "protocol": "openai",

--- a/tests/store/test_user_repository.py
+++ b/tests/store/test_user_repository.py
@@ -29,10 +29,13 @@ async def test_seeded(initialized_store: None) -> None:
     user = await repository.load(USER_ID)
     assert user is not None
     assert user.id == USER_ID
+    async with repository._engine.connect() as connection:
+        columns = (await connection.exec_driver_sql("PRAGMA table_info(users)")).all()
+    assert "default_max_rounds" not in {column[1] for column in columns}
 
     # Check 2: The local User starts with safe model, execution, and credential defaults.
     assert user.current_model == ""
-    assert user.default_max_rounds == 50
+    assert "default_max_rounds" not in user.model_dump()
     assert user.default_temperature == 0.0
     assert user.execution_mode == "auto"
     assert user.protocol == "openai"


### PR DESCRIPTION
Large `read_file` responses could be spooled by the generic tool-result handler, causing subsequent reads to paginate generated output with repeated line numbers. Keep file reads inline and bound their complete response to 16,384 characters. Return the absolute source path, actual line range, total line count, and explicit truncation counts so the agent can read additional windows from the source file. Other tools retain their existing overflow behavior.

Agent invocations also inherited the user's stored `default_max_rounds=50`, overriding the code's intended 200-round limit. Remove that preference from the User model, profile API, and frontend type, and use `DEFAULT_MAX_ROUNDS` directly for execution and turn records. The limit remains per ThinkUnit invocation.

Validation:
- Backend regression coverage for file-read boundaries and pagination, mixed tool-result spooling, invocation round limits, user storage, and profile handlers passed during implementation and review.
- The scripted invocation passes 50 rounds and reaches the code-defined boundary at 200 rounds before the existing empty-answer recovery runs.
- Electron typecheck passed; frontend tool-display tests passed (37 tests).
- Temporary-database checks confirmed existing-user upgrades and fresh installation seeding; `git diff --check` passed.

Compatibility: Existing databases retain the unused legacy column; fresh databases omit it. Recreating a missing user in a legacy table still fails its NOT NULL constraint, and opening a fresh database with the old 0.1.4 user model fails because the column is absent. Ordinary upgrades with the existing local user work. This change does not alter the framework's behavior when rounds are exhausted.
