### PR TITLE
fix(workflows): restore legacy package compatibility

### DIFF
--- a/src/amphi_agent/_agent.py
+++ b/src/amphi_agent/_agent.py
@@ -1172,6 +1172,46 @@ class AmphiAgent(AmphibiousAutoma[AmphiOTAContext, AmphiContext]):
             if isinstance(ota_context.think_status, BuildStageState) and not confirming_workflow:
                 await self._sync_build_space(ota_context, context)
             elif isinstance(ota_context.think_status, WorkflowStageState):
+                if think.get("stage") == "validate":
+                    # Consume the parked Turn before settlement can publish a result
+                    # or fail. Persistence must replace it with its original trace.
+                    approval_answers = self._permission_answers(ota_context.user_input)
+                    if latest_turn.status is TurnStatus.AWAITING_SUBAGENTS:
+                        self._resume_subagents(ota_context, context, subagent_state, rounds, original_user_input)
+                    elif latest_turn.status is TurnStatus.AWAITING_HUMAN:
+                        self._resume_human_choice(ota_context, context, interaction, rounds, original_user_input)
+                    else:
+                        ota_context.ota_record = [OTARecord.model_validate(record) for record in rounds]
+                        context.session = context.session.without_last()
+                        ota_context.user_input = original_user_input
+
+                    note = "Skipped the retired Workflow validation phase; its pending tools must not be replayed."
+                    if not ota_context.ota_record:
+                        ota_context.ota_record.append(OTARecord())
+                    held = ota_context.ota_record[-1]
+                    if latest_turn.status is TurnStatus.AWAITING_PERMISSION:
+                        permission = interaction.get("permission") or {}
+                        results = ActionResult.model_validate(held.action_result or {"results": []})
+                        recorded_ids = {step.tool_id for step in results.results}
+                        for raw_call in permission.get("calls") or []:
+                            call = StepToolCall.model_validate(raw_call)
+                            if call.call_id not in recorded_ids:
+                                results.results.append(ActionStepResult(
+                                    tool_id=call.call_id,
+                                    tool_name=call.tool,
+                                    tool_arguments=self._tool_args(call),
+                                    tool_result=note,
+                                    success=False,
+                                    error=note,
+                                ))
+                        held.action_result = results.model_dump(mode="json")
+                        for _, instruction in approval_answers.values():
+                            if instruction:
+                                note += f"\nUser approval note: {instruction}"
+                    held.observation_result = f"{held.observation_result}\n{note}" if held.observation_result else note
+                    ota_context.transition_interaction(None)
+                    ota_context.transition_subagents(None)
+
                 projected = await self._hydrate_run_workflow(
                     ota_context.think_status,
                     context,
@@ -1181,6 +1221,11 @@ class AmphiAgent(AmphibiousAutoma[AmphiOTAContext, AmphiContext]):
                 else:
                     ota_context.transition_think(projected)
                     await self._settle_workflow_boundary(ota_context, context)
+
+                if think.get("stage") == "validate":
+                    # The retired phase has settled (or its Run is already gone).
+                    # Do not replay pending validation tools or approvals.
+                    return
 
         # Resume the parked state selected by the durable Turn status
         if latest_turn.status is TurnStatus.AWAITING_SUBAGENTS:
@@ -1240,6 +1285,10 @@ class AmphiAgent(AmphibiousAutoma[AmphiOTAContext, AmphiContext]):
         if think.get("mode") == "build":
             ota_context.transition_think(BuildStageState.model_validate(think))
         elif think.get("mode") == "run_workflow":
+            if think.get("stage") == "validate":
+                # Only restore identity here; hydration below replaces the cursor
+                # with the completion boundary projected from the pinned source.
+                think = {**think, "stage": "execute"}
             ota_context.transition_think(WorkflowStageState.model_validate(think))
 
     async def _enter_or_resume_build(self, ota_context: AmphiOTAContext, context: AmphiContext, workflow_id: Optional[str] = None) -> Optional[BuildStageState]:

--- a/src/amphi_agent/_agent.py
+++ b/src/amphi_agent/_agent.py
@@ -888,16 +888,14 @@ class AmphiAgent(AmphibiousAutoma[AmphiOTAContext, AmphiContext]):
                             "status": "pending",
                         }
                     else:
-                        source, resolved_action = await self._enter_or_resume_run_workflow(
+                        result_fields, resolved_action = await self._enter_or_resume_run_workflow(
                             ota_context,
                             context,
                             result.workflow_id,
                             result.action,
                         )
                         step.tool_result = {
-                            "workflow_id": source.workflow_id,
-                            "workflow_name": source.name,
-                            **self._workflow_sections(source),
+                            **result_fields,
                             "status": resolved_action,
                             "reason": result.reason,
                         }
@@ -1663,7 +1661,7 @@ class AmphiAgent(AmphibiousAutoma[AmphiOTAContext, AmphiContext]):
 
         if selected_action is not None:
             try:
-                source, resolved_action = await self._enter_or_resume_run_workflow(
+                result_fields, resolved_action = await self._enter_or_resume_run_workflow(
                     ota_context,
                     context,
                     selected_workflow_id,
@@ -1679,9 +1677,7 @@ class AmphiAgent(AmphibiousAutoma[AmphiOTAContext, AmphiContext]):
                     )
                 )
                 result_fields = {
-                    "workflow_id": source.workflow_id,
-                    "workflow_name": source.name,
-                    **self._workflow_sections(source),
+                    **result_fields,
                     "resolved_action": resolved_action,
                 }
             except (RuntimeError, ValueError) as exc:
@@ -2410,8 +2406,8 @@ class AmphiAgent(AmphibiousAutoma[AmphiOTAContext, AmphiContext]):
         context: AmphiContext,
         workflow_id: str,
         action: str,
-    ) -> tuple[Any, str]:
-        """Enter, resume, or atomically restart the Workspace-owned Run."""
+    ) -> tuple[Dict[str, Any], str]:
+        """Enter or resume a Run and return action fields after settling its boundary."""
         if context.session.is_child:
             raise RuntimeError("Child Sessions cannot control Workflow Runs.")
         workflows = context.workflows
@@ -2495,7 +2491,21 @@ class AmphiAgent(AmphibiousAutoma[AmphiOTAContext, AmphiContext]):
             stage=state.stage,
             step_index=state.step_index,
         ))
-        return source, resolved_action
+        # Capture source fields before terminal publication removes the active Run.
+        result_fields = {
+            "workflow_id": source.workflow_id,
+            "workflow_name": source.name,
+            **self._workflow_sections(source),
+        }
+        published = await self._settle_workflow_boundary(ota_context, context)
+        if published is not None:
+            result_fields.update({
+                "run_id": published.run_id,
+                "run_status": published.status.value,
+                "created_at": published.created_at.isoformat(),
+                "published_result_dir": str(published.result_dir.resolve()),
+            })
+        return result_fields, resolved_action
 
     @staticmethod
     async def _hydrate_run_workflow(
@@ -2659,13 +2669,22 @@ class AmphiAgent(AmphibiousAutoma[AmphiOTAContext, AmphiContext]):
                 f"Workflow Run state points outside {status.stage} sections."
             )
 
+        run = context.workflow_runs.require_run_workflow()
+        failure = run.result_dir / "failure.md"
+        outcome = (
+            WorkflowRunStatus.FAILED
+            if failure.exists() or failure.is_symlink()
+            else WorkflowRunStatus.COMPLETED
+        )
         published = await self._publish_workflow_run(
             context,
             status,
-            status=WorkflowRunStatus.COMPLETED,
+            status=outcome,
         )
         terminal_summary = (
             f"Workflow `{published.workflow_name}` completed all execution sections successfully."
+            if outcome is WorkflowRunStatus.COMPLETED
+            else f"Workflow `{published.workflow_name}` failed; its saved failure report was retained."
         )
         await self._finish_workflow_run(
             ota_context,

--- a/src/amphi_agent/_cognitive.py
+++ b/src/amphi_agent/_cognitive.py
@@ -2479,42 +2479,6 @@ class BuildThink(MainThink):
             await self.workspace_block(ota_context, context),
         ]
 
-    @staticmethod
-    def human_document_reason(name: str, body: str) -> Optional[str]:
-        """Validate heading use in a human-facing Build document."""
-        level_one: List[int] = []
-        fence: Optional[str] = None
-        annotation = re.compile(
-            r"^\s*#{1,6}\s+`?(CODE|AGENT|STABLE|VOLATILE|HUMAN|sample)`?\s*[:=]",
-            flags=re.IGNORECASE,
-        )
-        for line_number, line in enumerate(body.splitlines(), start=1):
-            stripped = line.strip()
-            marker = re.match(r"^(`{3,}|~{3,})", stripped)
-            if marker:
-                candidate = marker.group(1)
-                if fence is None:
-                    fence = candidate
-                elif candidate[0] == fence[0] and len(candidate) >= len(fence):
-                    fence = None
-                continue
-            if fence is not None:
-                continue
-            if annotation.match(line):
-                return (
-                    f"{name} line {line_number} uses a machine annotation as a Markdown "
-                    "heading; write it as a list item with an inline-code marker instead."
-                )
-            if re.match(r"^#\s+\S", stripped):
-                level_one.append(line_number)
-        if len(level_one) > 1:
-            lines = ", ".join(str(line_number) for line_number in level_one)
-            return (
-                f"{name} has multiple level-one headings on lines {lines}; keep one "
-                "document title and use ## or ### for sections."
-            )
-        return None
-
     def workflow_validation_reason(
         self,
         context: AmphiContext,
@@ -2543,14 +2507,6 @@ class ClarifyThink(BuildThink):
     allowed_tools = BuildThink.allowed_tools | {
         "request_human_task_confirm",
     }
-
-    _MERMAID_DIAGRAM_TYPES = frozenset({
-        "architecture-beta", "block-beta", "classdiagram", "erdiagram", "gantt",
-        "gitgraph", "journey", "kanban", "mindmap", "packet-beta", "pie",
-        "quadrantchart", "radar-beta", "requirementdiagram", "sankey-beta",
-        "sequencediagram", "statediagram", "statediagram-v2", "timeline",
-        "treemap-beta", "xychart-beta", "zenuml",
-    })
 
     async def assemble_messages(
         self,
@@ -2666,125 +2622,10 @@ class ClarifyThink(BuildThink):
         )
 
     def task_validation_reason(self, context: AmphiContext) -> Optional[str]:
-        """Validate the current task definition and any Mermaid diagrams it contains."""
-        def diagram_reason(source: str) -> Optional[str]:
-            lines = [
-                (number, line.strip())
-                for number, line in enumerate(source.splitlines(), start=1)
-                if line.strip() and not line.lstrip().startswith("%%")
-            ]
-            if not lines:
-                return "the diagram is empty."
-
-            header = lines[0][1]
-            kind = header.split(maxsplit=1)[0].casefold().rstrip(";")
-            flowchart = kind in {"flowchart", "graph"}
-            if flowchart:
-                if not re.fullmatch(
-                    r"(?:flowchart|graph)\s+(?:TB|TD|BT|RL|LR)\s*;?",
-                    header,
-                    re.IGNORECASE,
-                ):
-                    return "declare a valid flow direction, for example `flowchart TD`."
-            elif kind not in self._MERMAID_DIAGRAM_TYPES and not kind.startswith("c4"):
-                return f"`{header}` is not a recognized Mermaid diagram declaration."
-            if len(lines) == 1:
-                return "the diagram has a declaration but no content."
-
-            pairs = {")": "(", "]": "[", "}": "{"}
-            stack: List[Tuple[str, int]] = []
-            quoted = False
-            escaped = False
-            for line_number, line in enumerate(source.splitlines(), start=1):
-                if line.lstrip().startswith("%%"):
-                    continue
-                for character in line:
-                    if escaped:
-                        escaped = False
-                    elif character == "\\" and quoted:
-                        escaped = True
-                    elif character == '"':
-                        quoted = not quoted
-                    elif not quoted and character in "([{":
-                        stack.append((character, line_number))
-                    elif not quoted and character in pairs:
-                        if not stack or stack[-1][0] != pairs[character]:
-                            return f"line {line_number} has an unmatched `{character}`."
-                        stack.pop()
-            if quoted:
-                return "a double-quoted label is not closed."
-            if stack:
-                opener, line_number = stack[-1]
-                return f"line {line_number} has an unmatched `{opener}`."
-
-            if flowchart:
-                open_subgraphs = 0
-                edge = r"(?:<-->|<==>|-->|---|-\.->|==>|~~~|--[ox]|[ox]--[ox])"
-                for line_number, line in lines[1:]:
-                    if re.match(r"^subgraph(?:\s|$)", line, flags=re.IGNORECASE):
-                        open_subgraphs += 1
-                    elif line.casefold().rstrip(";") == "end":
-                        if open_subgraphs == 0:
-                            return f"line {line_number} has an unmatched `end`."
-                        open_subgraphs -= 1
-                    dangling = re.match(rf"^{edge}", line) or re.search(
-                        rf"{edge}(?:\|[^|]*\|)?\s*;?$",
-                        line,
-                    )
-                    if dangling:
-                        return f"line {line_number} has a connector without nodes on both sides."
-                if open_subgraphs:
-                    return "a `subgraph` block is missing its closing `end`."
-            return None
-
+        """Require a readable task definition without enforcing prose formatting."""
         package = self.build_package(context)
         body = package.read_document("task.md") if package is not None else None
-        if not body:
-            return "write task.md before requesting confirmation."
-        document_reason = self.human_document_reason("task.md", body)
-        if document_reason:
-            return document_reason
-
-        diagrams: List[Tuple[int, str]] = []
-        fence: Optional[str] = None
-        start_line = 0
-        source: List[str] = []
-
-        for line_number, line in enumerate(body.splitlines(), start=1):
-            stripped = line.strip()
-            if fence is None:
-                opening = re.fullmatch(r"(`{3,})\s*mermaid\s*", stripped, flags=re.IGNORECASE)
-                if opening:
-                    fence = opening.group(1)
-                    start_line = line_number
-                    source = []
-                elif re.match(r"`{3,}.*\bmermaid\b", stripped, flags=re.IGNORECASE):
-                    return (
-                        f"task.md line {line_number} has an invalid Mermaid fence; "
-                        "use a standalone ```mermaid opening fence."
-                    )
-                continue
-
-            if stripped == fence:
-                diagrams.append((start_line, "\n".join(source)))
-                fence = None
-                source = []
-            elif stripped.startswith(fence):
-                return (
-                    f"task.md line {line_number} has an invalid Mermaid closing fence; "
-                    f"close the block with {fence} on its own line."
-                )
-            else:
-                source.append(line)
-
-        if fence is not None:
-            return f"the Mermaid block opened at task.md line {start_line} is not closed."
-
-        for index, (line_number, diagram) in enumerate(diagrams, start=1):
-            reason = diagram_reason(diagram)
-            if reason:
-                return f"Mermaid diagram {index} at task.md line {line_number}: {reason}"
-        return None
+        return None if body else "write task.md before requesting confirmation."
 
 
 class ExploreThink(BuildThink):
@@ -2890,8 +2731,7 @@ class ExploreThink(BuildThink):
         package = self.build_package(context)
         body = package.read_document("explore.md") if package is not None else None
         if body:
-            reason = self.human_document_reason("explore.md", body)
-            return f"switch rejected: {reason}" if reason else None
+            return None
         return (
             "switch rejected: write explore.md before handing off to "
             "generate; it is the operation sequence generate builds from. Create "
@@ -3081,23 +2921,29 @@ class VerifyThink(BuildThink):
                 "and the overall verification verdict before calling "
                 "request_human_workflow_confirm."
             )
-        document_reason = self.human_document_reason("verify.md", body)
-        if document_reason:
-            return f"confirm rejected: {document_reason}"
 
         def overall_verdict() -> Optional[str]:
-            """Read a localized overall-verdict section at the document tail."""
-            lines = [line.strip() for line in body.splitlines() if line.strip()]
-            if len(lines) < 2 or not re.fullmatch(r"##\s+\S.*", lines[-2]):
-                return None
-            return lines[-1].upper()
+            """Read the last explicit verdict outside code blocks, allowing later notes."""
+            verdict = None
+            fence = None
+            for line in body.splitlines():
+                stripped = line.strip()
+                marker = re.match(r"^(`{3,}|~{3,})", stripped)
+                if marker:
+                    candidate = marker.group(1)
+                    if fence is None:
+                        fence = candidate
+                    elif candidate[0] == fence[0] and len(candidate) >= len(fence):
+                        fence = None
+                    continue
+                if fence is None and stripped.upper() in {"PASS", "FAIL"}:
+                    verdict = stripped.upper()
+            return verdict
 
         if overall_verdict() != "PASS":
             return (
-                "confirm rejected: verify.md must end with a level-two heading meaning "
-                "Overall verdict in the document language, followed by `PASS`. Do not "
-                "mark PASS while safely testable behavior failed, Verify changed actual "
-                "external state, or a safety limitation was hidden."
+                "confirm rejected: verify.md must contain an explicit overall `PASS` verdict. "
+                "Do not mark PASS while safely testable behavior failed or a safety limitation was hidden."
             )
         reason = self.workflow_validation_reason(context)
         return f"confirm rejected: {reason}" if reason else None

--- a/src/amphi_agent/_workflows.py
+++ b/src/amphi_agent/_workflows.py
@@ -11,7 +11,7 @@ from typing import AsyncIterator, ClassVar, Dict, Iterator, Optional, Tuple
 
 import yaml
 from markdown_it import MarkdownIt
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from yaml.constructor import ConstructorError
 from yaml.nodes import MappingNode
 from yaml.tokens import AliasToken, AnchorToken
@@ -30,20 +30,10 @@ WORKFLOWS_ROOT_ENV_VAR = "BRIDGIC_AGENT_WORKFLOWS_ROOT"
 class _WorkflowMetadata(BaseModel):
     """Validated ``WORKFLOW.md`` frontmatter used by the Build pipeline."""
 
-    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+    model_config = ConfigDict(extra="ignore", str_strip_whitespace=True)
 
-    name: str = Field(
-        min_length=1,
-        max_length=100,
-        pattern=r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$",
-    )
-    description: str = Field(min_length=1, max_length=500)
-
-    @model_validator(mode="after")
-    def validate_description(self) -> "_WorkflowMetadata":
-        if "\n" in self.description or "\r" in self.description:
-            raise ValueError("`description` must fit on one line")
-        return self
+    name: str = Field(min_length=1)
+    description: str = Field(min_length=1)
 
 
 @dataclass(frozen=True)
@@ -89,9 +79,6 @@ class WorkflowPackage:
     SCRIPT_PATH_RE: ClassVar[re.Pattern[str]] = re.compile(
         r"(?<![\w.-])((?:(?:[A-Za-z]:)?[/\\])?"
         r"(?:[\w.-]+[/\\])*scripts[/\\][\w./\\-]+\.py)\b"
-    )
-    GENERIC_HEADING_RE: ClassVar[re.Pattern[str]] = re.compile(
-        r"Section\s+\d+", flags=re.IGNORECASE,
     )
     MAX_FRONTMATTER_BYTES: ClassVar[int] = 64 * 1024
     _MARKDOWN: ClassVar[MarkdownIt] = MarkdownIt("commonmark")
@@ -290,11 +277,6 @@ class WorkflowPackage:
         for index, (_, instruction_start, title) in enumerate(headings, start=1):
             if not title:
                 raise ValueError(f"contains an empty level-one {kind.replace(' ', '-')} heading")
-            if cls.GENERIC_HEADING_RE.fullmatch(title):
-                raise ValueError(
-                    f"heading `# {title}` is generic; describe what that {kind} "
-                    "does in the Build language"
-                )
             instruction_end = headings[index][0] if index < len(headings) else len(lines)
             instruction = "\n".join(lines[instruction_start:instruction_end]).strip()
             if not instruction:
@@ -322,12 +304,6 @@ class WorkflowPackage:
                 root_path = Path(root)
                 for name in sorted(dirs):
                     path = root_path / name
-                    if name in {".venv", "node_modules"}:
-                        rel = path.relative_to(self.source_root).as_posix()
-                        return (
-                            f"workflow/{rel} is a local dependency environment; "
-                            "Workflow source must use the app-level shared runtime bases."
-                        )
                     if path.is_symlink():
                         rel = path.relative_to(self.source_root).as_posix()
                         return f"workflow/{rel} is a symbolic link; workflow artifacts cannot contain links."
@@ -342,40 +318,6 @@ class WorkflowPackage:
                         return f"workflow/{rel} is a symbolic link; workflow artifacts cannot contain links."
                     if not stat.S_ISREG(mode):
                         return f"workflow/{rel} is not a regular file."
-            return None
-
-        def script_reference_rejection(reference: str, scripts_dir: Path, document_name: str) -> Optional[str]:
-            if "\\" in reference or reference.startswith("/"):
-                return f"`{reference}` is an invalid script path; use a relative `scripts/...py` path."
-            if reference.startswith(".build/workflow/scripts/"):
-                replacement = reference.removeprefix(".build/workflow/")
-                return (
-                    f"`{reference}` references the temporary Build workspace. Paths inside "
-                    f"{document_name} are relative to `workflow/`; replace it with `{replacement}`. "
-                    "Do not move or copy the on-disk script."
-                )
-            if reference.startswith("workflow/scripts/"):
-                replacement = reference.removeprefix("workflow/")
-                return (
-                    f"`{reference}` includes the workflow directory itself. Paths inside "
-                    f"{document_name} are relative to `workflow/`; replace it with `{replacement}`. "
-                    "Do not move or copy the on-disk script."
-                )
-            parts = reference.split("/")
-            if (
-                len(parts) < 2
-                or parts[0] != "scripts"
-                or any(part in {"", ".", ".."} for part in parts)
-            ):
-                return (
-                    f"`{reference}` is an invalid script path; it must stay under "
-                    "`workflow/scripts/` and cannot contain `.` or `..`."
-                )
-            candidate = scripts_dir.parent.joinpath(*parts)
-            try:
-                candidate.resolve(strict=False).relative_to(scripts_dir.resolve(strict=False))
-            except ValueError:
-                return f"`{reference}` escapes `workflow/scripts/`."
             return None
 
         def read_required_document(name: str) -> Tuple[Optional[str], Optional[str]]:
@@ -405,72 +347,48 @@ class WorkflowPackage:
 
         workflow_body = "\n".join(content.splitlines()[closing + 1 :])
         try:
-            self._parse_steps(workflow_body, "execution step")
+            steps = self._parse_steps(workflow_body, "execution step")
         except ValueError as exc:
             return f"workflow/{self.ENTRY_NAME} {exc}."
 
-        documents = [(self.ENTRY_NAME, workflow_body, closing + 2)]
-        references: set[str] = set()
-        reference_sources: dict[str, str] = {}
-        scripts_dir = self.scripts_dir
-        if scripts_dir.exists() and not scripts_dir.is_dir():
-            return "workflow/scripts must be a directory when present."
-
-        on_disk = set()
-        if scripts_dir.is_dir():
-            for root, _, files in os.walk(scripts_dir, followlinks=False):
-                root_path = Path(root)
-                for filename in files:
-                    path = root_path / filename
-                    if path.suffix == ".py":
-                        on_disk.add(f"scripts/{path.relative_to(scripts_dir).as_posix()}")
-
-        for document_name, body, body_start_line in documents:
-            invalid_references = []
-            for match in self.SCRIPT_PATH_RE.finditer(body):
-                reference = match.group(1)
-                references.add(reference)
-                reference_sources.setdefault(reference, document_name)
-                path_reason = script_reference_rejection(reference, scripts_dir, document_name)
-                if path_reason:
-                    line_number = body_start_line + body.count("\n", 0, match.start())
-                    invalid_references.append(
-                        f"- workflow/{document_name} line {line_number}: {path_reason}"
-                    )
-            if invalid_references:
-                count = len(invalid_references)
-                noun = "reference" if count == 1 else "references"
-                return (
-                    f"workflow/{document_name} contains {count} invalid script {noun}:\n"
-                    + "\n".join(invalid_references)
-                )
-
+        # Only executable instructions declare required scripts. Extra package
+        # files and unused documents do not add validation requirements.
+        references = {
+            match.group(1)
+            for step in steps
+            for match in self.SCRIPT_PATH_RE.finditer(step.instruction)
+        }
         for reference in sorted(references):
-            script_path = self.source_root.joinpath(*reference.split("/"))
+            relative = reference.replace("\\", "/")
+            if relative.startswith("/") or re.match(r"^[A-Za-z]:", relative):
+                return f"`{reference}` is an absolute script path; references must stay inside workflow/."
+            while relative.startswith("./"):
+                relative = relative[2:]
+            for prefix in (".build/workflow/", "workflow/"):
+                if relative.startswith(prefix):
+                    relative = relative.removeprefix(prefix)
+                    break
+            script_path = self.source_root.joinpath(*relative.split("/"))
+            try:
+                script_path.resolve().relative_to(self.source_root.resolve())
+            except ValueError:
+                return f"`{reference}` escapes workflow/."
             if not script_path.is_file():
-                document_name = reference_sources[reference]
                 return (
-                    f"workflow/{document_name} references `{reference}`, but that file does "
-                    "not exist under workflow/scripts/."
+                    f"workflow/{self.ENTRY_NAME} references `{reference}`, but that file does "
+                    "not exist in the workflow package."
                 )
             try:
                 source = script_path.read_text(encoding="utf-8")
             except (OSError, UnicodeError) as exc:
-                return f"workflow/{reference} cannot be read as UTF-8: {exc}."
+                return f"`{reference}` cannot be read as UTF-8: {exc}."
             try:
                 compile(source, reference, "exec")
             except SyntaxError as exc:
                 return (
-                    f"workflow/{reference} has a syntax error "
+                    f"`{reference}` has a syntax error "
                     f"(line {exc.lineno}: {exc.msg})."
                 )
-
-        orphaned = sorted(on_disk - references)
-        if orphaned:
-            return (
-                f"workflow/{orphaned[0]} exists but is not referenced by any "
-                "step in WORKFLOW.md."
-            )
         return None
 
 

--- a/src/amphi_agent/_workspace.py
+++ b/src/amphi_agent/_workspace.py
@@ -1126,6 +1126,17 @@ class RunWorkflowSpace:
             payload = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, UnicodeError, json.JSONDecodeError) as exc:
             raise ValueError("Run state is invalid JSON") from exc
+        if isinstance(payload, dict) and payload.get("stage") == "validate":
+            from ._workflows import WorkflowPackage
+
+            # The retired validation phase began only after every execution step
+            # succeeded. Its index belongs to a different section list, so it
+            # must never become an execution index. Keep discovery read-only.
+            state = cls._validated_state({**payload, "stage": "execute"})
+            source = WorkflowPackage(path.parent / "source")
+            if not source.is_available:
+                raise ValueError("Legacy Run Workflow source is unavailable")
+            return state.model_copy(update={"step_index": len(source.execution_steps)})
         return cls._validated_state(payload)
 
     @staticmethod

--- a/src/amphi_service/handler/_workflows_handler.py
+++ b/src/amphi_service/handler/_workflows_handler.py
@@ -36,7 +36,6 @@ class WorkflowDirectoryStore:
     ARCHIVE_MEDIA_TYPE = "application/vnd.bridgic.workflow+zip"
     ARCHIVE_MANIFEST = "manifest.json"
     SUPPORTED_ARCHIVE_FORMAT_VERSIONS = frozenset({1, 2})
-    LEGACY_RUNTIME_DIR_NAME = ".runtime"
     MAX_ARCHIVE_BYTES = 32 * 1024 * 1024
     MAX_ARCHIVE_FILE_BYTES = 16 * 1024 * 1024
     MAX_ARCHIVE_CONTENT_BYTES = 64 * 1024 * 1024
@@ -84,9 +83,15 @@ class WorkflowDirectoryStore:
                 relative = PurePosixPath(file.path)
                 if "__pycache__" in relative.parts or relative.suffix in {".pyc", ".pyo"}:
                     continue
-                archive.writestr(f"{cls.SOURCE_DIR_NAME}/{relative.as_posix()}", file.content)
+                archive.writestr(
+                    f"{cls.SOURCE_DIR_NAME}/{relative.as_posix()}",
+                    package.source_root.joinpath(*relative.parts).read_bytes(),
+                )
             if program.readme is not None:
-                archive.writestr(f"{cls.SOURCE_DIR_NAME}/{cls.README_NAME}", program.readme)
+                archive.writestr(
+                    f"{cls.SOURCE_DIR_NAME}/{cls.README_NAME}",
+                    (package.source_root / cls.README_NAME).read_bytes(),
+                )
         content = output.getvalue()
         if len(content) > cls.MAX_ARCHIVE_BYTES:
             raise ValueError("Workflow archive exceeds 32 MiB")
@@ -137,17 +142,11 @@ class WorkflowDirectoryStore:
                     mode = (info.external_attr >> 16) & 0xFFFF
                     if stat_module.S_ISLNK(mode) or info.flag_bits & 0x1:
                         raise ValueError(f"Workflow archive contains unsupported file: {normalized}")
-                    ignored_legacy_runtime_entry = (
-                        relative.parts[0] == cls.LEGACY_RUNTIME_DIR_NAME
-                    )
-                    allowed = (
+                    package_entry = (
                         normalized == cls.ARCHIVE_MANIFEST
                         or normalized in cls.DOCUMENT_NAMES
                         or relative.parts[0] == cls.SOURCE_DIR_NAME
-                        or ignored_legacy_runtime_entry
                     )
-                    if not allowed:
-                        raise ValueError(f"Workflow archive contains unsupported path: {normalized}")
                     if info.is_dir():
                         continue
                     if info.file_size > cls.MAX_ARCHIVE_FILE_BYTES:
@@ -156,7 +155,7 @@ class WorkflowDirectoryStore:
                     if total_size > cls.MAX_ARCHIVE_CONTENT_BYTES:
                         raise ValueError("Workflow archive expands beyond 64 MiB")
                     data = archive.read(info)
-                    if ignored_legacy_runtime_entry:
+                    if not package_entry:
                         continue
                     target = temporary.joinpath(*relative.parts)
                     target.parent.mkdir(parents=True, exist_ok=True)
@@ -176,11 +175,11 @@ class WorkflowDirectoryStore:
             ):
                 raise ValueError("Workflow archive format is not supported")
             name = manifest.get("name")
-            if not isinstance(name, str) or not name.strip() or len(name.strip()) > 200:
+            if not isinstance(name, str) or not name.strip():
                 raise ValueError("Workflow archive has an invalid name")
-            for key, limit in (("description", 500), ("domain", 100)):
+            for key in ("description", "domain"):
                 value = manifest.get(key)
-                if value is not None and (not isinstance(value, str) or len(value) > limit):
+                if value is not None and not isinstance(value, str):
                     raise ValueError(f"Workflow archive has an invalid {key}")
             manifest["name"] = name.strip()
 

--- a/tests/agent/cognitive/test_build_gates.py
+++ b/tests/agent/cognitive/test_build_gates.py
@@ -17,7 +17,7 @@ async def test_build_gates(test_sandbox: IsolatedPaths) -> None:
     {
       "clarify": {
         "missing_task": "blocked",
-        "malformed_diagram": "blocked",
+        "malformed_optional_diagram": "allowed",
         "reviewed_task": "confirmable"
       },
       "explore": {"missing_plan": "blocked", "written_plan": "generate_allowed"},
@@ -26,10 +26,10 @@ async def test_build_gates(test_sandbox: IsolatedPaths) -> None:
     }
 
     Checks:
-    1. Clarify requires a structurally valid task before confirmation.
+    1. Clarify requires a readable task before confirmation without policing optional diagrams.
     2. Explore hands off only after a valid implementation plan exists.
     3. Generate hands off only after the Workflow package is executable and validatable.
-    4. Verify requests final confirmation only after a valid report ends in PASS.
+    4. Verify requires an explicit PASS verdict and allows additional notes afterward.
     """
     workspace = make_workspace(test_sandbox, "build-gates")
     build = await workspace.prepare_build_space("create", stage="clarify")
@@ -61,9 +61,7 @@ Input -->
 ```
 """,
     )
-    assert "connector without nodes" in (
-        await clarify.legality_check(confirm_task, None, context) or ""
-    )
+    assert await clarify.legality_check(confirm_task, None, context) is None
     write(
         "task.md",
         """# Report workflow
@@ -100,6 +98,9 @@ A report containing the requested summary.
 
 ## Steps
 Read the input, create the report, and validate its contents.
+
+# Extra notes
+Additional headings and content are allowed.
 """,
     )
     assert await explore.legality_check(generate, None, context) is None
@@ -111,6 +112,10 @@ Read the input, create the report, and validate its contents.
         await generate_worker.legality_check(verify, None, context) or ""
     )
     write_workflow_source(build.root)
+    source = build.root / "workflow"
+    (source / "scripts").mkdir()
+    (source / "scripts" / "unused.py").write_text("def obsolete(:\n", encoding="utf-8")
+    (source / "VALIDATE.md").write_bytes(b"Unused scripts/missing.py\n\xff")
     assert await generate_worker.legality_check(verify, None, context) is None
 
     # Check 4: Verify requests final confirmation only after a valid report ends in PASS.
@@ -129,7 +134,7 @@ The isolated checks completed, but one Workflow check failed.
 FAIL
 """,
     )
-    assert "followed by `PASS`" in (
+    assert "explicit overall `PASS`" in (
         await verify_worker.legality_check(confirm_workflow, None, context) or ""
     )
     write(
@@ -140,6 +145,13 @@ The isolated checks completed successfully.
 
 ## Overall verdict
 PASS
+
+# Additional details
+These notes must not invalidate a successful verdict.
+
+```text
+FAIL
+```
 """,
     )
     assert await verify_worker.legality_check(confirm_workflow, None, context) is None

--- a/tests/agent/core/test_orchestration.py
+++ b/tests/agent/core/test_orchestration.py
@@ -199,6 +199,98 @@ async def _start_run(harness: _Harness, workflow_id: str, request: str) -> Amphi
     return ota_context
 
 
+def _add_legacy_validation(root: Path) -> None:
+    source = root / "workflow"
+    scripts = source / "scripts"
+    scripts.mkdir(exist_ok=True)
+    (scripts / "validate_htmls.py").write_text("def obsolete(:\n", encoding="utf-8")
+    (source / "VALIDATE.md").write_text(
+        "# Old instructions\n\nRun `python scripts/missing_legacy_check.py`.\n", encoding="utf-8",
+    )
+
+
+async def test_legacy_workflow_edit_and_start(orchestration: _Harness) -> None:
+    """A saved legacy package can enter Build and Run with its original source intact."""
+    saved = await _save_workflow(orchestration, "legacy-source")
+    _add_legacy_validation(saved.root)
+    original = {
+        path.relative_to(saved.root): path.read_bytes()
+        for path in saved.root.rglob("*") if path.is_file()
+    }
+    assert await orchestration.workflows.prepare_edit(saved.workflow_id) == saved
+    edit = _ota("Edit the report", _step("edit_workflow", EditWorkflow(saved.workflow_id)))
+    await _apply(orchestration, edit)
+    assert edit.think_status == BuildStageState(stage="clarify", workflow_id=saved.workflow_id)
+    restored = orchestration.workflows.require_package()
+    for relative, content in original.items():
+        assert (restored.root / relative).read_bytes() == content
+    await orchestration.workspace.discard_build()
+    orchestration.workflows.close_package()
+
+    started = await _start_run(orchestration, saved.workflow_id, "Create today's report")
+    assert isinstance(started.think_status, WorkflowStageState)
+    assert (started.think_status.stage, started.think_status.step_index) == ("execute", 0)
+    pinned = orchestration.workflows.require_package()
+    assert [step.title for step in pinned.execution_steps] == ["Create report"]
+    for relative, content in original.items():
+        assert (pinned.root / relative).read_bytes() == content
+        assert (saved.root / relative).read_bytes() == content
+
+
+@pytest.mark.parametrize("turn_status", [TurnStatus.COMPLETED, TurnStatus.CANCELLED, TurnStatus.AWAITING_HUMAN, TurnStatus.AWAITING_PERMISSION])
+@pytest.mark.parametrize("failed", [False, True])
+async def test_resume_legacy_validation(orchestration: _Harness, monkeypatch: pytest.MonkeyPatch, turn_status: TurnStatus, failed: bool) -> None:
+    """Settle retired validation from pinned results without replaying execution or held tools."""
+    def reject_replay(*args, **kwargs):
+        raise AssertionError("Legacy validation must not replay tools or step reports")
+
+    saved = await _save_workflow(orchestration, "legacy-resume")
+    _add_legacy_validation(saved.root)
+    started = await _start_run(orchestration, saved.workflow_id, "Create today's report")
+    active = orchestration.workflow_runs.require_run_workflow()
+    (active.result_dir / "report.txt").write_text("Already produced\n", encoding="utf-8")
+    (active.background_work_dir / "inputs.txt").write_text("Original inputs\n", encoding="utf-8")
+    if failed:
+        (active.result_dir / "failure.md").write_text("# Failure\n\nLegacy check failed.\n", encoding="utf-8")
+    state_path = active.root / ".state.json"
+    raw_state = json.loads(state_path.read_text(encoding="utf-8"))
+    raw_state.update(stage="validate", step_index=3)
+    state_path.write_text(json.dumps(raw_state), encoding="utf-8")
+    legacy_turn = _turn(started, "turn-legacy-validation", turn_status)
+    legacy_turn.agent_state["think"].update(stage="validate", step_index=3)
+    # The mutable library source must not determine the retained Run's boundary.
+    saved.entry_path.write_text(
+        saved.entry_path.read_text(encoding="utf-8") + "\n# New section\n\nNew instructions.\n",
+        encoding="utf-8",
+    )
+    orchestration.workspace.close_run_workflow_space()
+    orchestration.workflow_runs.close_run_workflow()
+    orchestration.workflows.close_package()
+    orchestration.context.session = Session(orchestration.record, [legacy_turn])
+    monkeypatch.setattr(AmphiAgent, "_resume_permission", reject_replay)
+    monkeypatch.setattr(WorkflowRunLibrary, "record_step", reject_replay)
+
+    resumed = AmphiOTAContext(user_input="Continue the report")
+    await orchestration.agent.init_state(resumed, orchestration.context)
+    assert resumed.think_status == NormalStageState()
+    assert not orchestration.workspace.has_run_workflow
+    result = resumed.ota_record[-1].workflow_result
+    published = orchestration.workflow_runs.get(result["run_id"])
+    assert published is not None
+    assert published.status is (WorkflowRunStatus.FAILED if failed else WorkflowRunStatus.COMPLETED)
+    assert published.read_file("result/report.txt") == "Already produced\n"
+    assert published.read_file("background/work/inputs.txt") == "Original inputs\n"
+    if failed:
+        assert published.read_file("result/failure.md") == "# Failure\n\nLegacy check failed.\n"
+
+    # Rehydrating stale legacy cognition after publication must not restart the Run.
+    resumed_again = AmphiOTAContext(user_input="Continue the report")
+    await orchestration.agent.init_state(resumed_again, orchestration.context)
+    assert resumed_again.think_status == NormalStageState()
+    assert not orchestration.workspace.has_run_workflow
+    assert not any(getattr(record, "workflow_result", None) for record in resumed_again.ota_record)
+
+
 async def test_build_entry(orchestration: _Harness) -> None:
     """Final Build routing:
 

--- a/tests/agent/core/test_orchestration.py
+++ b/tests/agent/core/test_orchestration.py
@@ -1,3 +1,4 @@
+import json
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from pathlib import Path
@@ -670,6 +671,114 @@ async def test_run_entry(orchestration: _Harness) -> None:
     assert (restarted_checkpoint.stage, restarted_checkpoint.step_index) == ("execute", 0)
     assert restarted_checkpoint.workflow_input.text == "Create today's report"
     assert not partial.exists()
+
+
+@pytest.mark.parametrize("entry", ["tool", "choice"])
+@pytest.mark.parametrize("stage,step_index,expected_status", [
+    pytest.param("execute", 1, None, id="unfinished"),
+    pytest.param("execute", 2, WorkflowRunStatus.COMPLETED, id="execution-complete"),
+    pytest.param("validate", 7, WorkflowRunStatus.COMPLETED, id="legacy-complete"),
+    pytest.param("validate", 7, WorkflowRunStatus.FAILED, id="legacy-failed"),
+])
+async def test_manual_run_resume(
+    orchestration: _Harness,
+    monkeypatch: pytest.MonkeyPatch,
+    entry: str,
+    stage: str,
+    step_index: int,
+    expected_status: WorkflowRunStatus | None,
+) -> None:
+    """Resume unfinished steps or publish terminal results through either manual entry."""
+    def reject_replay(*args, **kwargs):
+        raise AssertionError("Resuming a Run must not replay step reports")
+
+    saved = await _save_workflow(orchestration, "manual-resume")
+    saved.entry_path.write_text(
+        saved.entry_path.read_text(encoding="utf-8") + "\n# Deliver report\n\nDeliver the report.\n",
+        encoding="utf-8",
+    )
+    started = await _start_run(orchestration, saved.workflow_id, "Create today's report")
+    active = orchestration.workflow_runs.require_run_workflow()
+    (active.result_dir / "report.txt").write_text("Retained report\n", encoding="utf-8")
+    (active.background_work_dir / "inputs.txt").write_text("Retained inputs\n", encoding="utf-8")
+    if expected_status is WorkflowRunStatus.FAILED:
+        (active.result_dir / "failure.md").write_text("Recorded failure\n", encoding="utf-8")
+    state_path = active.root / ".state.json"
+    raw_state = json.loads(state_path.read_text(encoding="utf-8"))
+    raw_state.update(stage=stage, step_index=step_index)
+    state_path.write_text(json.dumps(raw_state), encoding="utf-8")
+    original_checkpoint = state_path.read_bytes()
+
+    # The saved Run remains on disk after the user has returned to normal chat.
+    orchestration.agent._close_run_workflow_bindings(orchestration.context)
+    paused = AmphiOTAContext(user_input="Pause the workflow and return to normal chat")
+    orchestration.context.session = Session(orchestration.record, [
+        _turn(paused, "turn-paused-run", TurnStatus.COMPLETED),
+    ])
+    monkeypatch.setattr(WorkflowRunLibrary, "record_step", reject_replay)
+
+    request = _ota(
+        "Continue the report",
+        _step("request_run_workflow", RequestRunWorkflow(
+            saved.workflow_id, "ask" if entry == "choice" else "resume",
+        )),
+    )
+    await orchestration.agent.init_state(request, orchestration.context)
+    assert request.think_status == NormalStageState()
+    await _apply(orchestration, request)
+    if entry == "choice":
+        choice = request.interaction_status
+        assert isinstance(choice, AwaitingWorkflowRunChoice)
+        orchestration.context.session = Session(orchestration.record, [
+            *orchestration.context.session.get_all(),
+            _pending(request, "turn-resume-choice"),
+        ])
+        resumed = AmphiOTAContext(user_input={
+            "type": "choice_answer",
+            "request_id": choice.request_id,
+            "answers": [{"index": 0, "option_id": "resume"}],
+        })
+        await orchestration.agent.init_state(resumed, orchestration.context)
+    else:
+        resumed = request
+
+    payload = _payload(resumed, "request_run_workflow")
+    assert payload["execution_steps"] == ["Create report", "Deliver report"]
+    assert payload["status"] == ("resolved" if entry == "choice" else "resumed")
+    assert resumed.interaction_status is None
+    if expected_status is None:
+        assert resumed.think_status == started.think_status.model_copy(update={"step_index": 1})
+        assert state_path.read_bytes() == original_checkpoint
+        assert (active.result_dir / "report.txt").read_text(encoding="utf-8") == "Retained report\n"
+        assert "run_id" not in payload
+        assert not any(getattr(record, "workflow_result", None) for record in resumed.ota_record)
+        return
+
+    assert resumed.think_status == NormalStageState()
+    assert not active.root.exists()
+    assert orchestration.workspace.run_workflow is None
+    assert orchestration.workflow_runs.run_workflow is None
+    assert orchestration.workflows.package is None
+    published = orchestration.workflow_runs.get(payload["run_id"])
+    assert published is not None
+    assert payload["run_status"] == published.status.value == expected_status.value
+    assert published.read_file("result/report.txt") == "Retained report\n"
+    assert published.read_file("background/work/inputs.txt") == "Retained inputs\n"
+    if expected_status is WorkflowRunStatus.FAILED:
+        assert published.read_file("result/failure.md") == "Recorded failure\n"
+    result = resumed.ota_record[-1].workflow_result
+    assert result["run_id"] == published.run_id
+
+    # A subsequent turn must not publish the completed Run again.
+    orchestration.context.session = Session(orchestration.record, [
+        *orchestration.context.session.get_all(),
+        _turn(resumed, "turn-resumed-run", TurnStatus.COMPLETED),
+    ])
+    resumed_again = AmphiOTAContext(user_input="Continue")
+    await orchestration.agent.init_state(resumed_again, orchestration.context)
+    assert resumed_again.think_status == NormalStageState()
+    assert not orchestration.workspace.has_run_workflow
+    assert not any(getattr(record, "workflow_result", None) for record in resumed_again.ota_record)
 
 
 async def test_run_completion(orchestration: _Harness) -> None:

--- a/tests/agent/invocation/test_interactions.py
+++ b/tests/agent/invocation/test_interactions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import sys
 from collections.abc import AsyncIterator
@@ -10,6 +11,7 @@ from typing import Any
 
 import pytest
 
+from src.amphi_agent._agent import AmphiAgent
 from src.amphi_agent._invocation import (
     AgentInvocation,
     InvocationDisposition,
@@ -24,6 +26,7 @@ from src.amphi_agent._state import (
     AwaitingWorkflowConfirm,
     AwaitingWorkflowRunChoice,
     BuildStageState,
+    SubAgentsCompleted,
 )
 from src.amphi_agent._workflow_run import WorkflowRunLibrary
 from src.amphi_agent._workflows import WorkflowLibrary
@@ -443,3 +446,205 @@ async def test_run_choice(interactions: _Harness) -> None:
     checkpoint = workspace.run_workflow_checkpoint()
     assert checkpoint is not None
     assert checkpoint.generation == "retained-generation"
+
+
+@pytest.mark.parametrize("answer_type", ["permission_answer", "choice_answer", "chat", "subagents"])
+@pytest.mark.parametrize("run_state", ["completed", "failed", "gone", "publication_error"])
+async def test_resume_retired_validation_turn(
+    interactions: _Harness,
+    agent_model: str,
+    monkeypatch: pytest.MonkeyPatch,
+    answer_type: str,
+    run_state: str,
+) -> None:
+    """Resume an old approval on the original Turn without replaying validation tools."""
+    async def reject_tool_replay(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("Retired validation tools must not execute")
+
+    async def fail_publication(*args: Any, **kwargs: Any) -> None:
+        raise OSError("Publication unavailable")
+
+    record = await interactions.create_session("retired-validation")
+    interactions.llm.enqueue_text("Earlier answer.")
+    await interactions.run(record.id, "Earlier request.")
+    previous = await interactions.turns.latest(record.id, USER_ID)
+    assert previous is not None
+
+    workspace = await interactions.workspace(record)
+    source = interactions.paths.root / "legacy-source"
+    _write_package(source)
+    workflows = await WorkflowLibrary(USER_ID).load()
+    saved = await workflows.materialize_workflow(
+        source,
+        workflow_id=None,
+        source_session_id=record.id,
+        source_turn_id="legacy-build",
+        name="Legacy report",
+        description="Create a report",
+    )
+    workflow_runs = await WorkflowRunLibrary(USER_ID).load()
+    original = UserInput(
+        text="Create the original report.",
+        blocks=[{"type": "text", "value": "Create the original report."}],
+    )
+    initial_state = RunWorkflowState(
+        workflow_id=saved.workflow_id,
+        generation="legacy-generation",
+        workflow_name=saved.name,
+        workflow_input=original,
+    )
+
+    def populate(root: Path) -> None:
+        workflow_runs.populate_run_workflow(root, saved.root)
+
+    active = await workspace.prepare_run_workflow_space("create", initial_state=initial_state, populate=populate)
+    (active.root / "result" / "report.txt").write_text("Original report\n", encoding="utf-8")
+    if run_state == "failed":
+        (active.root / "result" / "failure.md").write_text("Legacy failure\n", encoding="utf-8")
+    raw_state = json.loads((active.root / ".state.json").read_text(encoding="utf-8"))
+    raw_state.update(stage="validate", step_index=3)
+    (active.root / ".state.json").write_text(json.dumps(raw_state), encoding="utf-8")
+    if run_state == "gone":
+        await workspace.discard_run_workflow(expected_generation=initial_state.generation)
+    workspace.close_run_workflow_space()
+
+    prior_round = {"observation_result": "The original report was created."}
+    questions = [{"question": "Run the final validation?", "options": [{"id": "yes", "label": "Yes"}]}]
+    permission = answer_type == "permission_answer"
+    tool = "bash" if permission else "request_human_choice"
+    arguments = {"command": "legacy-validation"} if permission else {"questions": questions}
+    if answer_type == "subagents":
+        tool = "run_subagent"
+        arguments = {"goal": "Check the existing report."}
+    call = {
+        "call_id": "legacy-pending-tool",
+        "tool": tool,
+        "tool_arguments": [{"name": name, "value": value} for name, value in arguments.items()],
+    }
+    held_round = {
+        "think_result": {"step_content": "Validate the finished report.", "tool_calls": [call]},
+        "action_result": None if permission else {"results": [{
+            "tool_id": call["call_id"],
+            "tool_name": tool,
+            "tool_arguments": arguments,
+            "tool_result": questions,
+            "success": True,
+        }]},
+    }
+    interaction = {"request_id": "legacy-request"}
+    if permission:
+        interaction["permission"] = {"calls": [call], "verdicts": ["ask"], "items": [{"call_index": 0}]}
+    else:
+        interaction["questions"] = questions
+    state = {
+        "think": {
+            "mode": "run_workflow",
+            "stage": "validate",
+            "workflow_id": saved.workflow_id,
+            "generation": initial_state.generation,
+            "step_index": 3,
+        },
+        "interaction": interaction,
+    }
+    status = TurnStatus.AWAITING_PERMISSION if permission else TurnStatus.AWAITING_HUMAN
+    if answer_type == "subagents":
+        status = TurnStatus.AWAITING_SUBAGENTS
+        state["interaction"] = None
+        state["subagents"] = {"calls": [{
+            "tool_call_id": call["call_id"], "goal": arguments["goal"], "session_id": "finished-child",
+        }]}
+        held_round["action_result"]["results"][0]["tool_result"] = "Waiting for the child."
+    pending = await interactions.turns.append_result(
+        USER_ID,
+        session_id=record.id,
+        expected_tail_id=previous.id,
+        user_input=original,
+        ota_records=[prior_round, held_round],
+        agent_state=state,
+        browser_tool_loaded=False,
+        workspace_tools_loaded=False,
+        skills_tool_loaded=False,
+        status=status,
+        final_answer=None,
+        error=None,
+        context_usage={"model_id": agent_model, "input_tokens": 100, "output_tokens": 20},
+        model=agent_model,
+        execution_mode="auto",
+        max_rounds=8,
+        duration_ms=1234,
+    )
+    reply = {"type": answer_type, "request_id": "legacy-request"}
+    if permission:
+        reply["answers"] = [{"call_index": 0, "decision": "allow", "instruction": "Keep the original report unchanged."}]
+    elif answer_type == "choice_answer":
+        reply["answers"] = [{"index": 0, "option_id": "yes"}]
+    elif answer_type == "subagents":
+        reply = SubAgentsCompleted.model_validate({"results": [{
+            "tool_call_id": call["call_id"], "status": "completed", "answer": "The child finished checking.",
+        }]})
+    else:
+        reply["input"] = "Continue with the existing report."
+    monkeypatch.setattr(AmphiAgent, "action_tool_call", reject_tool_replay)
+    if run_state == "publication_error":
+        monkeypatch.setattr(WorkflowRunLibrary, "publish_run_workflow", fail_publication)
+        with pytest.raises(OSError, match="Publication unavailable"):
+            await interactions.run(record.id, reply)
+    else:
+        interactions.llm.enqueue_text("The report is ready.", input_tokens=10, output_tokens=2)
+        resumed = await interactions.run(record.id, reply)
+        assert resumed.outcome.disposition is InvocationDisposition.COMPLETED
+        assert resumed.interaction is None
+
+    turns = await interactions.turns.list_conversation(USER_ID, record.id)
+    assert len(turns) == 2
+    assert turns[0].id == previous.id
+    completed = turns[-1]
+    assert completed.id != pending.id
+    assert completed.session_ordinal == pending.session_ordinal
+    assert completed.user_input == original
+    assert completed.context_usage["input_tokens"] == (100 if run_state == "publication_error" else 110)
+    assert completed.context_usage["output_tokens"] == (20 if run_state == "publication_error" else 22)
+    assert completed.duration_ms >= 1234
+    assert completed.ota_records[0]["observation_result"] == prior_round["observation_result"]
+    held = completed.ota_records[1]
+    step = held["action_result"]["results"][0]
+    assert step["tool_id"] == call["call_id"]
+    if permission:
+        assert step["success"] is False
+        assert "Skipped" in step["error"]
+        assert "Keep the original report unchanged." in held["observation_result"]
+    else:
+        assert isinstance(step["tool_result"], str)
+        if answer_type == "subagents":
+            assert "The child finished checking." in step["tool_result"]
+        elif answer_type == "choice_answer":
+            assert "Yes" in step["tool_result"]
+        else:
+            assert reply["input"] in step["tool_result"]
+    assert completed.agent_state["interaction"] is None
+    assert completed.agent_state["subagents"] is None
+    if run_state == "publication_error":
+        assert completed.status is TurnStatus.FAILED
+        assert completed.error
+        assert workspace.has_run_workflow
+        assert (active.root / "result" / "report.txt").read_text(encoding="utf-8") == "Original report\n"
+        return
+    assert completed.status is TurnStatus.COMPLETED
+    assert completed.agent_state["think"] == {"mode": "normal", "stage": "main"}
+    assert not workspace.has_run_workflow
+    stamps = [item["workflow_result"] for item in completed.ota_records if item.get("workflow_result")]
+    await workflow_runs.load()
+    if run_state == "gone":
+        assert stamps == []
+        assert workflow_runs.runs() == ()
+    else:
+        assert len(stamps) == 1
+        assert len(workflow_runs.runs()) == 1
+        published = workflow_runs.get(stamps[0]["run_id"])
+        assert published is not None
+        assert published.status.value == run_state
+        assert published.read_file("result/report.txt") == "Original report\n"
+    if answer_type in {"permission_answer", "choice_answer"}:
+        with pytest.raises(InvocationStaleAnswerError):
+            await interactions.run(record.id, reply)
+        assert [turn.id for turn in await interactions.turns.list_conversation(USER_ID, record.id)] == [turn.id for turn in turns]

--- a/tests/agent/workflows/test_workflow_domain.py
+++ b/tests/agent/workflows/test_workflow_domain.py
@@ -36,13 +36,13 @@ def test_package(test_sandbox: IsolatedPaths) -> None:
     {
       "valid": {"execution_steps": 2},
       "missing_script": "rejected before use",
-      "local_environment": "rejected before use"
+      "extra_files": "allowed"
     }
 
     Checks:
     1. A complete package needs only WORKFLOW.md and exposes ordered execution sections.
     2. Package validation rejects a referenced script that is absent from the source tree.
-    3. Package validation rejects a bundled dependency environment from the source tree.
+    3. Package validation allows unused files and directories in the source tree.
     """
     root = test_sandbox.root / "package-contract"
     _write_package(root, "Initial")
@@ -69,7 +69,7 @@ def test_package(test_sandbox: IsolatedPaths) -> None:
     assert "scripts/generate.py" in reason
     assert "does not exist" in reason
 
-    # Check 3: A Workflow cannot capture a machine-local dependency environment.
+    # Check 3: Extra directories do not affect the executable source contract.
     package.entry_path.write_text(
         package.entry_path.read_text(encoding="utf-8").replace(
             "\nRun `scripts/generate.py` for the final output.\n",
@@ -78,9 +78,91 @@ def test_package(test_sandbox: IsolatedPaths) -> None:
         encoding="utf-8",
     )
     (package.source_root / ".venv").mkdir()
-    reason = package.validation_reason()
-    assert reason is not None
-    assert "local dependency environment" in reason
+    assert package.validation_reason() is None
+
+
+def test_optional_artifacts_are_ignored(test_sandbox: IsolatedPaths) -> None:
+    """Unused documents and scripts never impose requirements on executable source."""
+    root = test_sandbox.root / "legacy-package"
+    _write_package(root, "Legacy")
+    package = WorkflowPackage(root)
+    package.scripts_dir.mkdir()
+    validator = package.scripts_dir / "validate_htmls.py"
+    validator.write_text("def broken(:\n", encoding="utf-8")
+    validation = package.source_root / "VALIDATE.md"
+    validation.write_bytes(b"# Old document\nRun scripts/missing.py\n\xff")
+    (package.source_root / "node_modules").mkdir()
+    before = {path: path.read_bytes() for path in root.rglob("*") if path.is_file()}
+    assert package.validation_reason() is None
+    assert [step.title for step in package.execution_steps] == ["Collect inputs", "Publish report"]
+    assert {path: path.read_bytes() for path in before} == before
+    validator.unlink()
+    assert package.validation_reason() is None
+    validation.unlink()
+    validator.write_text("def broken(:\n", encoding="utf-8")
+    assert package.validation_reason() is None
+
+    # Filesystem boundaries apply to optional content as well as executable files.
+    outside = root / "outside.py"
+    outside.write_text("print('outside')\n", encoding="utf-8")
+    validator.unlink()
+    validator.symlink_to(outside)
+    assert "symbolic link" in package.validation_reason()
+
+
+def test_metadata_and_heading_extensions(test_sandbox: IsolatedPaths) -> None:
+    """Extra metadata, multiline descriptions, and generic titles remain executable."""
+    root = test_sandbox.root / "extended-package"
+    _write_package(root, "Extended")
+    package = WorkflowPackage(root)
+    package.entry_path.write_text(
+        "---\nname: 报表 Workflow v1\ndescription: |\n  First line.\n  Second line.\n"
+        "version: 1\ncustom: {owner: example}\n---\n"
+        "Extra introduction mentions scripts/unused.py.\n\n# Section 1\n\nProduce the report.\n",
+        encoding="utf-8",
+    )
+    assert package.validation_reason() is None
+    assert [step.title for step in package.execution_steps] == ["Section 1"]
+
+
+@pytest.mark.parametrize("reference", [
+    "scripts/generate.py", "./scripts/generate.py", "workflow/scripts/generate.py",
+    ".build/workflow/scripts/generate.py", r"scripts\generate.py",
+])
+def test_required_script_references(test_sandbox: IsolatedPaths, reference: str) -> None:
+    """Accept equivalent package paths while requiring usable execution scripts."""
+    root = test_sandbox.root / "script-package"
+    _write_package(root, "Scripts")
+    package = WorkflowPackage(root)
+    package.entry_path.write_text(
+        package.entry_path.read_text(encoding="utf-8") + f"\nRun `python {reference}`.\n",
+        encoding="utf-8",
+    )
+    assert "does not exist" in package.validation_reason()
+    package.scripts_dir.mkdir()
+    script = package.scripts_dir / "generate.py"
+    script.write_text("def broken(:\n", encoding="utf-8")
+    assert "syntax error" in package.validation_reason()
+    script.write_text("print('generated')\n", encoding="utf-8")
+    assert package.validation_reason() is None
+
+
+@pytest.mark.parametrize("body, reason", [
+    ("", "empty"),
+    ("# Run\nInstruction.\n", "frontmatter"),
+    ("---\ndescription: Run\n---\n# Run\nInstruction.\n", "name"),
+    ("---\nname: report\n---\n# Run\nInstruction.\n", "description"),
+    ("---\nname: report\ndescription: Run\n---\nInstruction.\n", "no level-one"),
+    ("---\nname: report\ndescription: Run\n---\n# Run\n", "no instructions"),
+    ("---\nname: report\ndescription: Run\n---\n# Run\nRun scripts/../../outside.py\n", "escapes"),
+])
+def test_required_source_content(test_sandbox: IsolatedPaths, body: str, reason: str) -> None:
+    """Relaxed validation still rejects missing execution content and escaping paths."""
+    root = test_sandbox.root / "incomplete-package"
+    _write_package(root, "Incomplete")
+    package = WorkflowPackage(root)
+    package.entry_path.write_text(body, encoding="utf-8")
+    assert reason in package.validation_reason()
 
 
 async def test_materialization(test_sandbox: IsolatedPaths, monkeypatch: pytest.MonkeyPatch, workflow_store: None) -> None:

--- a/tests/agent/workspace/test_run_space.py
+++ b/tests/agent/workspace/test_run_space.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import pytest
@@ -271,3 +272,53 @@ async def test_invalid_run(agent_workspace: Workspace) -> None:
     with pytest.raises(ValueError, match="invalid JSON"):
         await agent_workspace.prepare_run_workflow_space("resume")
     assert agent_workspace.run_workflow is None
+
+
+@pytest.mark.parametrize("backup", [False, True])
+@pytest.mark.parametrize("validation_index", [0, 7])
+async def test_legacy_validation_checkpoint(agent_workspace: Workspace, backup: bool, validation_index: int) -> None:
+    """Project legacy validation cursors to completion without changing discovery files."""
+    def populate(root: Path) -> None:
+        source = root / "source" / "workflow"
+        source.mkdir(parents=True)
+        (source / "WORKFLOW.md").write_text(
+            "---\nname: report\ndescription: Produce a report\n---\n"
+            "# Collect inputs\n\nRead inputs.\n\n# Publish report\n\nWrite result.\n",
+            encoding="utf-8",
+        )
+        (root / "report.txt").write_text("already produced\n", encoding="utf-8")
+
+    run = await agent_workspace.prepare_run_workflow_space(
+        "create", initial_state=_run_state(), populate=populate,
+    )
+    state = {**_run_state().model_dump(mode="json"), "stage": "validate", "step_index": validation_index}
+    state_path = run.root / ".state.json"
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    original = state_path.read_bytes()
+    agent_workspace.close_run_workflow_space()
+    retained = run.root.with_name(".run.backup.legacy") if backup else run.root
+    if backup:
+        run.root.replace(retained)
+
+    checkpoint = agent_workspace.run_workflow_checkpoint()
+    assert checkpoint is not None
+    assert (checkpoint.stage, checkpoint.step_index) == ("execute", 2)
+    assert checkpoint.generation == _run_state().generation
+    assert checkpoint.workflow_input == _run_state().workflow_input
+    assert (retained / ".state.json").read_bytes() == original
+    assert (retained / "report.txt").read_text(encoding="utf-8") == "already produced\n"
+
+    resumed = await agent_workspace.prepare_run_workflow_space("resume")
+    assert (resumed.stage, resumed.step_index) == ("execute", 2)
+    assert (resumed.root / "report.txt").read_text(encoding="utf-8") == "already produced\n"
+
+
+@pytest.mark.parametrize("stage, step_index", [("unknown", 0), ("validate", -1), ("validate", 0)])
+async def test_legacy_migration_rejects_invalid_state(agent_workspace: Workspace, stage: str, step_index: int) -> None:
+    """Legacy compatibility must not invent a cursor for corrupt persisted state."""
+    run = await agent_workspace.prepare_run_workflow_space("create", initial_state=_run_state())
+    state = {**_run_state().model_dump(mode="json"), "stage": stage, "step_index": step_index}
+    (run.root / ".state.json").write_text(json.dumps(state), encoding="utf-8")
+    assert run.checkpoint() is None
+    with pytest.raises(ValueError):
+        await agent_workspace.prepare_run_workflow_space("resume")

--- a/tests/service/handlers/test_workflow_handler.py
+++ b/tests/service/handlers/test_workflow_handler.py
@@ -4,6 +4,7 @@ import zipfile
 from datetime import datetime
 
 import httpx
+import pytest
 
 
 def _workflow_archive(name: str) -> bytes:
@@ -145,6 +146,72 @@ async def test_import(service_client: httpx.AsyncClient) -> None:
             "description": "Build a deterministic report",
             "domain": "reporting",
         }
+
+
+@pytest.mark.parametrize("format_version", [1, 2])
+async def test_legacy_archive_round_trip(service_client: httpx.AsyncClient, format_version: int) -> None:
+    """Import and export old packages without deleting or promoting validation source."""
+    with zipfile.ZipFile(io.BytesIO(_workflow_archive("Legacy report"))) as archive:
+        files = {name: archive.read(name) for name in archive.namelist()}
+    manifest = json.loads(files["manifest.json"])
+    manifest["format_version"] = format_version
+    files["manifest.json"] = json.dumps(manifest).encode()
+    files["workflow/VALIDATE.md"] = b"# Old document\nRun scripts/missing_legacy_check.py\n\xff"
+    files["workflow/scripts/validate_htmls.py"] = b"def obsolete(:\n"
+    files["workflow/assets/data.bin"] = b"\x00\xff\x80\xfe"
+    files["workflow/node_modules/unused.txt"] = b"Optional extra content."
+    files["workflow/WORKFLOW.md"] = files["workflow/WORKFLOW.md"].replace(
+        b"name: report-workflow", b"name: Report Workflow\nextra_field: preserved",
+    ).replace(b"# Produce the report", b"# Section 1")
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w") as archive:
+        for name, content in files.items():
+            archive.writestr(name, content)
+        archive.writestr("extra-notes.txt", "Optional archive notes.")
+
+    response = await service_client.put(
+        "/workflows", files={"file": ("legacy.amphi-workflow", output.getvalue())},
+    )
+    assert response.status_code == 201, response.text
+    workflow_id = response.json()["id"]
+    exported = await service_client.get(f"/workflows/{workflow_id}", params={"archive": True})
+    assert exported.status_code == 200, exported.text
+    with zipfile.ZipFile(io.BytesIO(exported.content)) as archive:
+        assert set(archive.namelist()) == set(files)
+        for name, content in files.items():
+            if name != "manifest.json":
+                assert archive.read(name) == content
+        assert json.loads(archive.read("manifest.json"))["format_version"] == 2
+
+
+@pytest.mark.parametrize("missing", ["task.md", "explore.md", "verify.md", "workflow/WORKFLOW.md"])
+async def test_import_requires_package_documents(service_client: httpx.AsyncClient, missing: str) -> None:
+    """Extra files are allowed, but they cannot replace required package documents."""
+    output = io.BytesIO()
+    with zipfile.ZipFile(io.BytesIO(_workflow_archive("Incomplete"))) as original:
+        with zipfile.ZipFile(output, "w") as archive:
+            for name in original.namelist():
+                if name != missing:
+                    archive.writestr(name, original.read(name))
+            archive.writestr("workflow/extra.md", "Extra material.")
+    response = await service_client.put(
+        "/workflows", files={"file": ("incomplete.amphi-workflow", output.getvalue())},
+    )
+    assert response.status_code == 400
+    assert (await service_client.get("/workflows")).json() == []
+
+
+@pytest.mark.parametrize("unsafe", ["../outside.txt", "extra/../../outside.txt", "/absolute/extra.txt"])
+async def test_import_rejects_unsafe_extra_paths(service_client: httpx.AsyncClient, unsafe: str) -> None:
+    """Ignoring extra files must not bypass the archive's traversal protection."""
+    output = io.BytesIO(_workflow_archive("Unsafe extras"))
+    with zipfile.ZipFile(output, "a") as archive:
+        archive.writestr(unsafe, "Unsafe archive path.")
+    response = await service_client.put(
+        "/workflows", files={"file": ("unsafe.amphi-workflow", output.getvalue())},
+    )
+    assert response.status_code == 400
+    assert (await service_client.get("/workflows")).json() == []
 
 
 async def test_rename_delete(service_client: httpx.AsyncClient) -> None:


### PR DESCRIPTION
Legacy Workflow packages could fail during import, export, Build, edit, or Run because package validation rejected unused scripts, extra metadata, or document formatting. Relax those checks while retaining required documents, executable sections, referenced Python script checks, and filesystem/archive safety boundaries. Export source files as raw bytes so optional and binary assets survive an import/export round trip.

Restore retained Runs from the retired validation stage by projecting their cursor to the end of the pinned execution steps. Manual resume settles completed Runs and preserves existing failure results. Awaiting continuations retain the original request, trace, usage, and duration and replace the original Turn; obsolete pending validation tools are recorded as skipped. Prompt files are unchanged.

Validation:

- Full backend suite after merging `main`: `uv run pytest -q --timeout=60 --tb=short --cov=src --cov-report=term:skip-covered --cov-fail-under=70` — 513 passed; coverage 76.21%.
- Desktop suite: `bun run test` — 1,346 passed, 6 skipped.
- Regression coverage includes legacy archive round trips, required-content rejection, Build/edit/Run compatibility, cursor migration, both manual resume paths, awaiting continuations, and publication failures.
- `git diff --check`, desktop ESLint, and all desktop TypeScript type checks passed.

Remaining limitations:

- Verify uses the last standalone PASS/FAIL outside code fences; a later per-check PASS can override an earlier overall FAIL.
- A retained validation-stage Turn awaiting a Workflow resume/restart choice still uses generic human-choice recovery. It can leave that choice unresolved and overwrite an earlier ordinary answer in the same Turn.
