### PR TITLE
fix(agent): isolate stage context and preserve compaction across turns

### DIFF
--- a/src/amphi_agent/_agent.py
+++ b/src/amphi_agent/_agent.py
@@ -5,6 +5,7 @@ import re
 import secrets
 import time
 from datetime import datetime
+from itertools import chain
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 from uuid import uuid4
@@ -36,7 +37,7 @@ from ._cognitive import (
     WorkflowThink,
     render_input,
 )
-from ._context import AmphiContext, AmphiOTAContext, ContextUsageSnapshot
+from ._context import AmphiContext, AmphiOTAContext, ContextUsageSnapshot, _view
 from ._describe import describe_commands
 from ._error import AgentEmptyAnswerError
 from ._prompt import TITLE_PROMPT
@@ -610,6 +611,80 @@ class AmphiAgent(AmphibiousAutoma[AmphiOTAContext, AmphiContext]):
         model re-loops the stage blind to why a call was vetoed. (The permission PARK
         records no round permission, so it is untouched by this fold.)
         """
+        def _handoff_reason(reason: str) -> str:
+            """Append saved human-tool outcomes, without replaying execution traces."""
+            def outcomes():
+                history = (
+                    record for turn in reversed(context.session.get_all()) if turn.status.is_terminal
+                    for record in reversed(turn.ota_records or [])
+                )
+                for record in chain(reversed(ota_context.ota_record), history):
+                    for action in reversed(_view(_view(record, "action_result"), "results") or []):
+                        name, result = _view(action, "tool_name"), _view(action, "tool_result")
+                        if _view(action, "success") is False or _view(action, "error"):
+                            continue
+                        prompt, questions = "", []
+                        if name == "request_human_choice" and isinstance(result, str) and result.strip():
+                            lines = [f"Answer: {result.strip()}"]
+                            arguments = _view(action, "tool_arguments") or {}
+                            if isinstance(arguments, list):
+                                arguments = {_view(arg, "name"): _view(arg, "value") for arg in arguments}
+                            prompt = str(_view(arguments, "prompt") or "")
+                            questions = RequestHumanChoice.coerce_questions(_view(arguments, "questions"))
+                        elif name in {"request_build", "request_run_workflow", "request_human_task_confirm", "request_human_workflow_confirm"} and isinstance(result, dict):
+                            if result.get("status") not in {"confirmed", "cancelled", "resolved", "not_answered", "revision_requested", "save_failed", "failed"}:
+                                continue
+                            lines = []
+                            for key in ("message", "feedback", "user_message", "response"):
+                                text = str(result.get(key) or "").strip()
+                                if text and not any(text in line for line in lines):
+                                    lines.append(text)
+                            if not lines:
+                                lines.append(f"User decision: {str(result.get('action') or result['status']).replace('_', ' ')}.")
+                            if name == "request_build" and result.get("status") == "not_answered":
+                                prompt = str(result.get("reason") or "")
+                                questions = RequestHumanChoice.coerce_questions(result.get("questions"))
+                        else:
+                            continue
+                        # Free-form answers such as "the second option" need their question.
+                        for question in questions:
+                            text = str(_view(question, "question") or "").strip()
+                            if not text:
+                                continue
+                            options = "; ".join(
+                                f"{index}. {_view(option, 'label')}"
+                                for index, option in enumerate(_view(question, "options") or [], 1)
+                            )
+                            lines.append(f"Question: {text}" + (f" Options: {options}" if options else ""))
+                        yield f"- {name}: " + "\n  ".join(lines), prompt
+
+            items: List[str] = []
+            seen: set[tuple[str, str]] = set()
+            size = 0
+            omitted = False
+            for item, prompt in outcomes():
+                # Compare the original context, not a clipped rendering of different decisions.
+                if (item, prompt) in seen:
+                    continue
+                seen.add((item, prompt))
+                if len(item) > 1_000:
+                    item = item[:900] + " … [truncated; see the Session transcript]"
+                    omitted = True
+                if prompt:
+                    item += f"\n  Context: {prompt}"
+                # Keep the newest decision even when its complete prompt exceeds the soft budget.
+                if len(items) >= 8 or (items and size + len(item) > 4_000):
+                    omitted = True
+                    break
+                items.append(item)
+                size += len(item)
+            if not items:
+                return reason
+            note = "[user interaction outcomes; oldest to newest]\n" + "\n".join(reversed(items))
+            if omitted:
+                note += "\nAdditional details omitted; see the Session transcript."
+            return f"{reason}\n\n{note}" if reason else note
+
         gate = self._get_current_ota_permission_status(ota_context)
         effective_execution_mode = (
             gate.execution_mode or self._effective_execution_mode(ota_context, context)
@@ -641,6 +716,7 @@ class AmphiAgent(AmphibiousAutoma[AmphiOTAContext, AmphiContext]):
                         target_mode,
                         sig.get("stage"),
                     )
+                sig["reason"] = _handoff_reason(sig.get("reason") or "")
                 ota_context.transition_think(next_status)
                 if sig.get("reason") and not isinstance(next_status, NormalStageState):
                     self._stamp_stage_handoff(ota_context, current_status, next_status, sig["reason"])

--- a/src/amphi_agent/_cognitive.py
+++ b/src/amphi_agent/_cognitive.py
@@ -50,6 +50,7 @@ from ._state import (
     BuildStageState,
     ContextCompactionState,
     NormalStageState,
+    SessionCompactionState,
     TurnCompactionState,
     WorkflowStageState,
 )
@@ -62,7 +63,6 @@ from .tools import (
     WORKSPACE_ADVANCED_TOOL_NAMES,
     switch_tool,
 )
-from .tools._request_human import RequestHumanChoice
 
 __all__ = [
     "BuildThink",
@@ -129,6 +129,271 @@ class ToolSurface:
     def names(self) -> Tuple[str, ...]:
         """Return prompt-ready names derived from the runtime specs."""
         return tuple(spec.tool_name for spec in self.specs)
+
+
+def _tool_round_messages(record: Any, tools: Sequence[ToolSpec], id_prefix: str, extras: Optional[Dict[str, Any]] = None) -> List[Message]:
+    """Replay completed tool activity identically within and across Turns.
+
+    Executed steps, not the original proposed calls, own the replayed arguments.
+    Large or invalid calls become text as a whole round; native calls always
+    keep their paired results. Only current-Turn callers supply reasoning extras.
+    """
+    MAX_ARG_VALUE_CHARS = 1200
+
+    def step_call(step: Any, step_index: int) -> Tuple[Dict[str, Any], Dict[str, int], List[str]]:
+        """Render one historical tool call and report why native replay may be unsafe."""
+        name = _view(step, "tool_name") or ""
+        args = _view(step, "tool_arguments")
+        provided = set(args) if isinstance(args, dict) else set()
+        omitted: Dict[str, int] = {}
+        if isinstance(args, dict):
+            replay_args: Dict[str, Any] = {}
+            for key, value in args.items():
+                if isinstance(value, str):
+                    rendered = value
+                else:
+                    try:
+                        rendered = json.dumps(value, ensure_ascii=False, default=str)
+                    except (TypeError, ValueError):
+                        rendered = str(value)
+                if len(rendered) > MAX_ARG_VALUE_CHARS:
+                    omitted[str(key)] = len(rendered)
+                else:
+                    replay_args[key] = value
+            args = replay_args
+        spec = next((tool for tool in tools if tool.tool_name == name), None)
+        required = set((getattr(spec, "tool_parameters", None) or {}).get("required") or [])
+        missing = sorted(str(key) for key in required - provided)
+        call = {
+            "id": _view(step, "tool_id") or f"{id_prefix}_{step_index}",
+            "name": name,
+            "arguments": args or {},
+        }
+        return call, omitted, missing
+
+    def step_result(step: Any) -> str:
+        """Render one historical tool result."""
+        error = _view(step, "error")
+        if error or _view(step, "success") is False:
+            return f"failed: {error or 'tool failed'}"
+        result = _view(step, "tool_result")
+        if result is None:
+            return "(no output)"
+        if result == "":
+            return "(awaiting the user's answer)"
+        return str(result)
+
+    def step_summary(call: Dict[str, Any], step: Any, omitted: Dict[str, int], missing: List[str]) -> str:
+        """Summarize a call that must not be replayed as a native tool example."""
+        facts: List[str] = []
+        arguments = call.get("arguments") or {}
+        if arguments:
+            retained = ", ".join(
+                f"`{name}`: {json.dumps(value, ensure_ascii=False, default=str)}"
+                for name, value in arguments.items()
+            )
+            facts.append(f"retained arguments {retained}")
+        if omitted:
+            details = ", ".join(
+                f"`{name}` ({count} characters)" for name, count in omitted.items()
+            )
+            facts.append(f"large arguments not replayed: {details}")
+        if missing:
+            facts.append("missing required arguments: " + ", ".join(f"`{name}`" for name in missing))
+        failed = bool(_view(step, "error")) or _view(step, "success") is False
+        facts.append(f"status: {'failed' if failed else 'succeeded'}")
+        facts.append(f"result: {json.dumps(step_result(step), ensure_ascii=False)}")
+        return f"- `{call['name']}` — " + "; ".join(facts)
+
+    think = _view(_view(record, "think_result"), "step_content") or ""
+    steps = _view(_view(record, "action_result"), "results") or []
+    rendered_steps = [step_call(step, i) for i, step in enumerate(steps)]
+    extras = dict(extras or {})
+    signatures = extras.pop("thought_signatures", None)
+    messages: List[Message] = []
+    if any(omitted or missing for _, omitted, missing in rendered_steps):
+        activity = "\n".join(
+            step_summary(call, step, omitted, missing)
+            for (call, omitted, missing), step in zip(rendered_steps, steps)
+        )
+        summary = (
+            "Completed historical tool activity is summarized as text because "
+            "native replay would contain omitted or invalid arguments:\n"
+            f"{activity}\nInspect current files or `<transcript>` when the original tool "
+            "output is needed."
+        )
+        messages.append(Message.from_text(
+            f"{think}\n\n{summary}" if think else summary,
+            role=Role.AI,
+            extras=extras,
+        ))
+    else:
+        calls = [call for call, _, _ in rendered_steps]
+        if signatures and len(signatures) == len(calls):
+            extras = {**extras, "thought_signatures": list(signatures)}
+        messages.append(Message.from_tool_call(
+            tool_calls=calls, text=think or None,
+            extras=extras,
+        ))
+        for (call, _, _), step in zip(rendered_steps, steps):
+            messages.append(Message.from_tool_result(
+                tool_id=call["id"],
+                content=step_result(step),
+            ))
+    return messages
+
+
+_HistoryScope = Tuple[str, str]
+
+
+@dataclass(frozen=True)
+class _HistoryRound:
+    """One projected round, retaining its one-based position in the durable Turn."""
+
+    number: int
+    record: Any
+
+
+def _record_scope(record: Any) -> Optional[_HistoryScope]:
+    scope = _view(record, "think_scope")
+    mode = str(_view(scope, "mode") or "").strip()
+    stage = str(_view(scope, "stage") or "").strip()
+    if mode and stage:
+        return mode, stage
+    legacy = str(_view(record, "build_stage") or "").strip()
+    return ("build", legacy) if legacy else None
+
+
+def _project_rounds(records: Sequence[Any], scope: _HistoryScope) -> List[_HistoryRound]:
+    """Select owned rounds plus explicit incoming handoffs, never a foreign raw trace."""
+    def incoming_handoff(record: Any) -> str:
+        observation = str(_view(record, "observation_result") or "")
+        header = re.search(r"\[stage handoff\] `[^`]+` → `([^`]+)`", observation)
+        if header and header.group(1) == "/".join(scope):
+            return observation
+        if scope == ("normal", "main") and (
+            "[mode transition]" in observation and "returned control to Main" in observation
+            or "[artifact publication]" in observation
+        ):
+            return observation
+        notes = []
+        for step in _view(_view(record, "action_result"), "results") or []:
+            if _view(step, "success") is False or _view(step, "error"):
+                continue
+            name = _view(step, "tool_name")
+            arguments = _view(step, "tool_arguments") or {}
+            if isinstance(arguments, list):
+                arguments = {_view(arg, "name"): _view(arg, "value") for arg in arguments}
+            result = _view(step, "tool_result") or {}
+            if name == "switch":
+                source = _record_scope(record)
+                mode = str(_view(result, "mode") or _view(arguments, "mode") or (source or scope)[0])
+                stage = "main" if mode == "normal" else str(_view(result, "stage") or _view(arguments, "stage") or "")
+                if (mode, stage) == scope:
+                    reason = _view(result, "reason") or _view(arguments, "reason") or ""
+                    notes.append(f"[stage handoff] to `{mode}/{stage}`\n{reason}")
+            elif name == "request_build" and scope == ("build", "clarify"):
+                if _view(result, "mode") == "start" or _view(result, "status") == "confirmed":
+                    notes.append(f"[stage handoff] to `build/clarify`\n{_view(result, 'goal') or ''}")
+            elif name == "request_run_workflow" and scope == ("run_workflow", "execute"):
+                status = _view(result, "status")
+                if status in {"started", "resumed", "restarted"}:
+                    notes.append(
+                        f"[stage handoff] to `run_workflow/execute`\n"
+                        f"Workflow `{_view(result, 'workflow_id') or ''}` {status}.\n"
+                        f"{_view(result, 'reason') or _view(arguments, 'reason') or ''}"
+                    )
+        return "\n\n".join(notes)
+
+    projected = []
+    for index, record in enumerate(records):
+        owner = _record_scope(record)
+        # Pre-scope traces cannot be classified reliably. Keep them rather than
+        # silently discarding user work; all new rounds persist their owner.
+        if owner is None or owner == scope:
+            projected.append(_HistoryRound(index + 1, record))
+        elif note := incoming_handoff(record):
+            projected.append(_HistoryRound(index + 1, {
+                "think_scope": {"mode": scope[0], "stage": scope[1]},
+                "think_result": {"step_content": note, "tool_calls": []},
+                "history_handoff": True,
+            }))
+    return projected
+
+
+def _covered_rounds(records: Sequence[Any], scope: _HistoryScope, projection: Optional[TurnCompactionState]) -> set[int]:
+    """Resolve exact coverage, or migrate an old stage-local prefix without changing its coordinates."""
+    if projection is None or not projection.turn_summary:
+        return set()
+    if projection.turn_covered_rounds is not None:
+        return set(projection.turn_covered_rounds)
+    mode, stage = scope
+    scopes = [_record_scope(record) for record in records]
+    indexes = list(range(len(records)))
+    if mode == "build":
+        mode_indexes = [index for index, owner in enumerate(scopes) if owner and owner[0] == mode]
+        selected = set(indexes) if not mode_indexes else set()
+        if mode_indexes and scopes[mode_indexes[0]] == scope:
+            selected.update(range(mode_indexes[0]))
+        for index, record in enumerate(records):
+            if scopes[index] == scope:
+                selected.add(index)
+            for step in _view(_view(record, "action_result"), "results") or []:
+                if _view(step, "tool_name") != "switch" or _view(step, "success") is False:
+                    continue
+                result = _view(step, "tool_result") or {}
+                arguments = _view(step, "tool_arguments") or {}
+                if str(_view(result, "stage") or _view(arguments, "stage") or "") == stage:
+                    selected.add(index)
+            next_scope = scopes[index + 1] if index + 1 < len(scopes) else scope
+            if next_scope == scope and (scopes[index] is None or scopes[index][0] != mode):
+                selected.add(index)
+        indexes = sorted(selected)
+    elif mode == "run_workflow":
+        visits = []
+        last_target = None
+        for index, owner in enumerate(scopes):
+            if owner and owner[0] == mode:
+                if not visits or visits[-1] != owner[1]:
+                    visits.append(owner[1])
+                if owner == scope:
+                    last_target = index
+        if visits.count(stage) > 1 or (visits and last_target is None):
+            return set()
+        end = len(records) if last_target is None else last_target + 1
+        boundary = max((index for index, owner in enumerate(scopes[:end]) if owner and owner[0] == mode and owner != scope), default=-1)
+        indexes = list(range(boundary + 1, end))
+    return {index + 1 for index in indexes[:projection.turn_through_round]}
+
+
+def _session_projection(compaction: Optional[ContextCompactionState], turns: Sequence[Any], scope: _HistoryScope) -> SessionCompactionState:
+    """Do not apply a legacy mixed-mode Session summary to a narrowed stage view."""
+    if compaction is None:
+        return SessionCompactionState()
+    projection = compaction.session.get(scope[0], {}).get(scope[1])
+    if projection is not None:
+        return projection
+    if scope == ("normal", "main") and compaction.session_summary and all(
+        _record_scope(record) in (None, scope)
+        for turn in turns if turn.session_ordinal <= compaction.session_through_ordinal
+        for record in turn.ota_records or []
+    ):
+        return SessionCompactionState(
+            session_summary=compaction.session_summary,
+            session_through_ordinal=compaction.session_through_ordinal,
+        )
+    return SessionCompactionState()
+
+
+def _turn_has_scope(turn: Any, scope: _HistoryScope) -> bool:
+    """Count only historical Turns belonging to this stage's retention window."""
+    if _project_rounds(turn.ota_records or [], scope):
+        return True
+    state = turn.agent_state or {}
+    if (state.get("context_compaction") or {}).get("turn", {}).get(scope[0], {}).get(scope[1], {}).get("turn_summary"):
+        return True
+    think = state.get("think") or {}
+    return not turn.ota_records and (think.get("mode", "normal"), think.get("stage", "main")) == scope
 
 
 def _node_environment_summary(workspace: Optional[Any]) -> str:
@@ -324,7 +589,7 @@ class MainThink(CognitiveWorker):
         ota_context._current_record().think_scope = {
             "mode": status.mode,
             "stage": status.stage,
-            "session_history": "all_stages",
+            "session_history": "stage_scoped_v2",
         }
         messages = await self.assemble_messages(ota_context, context)
         messages = await self.append_runtime_state(messages, ota_context, context)
@@ -689,14 +954,17 @@ class MainThink(CognitiveWorker):
             return summary, through
 
         async def compact_session_history() -> bool:
-            turns = context.session.get_all()
+            think = ota_context.think_status
+            scope = (think.mode, think.stage)
+            projection = _session_projection(candidate, context.session.get_all(), scope)
+            turns = [turn for turn in context.session.get_all() if _turn_has_scope(turn, scope)]
             raw_prefix = turns[:max(0, len(turns) - CONTEXT_COMPACTION_KEEP_SESSION_TURNS)]
             units: List[Tuple[int, str]] = []
             for turn in raw_prefix:
-                if turn.session_ordinal <= candidate.session_through_ordinal:
+                if turn.session_ordinal <= projection.session_through_ordinal:
                     continue
                 payload = trim_text(
-                    serialize_messages(self._session_messages([turn], context)),
+                    serialize_messages(self._session_messages([turn], context, scope, ota_context.tools)),
                     unit_tokens,
                 )
                 units.append((
@@ -708,30 +976,33 @@ class MainThink(CognitiveWorker):
             def render(previous: str, history: str) -> str:
                 return render_session_compaction_prompt(previous, history)
 
-            summary, through = await roll_summary(candidate.session_summary, units, render)
-            if through is None or through <= candidate.session_through_ordinal:
+            summary, through = await roll_summary(projection.session_summary, units, render)
+            if through is None or through <= projection.session_through_ordinal:
                 return False
-            candidate.session_summary = summary
-            candidate.session_through_ordinal = through
+            candidate.session.setdefault(think.mode, {})[think.stage] = projection.model_copy(update={
+                "session_summary": summary,
+                "session_through_ordinal": through,
+            })
             return True
 
         async def compact_turn_history() -> bool:
             think = ota_context.think_status
             mode = think.mode
             stage = think.stage
-            turn_context, _ = self._stage_turn_context(ota_context, mode, stage)
-            records = turn_context.ota_record
+            records = _project_rounds(ota_context.ota_record, (mode, stage))
             turn_compaction = candidate.turn.get(mode, {}).get(
                 stage,
                 TurnCompactionState(),
             )
             prefix_end = max(0, len(records) - CONTEXT_COMPACTION_KEEP_TURN_ROUNDS)
-            start = min(turn_compaction.turn_through_round, len(records))
+            covered = _covered_rounds(ota_context.ota_record, (mode, stage), turn_compaction)
             projected_state = ota_context.state.model_copy(update={"context_compaction": None})
             units: List[Tuple[int, str]] = []
-            for index in range(start, prefix_end):
-                projected = turn_context.model_copy(update={
-                    "ota_record": [records[index]],
+            for index in range(prefix_end):
+                if records[index].number in covered:
+                    continue
+                projected = ota_context.model_copy(update={
+                    "ota_record": [records[index].record],
                     "state": projected_state,
                 })
                 payload = trim_text(
@@ -752,11 +1023,12 @@ class MainThink(CognitiveWorker):
                 )
 
             summary, through = await roll_summary(turn_compaction.turn_summary, units, render)
-            if through is None or through <= turn_compaction.turn_through_round:
+            if through is None:
                 return False
             candidate.turn.setdefault(mode, {})[stage] = turn_compaction.model_copy(update={
                 "turn_summary": summary,
                 "turn_through_round": through,
+                "turn_covered_rounds": sorted(covered | {record.number for record in records[:through]}),
             })
             return True
 
@@ -990,21 +1262,6 @@ class MainThink(CognitiveWorker):
         messages.append(await self.current_user_message(ota_context, context))
         messages += self.turn_messages_block(ota_context, context)
         return messages
-
-    @staticmethod
-    def _record_think_scope(record: Any) -> Optional[Tuple[str, str]]:
-        """Return one round's cognitive mode and stage, including legacy Build records."""
-        scope = _view(record, "think_scope")
-        mode = str(_view(scope, "mode") or "").strip()
-        stage = str(_view(scope, "stage") or "").strip()
-        if mode and stage:
-            return mode, stage
-        legacy_build_stage = str(_view(record, "build_stage") or "").strip()
-        return ("build", legacy_build_stage) if legacy_build_stage else None
-
-    def _stage_turn_context(self, ota_context: AmphiOTAContext, mode: str, stage: str) -> Tuple[AmphiOTAContext, Optional[int]]:
-        """Return the full current-Turn trace unless a specialized worker projects it."""
-        return ota_context, None
 
     async def context_blocks(self, ota_context: AmphiOTAContext, context: AmphiContext) -> List[str]:
         """Render Main context from the most stable prefix to live round state."""
@@ -1347,11 +1604,13 @@ class MainThink(CognitiveWorker):
         return f"<transcript>\n{os.path.join(root, 'history.md')}\n</transcript>"
 
     async def session_messages_block(self, ota_context: AmphiOTAContext, context: AmphiContext) -> List[Message]:
-        """Replay the persisted Session summary followed by uncovered raw Turns."""
+        """Replay only the active stage's Session summary and compacted historical Turns."""
         turns = context.session.get_all()
-        compaction = ota_context.state.context_compaction
-        if compaction is None or not compaction.session_summary:
-            return self._session_messages(turns, context)
+        think = ota_context.think_status
+        scope = (think.mode, think.stage)
+        compaction = _session_projection(ota_context.state.context_compaction, turns, scope)
+        if not compaction.session_summary:
+            return self._session_messages(turns, context, scope, ota_context.tools)
         remaining = [
             turn
             for turn in turns
@@ -1364,7 +1623,7 @@ class MainThink(CognitiveWorker):
                 "through_ordinal",
                 compaction.session_through_ordinal,
             ),
-            *self._session_messages(remaining, context),
+            *self._session_messages(remaining, context, scope, ota_context.tools),
         ]
 
     @staticmethod
@@ -1377,149 +1636,80 @@ class MainThink(CognitiveWorker):
         )
         return Message.from_text(content, role=Role.AI)
 
-    def _session_messages(self, turns: Sequence[SessionTurnRecord], context: AmphiContext) -> List[Message]:
-        """Replay persisted Turns oldest-first, reusing only the global normal-mode projection."""
+    def _session_messages(
+        self,
+        turns: Sequence[SessionTurnRecord],
+        context: AmphiContext,
+        scope: _HistoryScope = ("normal", "main"),
+        tools: Sequence[ToolSpec] = (),
+    ) -> List[Message]:
+        """Project a stage's historical Turns without importing another stage's execution history."""
         messages: List[Message] = []
         for turn in turns:
+            if not _turn_has_scope(turn, scope):
+                continue
             ota = turn.ota_context_dump()
+            records = ota.get("ota_record") or []
             messages.append(self._user_message(
                 turn.user_input,
                 self._render_user_input(turn.user_input, context),
                 context,
                 reject_unsupported=False,
             ))
-            compaction_data = (turn.agent_state or {}).get("context_compaction")
-            compaction = (
-                ContextCompactionState.model_validate(compaction_data)
-                if compaction_data
-                else None
-            )
-            turn_compaction = (
-                compaction.turn.get("normal", {}).get("main")
-                if compaction is not None
-                else None
-            )
-            if turn_compaction is not None and turn_compaction.turn_summary:
+            data = (turn.agent_state or {}).get("context_compaction")
+            compaction = ContextCompactionState.model_validate(data) if data else None
+            projection = compaction.turn.get(scope[0], {}).get(scope[1]) if compaction else None
+            covered = _covered_rounds(records, scope, projection)
+            if projection is not None and projection.turn_summary:
                 messages.append(self._compaction_summary_message(
-                    "turn_history",
-                    turn_compaction.turn_summary,
-                    "through_round",
-                    turn_compaction.turn_through_round,
+                    "turn_history", projection.turn_summary, "through_round", projection.turn_through_round,
                 ))
-                ota["ota_record"] = (
-                    ota.get("ota_record") or []
-                )[turn_compaction.turn_through_round:]
-            messages.extend(self._ota_messages(ota, turn.session_ordinal))
+            remaining = [item for item in _project_rounds(records, scope) if item.number not in covered]
+            ota["ota_record"] = [item.record for item in remaining]
+            messages.extend(self._ota_messages(ota, turn.session_ordinal, [item.number for item in remaining], tools))
             if turn.status == TurnStatus.FAILED:
                 messages.append(Message.from_text(TURN_FAILED_MESSAGE, role=Role.AI))
         return messages
 
-    def _ota_messages(self, ota: Dict[str, Any], turn_index: int) -> List[Message]:
-        """One persisted OTA dump as AI/tool messages; intentionally separate from
-        ``turn_messages_block`` because session replay is whole-OTA and driven by
-        ``think_result.tool_calls``.
+    def _ota_messages(
+        self,
+        ota: Dict[str, Any],
+        turn_index: int,
+        round_numbers: Optional[Sequence[int]] = None,
+        tools: Sequence[ToolSpec] = (),
+    ) -> List[Message]:
+        """Replay a persisted Turn with the same bounded tool activity as the live loop.
 
-        Native tool replay is atomic: every call must have a persisted result.
-        Interrupted rounds fall back to their visible text so a cancelled Turn
-        cannot leave a dangling tool call in the next model request.
+        Only completed action steps become native pairs, even after interruption.
+        Session replay drops provider reasoning and collapses intermediate text,
+        but never re-expands original tool arguments from Think proposals.
         """
-        def tool_call_args(call: Any) -> Dict[str, Any]:
-            args = _view(call, "tool_arguments")
-            if isinstance(args, list):
-                return {
-                    _view(arg, "name"): _view(arg, "value")
-                    for arg in args
-                    if _view(arg, "name")
-                }
-            direct = _view(call, "arguments")
-            return direct if isinstance(direct, dict) else {}
-
-        def tool_call_name(call: Any) -> str:
-            return str(_view(call, "tool") or _view(call, "name") or "")
-
-        def tool_result_content(step: Any) -> str:
-            error = _view(step, "error")
-            if error or _view(step, "success") is False:
-                return f"failed: {error or 'tool failed'}"
-            result = _view(step, "tool_result")
-            if result is None:
-                return "(no output)"
-            if result == "":
-                return "(awaiting the user's answer)"
-            return str(result)
-
-        def asked_choice() -> str:
-            questions: Any = None
-            for record in ota.get("ota_record") or []:
-                for step in (_view(_view(record, "action_result"), "results") or []):
-                    if _view(step, "tool_name") != "request_human_choice":
-                        continue
-                    args = _view(step, "tool_arguments") or []
-                    if isinstance(args, list):
-                        values = {
-                            _view(arg, "name"): _view(arg, "value")
-                            for arg in args
-                        }
-                        questions = values.get("questions") or values.get("prompt") or questions
-                    elif isinstance(args, dict):
-                        questions = args.get("questions") or args.get("prompt") or questions
-            if not questions:
-                return ""
-            lines: List[str] = []
-            for q in RequestHumanChoice.coerce_questions(questions):
-                if not isinstance(q, dict):
-                    continue
-                text = (q.get("question") or "").strip()
-                if text:
-                    lines.append(text)
-                for opt in q.get("options") or []:
-                    if isinstance(opt, dict) and opt.get("label"):
-                        desc = (opt.get("description") or "").strip()
-                        lines.append(f"  - {opt['label']}" + (f": {desc}" if desc else ""))
-            return "\n".join(lines)
 
         messages: List[Message] = []
         final_answer = ""
         for record_index, record in enumerate(ota.get("ota_record") or []):
+            source_index = round_numbers[record_index] - 1 if round_numbers is not None else record_index
             think = _view(record, "think_result") or {}
             content = str(_view(think, "step_content") or "")
             calls = _view(think, "tool_calls") or []
             steps = _view(_view(record, "action_result"), "results") or []
-            if calls and len(calls) == len(steps):
-                rendered_calls: List[Dict[str, Any]] = []
-                for call_index, call in enumerate(calls):
-                    step = steps[call_index]
-                    rendered_calls.append({
-                        "id": (
-                            _view(step, "tool_id")
-                            or f"hist_call_{turn_index}_{record_index}_{call_index}"
-                        ),
-                        "name": tool_call_name(call),
-                        "arguments": tool_call_args(call),
-                    })
-                messages.append(Message.from_tool_call(
-                    tool_calls=rendered_calls,
-                    text=content or None,
-                ))
-                for call, step in zip(rendered_calls, steps):
-                    messages.append(Message.from_tool_result(
-                        tool_id=call["id"],
-                        content=tool_result_content(step),
-                    ))
+            if steps:
+                messages.extend(_tool_round_messages(record, tools, f"hist_call_{turn_index}_{source_index}"))
                 final_answer = ""
             elif calls:
                 if content:
                     messages.append(Message.from_text(content, role=Role.AI))
+                final_answer = ""
+            elif content and _view(record, "history_handoff"):
+                if final_answer:
+                    messages.append(Message.from_text(final_answer, role=Role.AI))
+                messages.append(Message.from_text(content, role=Role.AI))
                 final_answer = ""
             elif content:
                 final_answer = content
 
         if final_answer:
             messages.append(Message.from_text(final_answer, role=Role.AI))
-        else:
-            question = asked_choice()
-            if question:
-                messages.append(Message.from_text(question, role=Role.AI))
         return messages
 
     def _render_user_input(self, user_input: Any, context: AmphiContext) -> str:
@@ -1634,7 +1824,6 @@ class MainThink(CognitiveWorker):
             USER  "<observation>"                               (a stamped nudge, if any)
         """
         records = ota_context.ota_record
-        round_offset = 0
         compaction = ota_context.state.context_compaction
         think = ota_context.think_status
         turn_compaction = (
@@ -1642,75 +1831,10 @@ class MainThink(CognitiveWorker):
             if compaction is not None
             else None
         )
-        if turn_compaction is not None and turn_compaction.turn_summary:
-            round_offset = turn_compaction.turn_through_round
-            records = records[round_offset:]
-        MAX_ARG_VALUE_CHARS = 1200
-
-        def step_call(step: Any, round_index: int, step_index: int) -> Tuple[Dict[str, Any], Dict[str, int], List[str]]:
-            """Render one historical tool call and report why native replay may be unsafe."""
-            name = _view(step, "tool_name") or ""
-            args = _view(step, "tool_arguments")
-            provided = set(args) if isinstance(args, dict) else set()
-            omitted: Dict[str, int] = {}
-            if isinstance(args, dict):
-                replay_args: Dict[str, Any] = {}
-                for key, value in args.items():
-                    if isinstance(value, str):
-                        rendered = value
-                    else:
-                        try:
-                            rendered = json.dumps(value, ensure_ascii=False, default=str)
-                        except (TypeError, ValueError):
-                            rendered = str(value)
-                    if len(rendered) > MAX_ARG_VALUE_CHARS:
-                        omitted[str(key)] = len(rendered)
-                    else:
-                        replay_args[key] = value
-                args = replay_args
-            spec = next((tool for tool in ota_context.tools if tool.tool_name == name), None)
-            required = set((getattr(spec, "tool_parameters", None) or {}).get("required") or [])
-            missing = sorted(str(key) for key in required - provided)
-            call = {
-                "id": _view(step, "tool_id") or f"call_{round_index}_{step_index}",
-                "name": name,
-                "arguments": args or {},
-            }
-            return call, omitted, missing
-
-        def step_result(step: Any) -> str:
-            """Render one historical tool result."""
-            error = _view(step, "error")
-            if error or _view(step, "success") is False:
-                return f"failed: {error or 'tool failed'}"
-            result = _view(step, "tool_result")
-            if result is None:
-                return "(no output)"
-            if result == "":
-                return "(awaiting the user's answer)"
-            return str(result)
-
-        def step_summary(call: Dict[str, Any], step: Any, omitted: Dict[str, int], missing: List[str]) -> str:
-            """Summarize a call that must not be replayed as a native tool example."""
-            facts: List[str] = []
-            arguments = call.get("arguments") or {}
-            if arguments:
-                retained = ", ".join(
-                    f"`{name}`: {json.dumps(value, ensure_ascii=False, default=str)}"
-                    for name, value in arguments.items()
-                )
-                facts.append(f"retained arguments {retained}")
-            if omitted:
-                details = ", ".join(
-                    f"`{name}` ({count} characters)" for name, count in omitted.items()
-                )
-                facts.append(f"large arguments not replayed: {details}")
-            if missing:
-                facts.append("missing required arguments: " + ", ".join(f"`{name}`" for name in missing))
-            failed = bool(_view(step, "error")) or _view(step, "success") is False
-            facts.append(f"status: {'failed' if failed else 'succeeded'}")
-            facts.append(f"result: {json.dumps(step_result(step), ensure_ascii=False)}")
-            return f"- `{call['name']}` — " + "; ".join(facts)
+        scope = (think.mode, think.stage)
+        covered = _covered_rounds(records, scope, turn_compaction)
+        projected_records = [item for item in _project_rounds(records, scope) if item.number not in covered]
+        records = [item.record for item in projected_records]
 
         def reasoning_extras(record: Any, mode: Optional[str]) -> Dict[str, Any]:
             """This round's captured reasoning as ``Message.extras`` for replay — an
@@ -1750,11 +1874,11 @@ class MainThink(CognitiveWorker):
                 "through_round",
                 turn_compaction.turn_through_round,
             ))
-        for index, record in enumerate(records, start=round_offset):
+        for item in projected_records:
+            index, record = item.number - 1, item.record
             think = _view(_view(record, "think_result"), "step_content") or ""
             steps = _view(_view(record, "action_result"), "results") or []
             if steps:
-                rendered_steps = [step_call(step, index, i) for i, step in enumerate(steps)]
                 extras = reasoning_extras(record, reasoning_mode)
                 reasoning_items = _view(record, "reasoning_items")
                 if reasoning_items:
@@ -1764,36 +1888,10 @@ class MainThink(CognitiveWorker):
                 reasoning_details = _view(record, "reasoning_details")
                 if reasoning_details:
                     extras = {**extras, "reasoning_details": reasoning_details}
-                if any(omitted or missing for _, omitted, missing in rendered_steps):
-                    activity = "\n".join(
-                        step_summary(call, step, omitted, missing)
-                        for (call, omitted, missing), step in zip(rendered_steps, steps)
-                    )
-                    summary = (
-                        "Completed historical tool activity is summarized as text because "
-                        "native replay would contain omitted or invalid arguments:\n"
-                        f"{activity}\nInspect current files or `<transcript>` when the original tool "
-                        "output is needed."
-                    )
-                    messages.append(Message.from_text(
-                        f"{think}\n\n{summary}" if think else summary,
-                        role=Role.AI,
-                        extras=extras,
-                    ))
-                else:
-                    calls = [call for call, _, _ in rendered_steps]
-                    signatures = _view(record, "thought_signatures")
-                    if signatures and len(signatures) == len(calls):
-                        extras = {**extras, "thought_signatures": list(signatures)}
-                    messages.append(Message.from_tool_call(
-                        tool_calls=calls, text=think or None,
-                        extras=extras,
-                    ))
-                    for (call, _, _), step in zip(rendered_steps, steps):
-                        messages.append(Message.from_tool_result(
-                            tool_id=call["id"],
-                            content=step_result(step),
-                        ))
+                signatures = _view(record, "thought_signatures")
+                if signatures:
+                    extras = {**extras, "thought_signatures": list(signatures)}
+                messages.extend(_tool_round_messages(record, ota_context.tools, f"call_{index}", extras))
             elif think:
                 reasoning_items = _view(record, "reasoning_items")
                 extras = {"reasoning_items": list(reasoning_items)} if reasoning_items else {}
@@ -2006,24 +2104,6 @@ class WorkflowRunThink(MainThink):
         | {"report_workflow_step"}
     )
 
-    def _stage_turn_context(self, ota_context: AmphiOTAContext, mode: str, stage: str) -> Tuple[AmphiOTAContext, Optional[int]]:
-        """Keep only the active automatic Workflow stage's trace."""
-        boundary = next((
-            index
-            for index in range(len(ota_context.ota_record) - 1, -1, -1)
-            if (
-                (scope := self._record_think_scope(ota_context.ota_record[index]))
-                is not None
-                and scope[0] == mode
-                and scope[1] != stage
-            )
-        ), None)
-        if boundary is None:
-            return ota_context, None
-        return ota_context.model_copy(update={
-            "ota_record": list(ota_context.ota_record[boundary + 1:]),
-        }), boundary
-
     async def assemble_messages(
         self,
         ota_context: AmphiOTAContext,
@@ -2040,15 +2120,10 @@ class WorkflowRunThink(MainThink):
             umbrella,
         )
 
-        turn_context, _ = self._stage_turn_context(
-            ota_context,
-            "run_workflow",
-            self.workflow_stage,
-        )
         messages = [Message.from_text(system, role=Role.SYSTEM)]
         messages += await self.session_messages_block(ota_context, context)
         messages.append(await self.current_user_message(ota_context, context))
-        messages += self.turn_messages_block(turn_context, context)
+        messages += self.turn_messages_block(ota_context, context)
         return messages
 
     async def context_blocks(self, ota_context: AmphiOTAContext, context: AmphiContext) -> List[str]:
@@ -2321,55 +2396,6 @@ class BuildThink(MainThink):
         })
     )
 
-    def _stage_turn_context(self, ota_context: AmphiOTAContext, mode: str, stage: str) -> Tuple[AmphiOTAContext, Optional[int]]:
-        """Project one stable Build-stage trace with its entry and switch context."""
-        def switches_to_target(record: Any) -> bool:
-            steps = _view(_view(record, "action_result"), "results") or []
-            for step in steps:
-                if _view(step, "tool_name") != "switch" or _view(step, "success") is False:
-                    continue
-                arguments = _view(step, "tool_arguments") or {}
-                result = _view(step, "tool_result") or {}
-                if str(_view(result, "stage") or _view(arguments, "stage") or "") == stage:
-                    return True
-            return False
-
-        records = ota_context.ota_record
-        scopes = [self._record_think_scope(record) for record in records]
-        target_scope = (mode, stage)
-        mode_indexes = [
-            index for index, scope in enumerate(scopes)
-            if scope is not None and scope[0] == mode
-        ]
-        # The first Build stage owns the pre-Build entry prefix. Keeping that
-        # prefix on later stage re-entry makes persisted compaction boundaries
-        # refer to the same projected-round coordinates for the whole Turn.
-        selected = set(range(len(records))) if not mode_indexes else set()
-        if mode_indexes and scopes[mode_indexes[0]] == target_scope:
-            selected.update(range(mode_indexes[0]))
-        transitions: List[int] = []
-        for index, (record, scope) in enumerate(zip(records, scopes)):
-            if scope == target_scope:
-                selected.add(index)
-            if switches_to_target(record):
-                selected.add(index)
-                transitions.append(index)
-                continue
-            next_scope = scopes[index + 1] if index + 1 < len(scopes) else target_scope
-            if next_scope == target_scope and scope != target_scope:
-                transitions.append(index)
-                # A later cross-mode entry can carry the request that reopened
-                # Build, so retain its immediate handoff round as well.
-                if scope is None or scope[0] != mode:
-                    selected.add(index)
-        projected = [record for index, record in enumerate(records) if index in selected]
-        turn_context = (
-            ota_context
-            if len(projected) == len(records)
-            else ota_context.model_copy(update={"ota_record": projected})
-        )
-        return turn_context, transitions[-1] if transitions else None
-
     def system_block(self, ota_context: AmphiOTAContext, context: AmphiContext) -> str:
         """Render the Build-stage persona with its exact current ToolSurface."""
         tools = self.select_tools(ota_context, context)
@@ -2598,16 +2624,10 @@ class ClarifyThink(BuildThink):
             umbrella,
         )
 
-        turn_context, _ = self._stage_turn_context(
-            ota_context,
-            "build",
-            "clarify",
-        )
-
         messages = [Message.from_text(system, role=Role.SYSTEM)]
         messages += await self.session_messages_block(ota_context, context)
         messages.append(await self.current_user_message(ota_context, context))
-        messages += self.turn_messages_block(turn_context, context)
+        messages += self.turn_messages_block(ota_context, context)
         return messages
 
     async def legality_check(
@@ -2840,16 +2860,10 @@ class ExploreThink(BuildThink):
             umbrella,
         )
 
-        turn_context, _ = self._stage_turn_context(
-            ota_context,
-            "build",
-            "explore",
-        )
-
         messages = [Message.from_text(system, role=Role.SYSTEM)]
         messages += await self.session_messages_block(ota_context, context)
         messages.append(await self.current_user_message(ota_context, context))
-        messages += self.turn_messages_block(turn_context, context)
+        messages += self.turn_messages_block(ota_context, context)
         return messages
 
     async def legality_check(
@@ -2941,16 +2955,10 @@ class GenerateThink(BuildThink):
             umbrella,
         )
 
-        turn_context, _ = self._stage_turn_context(
-            ota_context,
-            "build",
-            "generate",
-        )
-
         messages = [Message.from_text(system, role=Role.SYSTEM)]
         messages += await self.session_messages_block(ota_context, context)
         messages.append(await self.current_user_message(ota_context, context))
-        messages += self.turn_messages_block(turn_context, context)
+        messages += self.turn_messages_block(ota_context, context)
         return messages
 
     async def legality_check(
@@ -3035,16 +3043,10 @@ class VerifyThink(BuildThink):
             umbrella,
         )
 
-        turn_context, _ = self._stage_turn_context(
-            ota_context,
-            "build",
-            "verify",
-        )
-
         messages = [Message.from_text(system, role=Role.SYSTEM)]
         messages += await self.session_messages_block(ota_context, context)
         messages.append(await self.current_user_message(ota_context, context))
-        messages += self.turn_messages_block(turn_context, context)
+        messages += self.turn_messages_block(ota_context, context)
         return messages
 
     async def legality_check(

--- a/src/amphi_agent/_cognitive.py
+++ b/src/amphi_agent/_cognitive.py
@@ -293,9 +293,39 @@ def _project_rounds(records: Sequence[Any], scope: _HistoryScope) -> List[_Histo
                 if (mode, stage) == scope:
                     reason = _view(result, "reason") or _view(arguments, "reason") or ""
                     notes.append(f"[stage handoff] to `{mode}/{stage}`\n{reason}")
-            elif name == "request_build" and scope == ("build", "clarify"):
-                if _view(result, "mode") == "start" or _view(result, "status") == "confirmed":
-                    notes.append(f"[stage handoff] to `build/clarify`\n{_view(result, 'goal') or ''}")
+            elif name == "request_build" and scope[0] == "build":
+                status, action = _view(result, "status"), _view(result, "action")
+                target_stage = None
+                if _view(result, "mode") == "start" or status == "confirmed":
+                    target_stage = "clarify"
+                elif status in {"resolved", "not_answered"}:
+                    if action in {"keep", "not_answered"}:
+                        target_stage = _view(result, "existing_stage")
+                    elif action in {"merge", "replace"}:
+                        target_stage = "clarify"
+                if scope[1] != target_stage:
+                    continue
+                lines = []
+                # A kept Build must not inherit the competing proposal as its goal.
+                if action not in {"keep", "not_answered"} and (goal := _view(result, "goal")):
+                    lines.append(f"Workflow goal: {goal}")
+                for key in ("message", "response", "user_message"):
+                    text = str(_view(result, key) or "").strip()
+                    if text and not any(text in line for line in lines):
+                        lines.append(text)
+                if status == "not_answered":
+                    if prompt := _view(result, "reason"):
+                        lines.append(f"Context: {prompt}")
+                    for question in _view(result, "questions") or []:
+                        text = str(_view(question, "question") or "").strip()
+                        if not text:
+                            continue
+                        options = "; ".join(
+                            f"{index}. {_view(option, 'label')}"
+                            for index, option in enumerate(_view(question, "options") or [], 1)
+                        )
+                        lines.append(f"Question: {text}" + (f" Options: {options}" if options else ""))
+                notes.append(f"[stage handoff] to `build/{target_stage}`\n" + "\n".join(lines))
             elif name == "request_run_workflow" and scope == ("run_workflow", "execute"):
                 status = _view(result, "status")
                 if status in {"started", "resumed", "restarted"}:
@@ -395,6 +425,32 @@ def _turn_has_scope(turn: Any, scope: _HistoryScope) -> bool:
         return True
     think = state.get("think") or {}
     return not turn.ota_records and (think.get("mode", "normal"), think.get("stage", "main")) == scope
+
+
+def _project_turn_history(records: Sequence[Any], compaction: Optional[ContextCompactionState], scopes: Sequence[_HistoryScope]) -> Tuple[List[Tuple[_HistoryScope, TurnCompactionState]], List[_HistoryRound]]:
+    """Merge read views in journal order, applying each owner's own Turn coverage."""
+    summaries = []
+    remaining: Dict[Tuple[int, str], _HistoryRound] = {}
+    covered_unscoped: set[int] = set()
+    for scope in scopes:
+        projection = compaction.turn.get(scope[0], {}).get(scope[1]) if compaction else None
+        covered = _covered_rounds(records, scope, projection)
+        if projection is not None and projection.turn_summary:
+            summaries.append((scope, projection))
+        # Legacy unscoped records can appear in both views. A summary already
+        # representing such a record must not cause it to expand via the other view.
+        covered_unscoped.update(
+            number for number in covered
+            if 0 < number <= len(records) and _record_scope(records[number - 1]) is None
+        )
+        for item in _project_rounds(records, scope):
+            if item.number in covered:
+                continue
+            # Keep a stage's natural-language handoff alongside the shared raw
+            # result, but replay overlapping native call/result pairs only once.
+            note = str(_view(_view(item.record, "think_result"), "step_content") or "") if _view(item.record, "history_handoff") else ""
+            remaining.setdefault((item.number, note), item)
+    return summaries, [remaining[key] for key in sorted(remaining) if key[0] not in covered_unscoped]
 
 
 def _node_environment_summary(workspace: Optional[Any]) -> str:
@@ -1014,7 +1070,7 @@ class MainThink(CognitiveWorker):
                     "state": projected_state,
                 })
                 payload = trim_text(
-                    serialize_messages(self.turn_messages_block(projected, context)),
+                    serialize_messages(self.turn_messages_block(projected, context, include_shared=False)),
                     unit_tokens,
                 )
                 units.append((
@@ -1040,25 +1096,26 @@ class MainThink(CognitiveWorker):
             })
             return True
 
-        async def reassemble() -> List[Message]:
-            rebuilt = await self.assemble_messages(ota_context, context)
-            return await self.append_runtime_state(rebuilt, ota_context, context)
-
         stream = getattr(ota_context, "stream", None)
         if stream is not None:
             stream.publish("context_compaction", active=True)
         try:
+            validated_context: Optional[AmphiOTAContext] = None
             session_changed = await compact_session_history()
             turn_changed = await compact_turn_history()
             if session_changed or turn_changed:
-                ota_context.state.context_compaction = candidate
-                compacted_messages = await reassemble()
+                # Rebuild privately so cancellation or failure cannot publish an unchecked candidate.
+                projected = ota_context.model_copy(update={
+                    "state": ota_context.state.model_copy(update={"context_compaction": candidate}),
+                })
+                compacted_messages = await self.assemble_messages(projected, context)
+                compacted_messages = await self.append_runtime_state(compacted_messages, projected, context)
                 compacted_tokens = self._estimate_request_tokens(compacted_messages, tools)
                 if compacted_tokens < before_tokens:
                     messages = compacted_messages
                     before_tokens = compacted_tokens
+                    validated_context = projected
                 else:
-                    ota_context.state.context_compaction = original_compaction
                     logger.warning(
                         "Discarded context compaction without a net token reduction: before=%s after=%s",
                         before_tokens,
@@ -1073,6 +1130,12 @@ class MainThink(CognitiveWorker):
                     before_tokens,
                     target,
                 )
+            if validated_context is not None:
+                # Commit both scopes and their assembly metadata together, with no intervening await.
+                ota_context.tools = validated_context.tools
+                ota_context.selected_skill_dirs = validated_context.selected_skill_dirs
+                ota_context.prompt_time = validated_context.prompt_time
+                ota_context.state.context_compaction = candidate
             return messages
         finally:
             if stream is not None:
@@ -1623,33 +1686,31 @@ class MainThink(CognitiveWorker):
         return f"<transcript>\n{os.path.join(root, 'history.md')}\n</transcript>"
 
     async def session_messages_block(self, ota_context: AmphiOTAContext, context: AmphiContext) -> List[Message]:
-        """Replay only the active stage's Session summary and compacted historical Turns."""
+        """Clarify also reads Normal; every source retains its own Session boundary."""
         turns = context.session.get_all()
         think = ota_context.think_status
         scope = (think.mode, think.stage)
-        compaction = _session_projection(ota_context.state.context_compaction, turns, scope)
-        if not compaction.session_summary:
-            return self._session_messages(turns, context, scope, ota_context.tools)
-        remaining = [
-            turn
-            for turn in turns
-            if turn.session_ordinal > compaction.session_through_ordinal
-        ]
-        return [
-            self._compaction_summary_message(
-                "session_history",
-                compaction.session_summary,
-                "through_ordinal",
-                compaction.session_through_ordinal,
-            ),
-            *self._session_messages(remaining, context, scope, ota_context.tools),
-        ]
+        scopes = [("normal", "main"), scope] if scope == ("build", "clarify") else [scope]
+        projections = {
+            source: _session_projection(ota_context.state.context_compaction, turns, source)
+            for source in scopes
+        }
+        messages = []
+        for source, projection in projections.items():
+            if projection.session_summary:
+                messages.append(self._compaction_summary_message(
+                    "session_history", projection.session_summary, "through_ordinal", projection.session_through_ordinal,
+                    owner=source if len(scopes) > 1 else None,
+                ))
+        messages.extend(self._session_messages(turns, context, scope, ota_context.tools, session_projections=projections))
+        return messages
 
     @staticmethod
-    def _compaction_summary_message(scope: str, summary: str, through_name: str, through: int) -> Message:
+    def _compaction_summary_message(scope: str, summary: str, through_name: str, through: int, owner: Optional[_HistoryScope] = None) -> Message:
         """Render one persisted summary as low-authority Assistant history."""
+        owner_attribute = f' owner="{owner[0]}/{owner[1]}"' if owner else ""
         content = (
-            f"<{scope}_summary {through_name}=\"{through}\">\n"
+            f"<{scope}_summary {through_name}=\"{through}\"{owner_attribute}>\n"
             f"{summary.strip()}\n"
             f"</{scope}_summary>"
         )
@@ -1661,29 +1722,45 @@ class MainThink(CognitiveWorker):
         context: AmphiContext,
         scope: _HistoryScope = ("normal", "main"),
         tools: Sequence[ToolSpec] = (),
+        *,
+        session_projections: Optional[Dict[_HistoryScope, SessionCompactionState]] = None,
     ) -> List[Message]:
-        """Project a stage's historical Turns without importing another stage's execution history."""
+        """Merge requested read views; compaction callers request only their own scope."""
+        projections = session_projections if session_projections is not None else {scope: SessionCompactionState()}
         messages: List[Message] = []
         for turn in turns:
-            if not _turn_has_scope(turn, scope):
+            scopes = [
+                source for source, projection in projections.items()
+                if (not projection.session_summary or turn.session_ordinal > projection.session_through_ordinal)
+                and _turn_has_scope(turn, source)
+            ]
+            if not scopes:
                 continue
             ota = turn.ota_context_dump()
             records = ota.get("ota_record") or []
+            data = (turn.agent_state or {}).get("context_compaction")
+            compaction = ContextCompactionState.model_validate(data) if data else None
+            summaries, remaining = _project_turn_history(records, compaction, scopes)
+            if len(projections) > 1 and any(
+                projection.session_summary and turn.session_ordinal <= projection.session_through_ordinal
+                for projection in projections.values()
+            ):
+                # Unscoped legacy rounds covered by a shared Session summary
+                # must not reopen through the other source's retention window.
+                remaining = [item for item in remaining if _record_scope(item.record) is not None]
+                if records and not summaries and not remaining:
+                    continue
             messages.append(self._user_message(
                 turn.user_input,
                 self._render_user_input(turn.user_input, context),
                 context,
                 reject_unsupported=False,
             ))
-            data = (turn.agent_state or {}).get("context_compaction")
-            compaction = ContextCompactionState.model_validate(data) if data else None
-            projection = compaction.turn.get(scope[0], {}).get(scope[1]) if compaction else None
-            covered = _covered_rounds(records, scope, projection)
-            if projection is not None and projection.turn_summary:
+            for source, projection in summaries:
                 messages.append(self._compaction_summary_message(
                     "turn_history", projection.turn_summary, "through_round", projection.turn_through_round,
+                    owner=source if len(projections) > 1 else None,
                 ))
-            remaining = [item for item in _project_rounds(records, scope) if item.number not in covered]
             ota["ota_record"] = [item.record for item in remaining]
             messages.extend(self._ota_messages(ota, turn.session_ordinal, [item.number for item in remaining], tools))
             if turn.status == TurnStatus.FAILED:
@@ -1829,13 +1906,15 @@ class MainThink(CognitiveWorker):
             reject_unsupported=True,
         )
 
-    def turn_messages_block(self, ota_context: AmphiOTAContext, context: AmphiContext) -> List[Message]:
+    def turn_messages_block(self, ota_context: AmphiOTAContext, context: AmphiContext, *, include_shared: bool = True) -> List[Message]:
         """Render this turn's completed rounds for the next model call.
 
         Calls with complete, bounded arguments remain native AI/TOOL pairs. A
         round containing large omitted values or missing required arguments is
         rendered as an AI text summary so replay never teaches the model an
-        invalid tool-call shape. Observations remain trailing USER notes::
+        invalid tool-call shape. Clarify additionally reads Normal's compacted
+        view, unless the caller is collecting only its own compaction inputs.
+        Observations remain trailing USER notes::
 
             AI    "<thought>" + ToolCallBlock(id, name, args)…  (a round that acted)
             TOOL  ToolResultBlock(id, "<result>")               (one per call, paired by id)
@@ -1845,14 +1924,10 @@ class MainThink(CognitiveWorker):
         records = ota_context.ota_record
         compaction = ota_context.state.context_compaction
         think = ota_context.think_status
-        turn_compaction = (
-            compaction.turn.get(think.mode, {}).get(think.stage)
-            if compaction is not None
-            else None
-        )
         scope = (think.mode, think.stage)
-        covered = _covered_rounds(records, scope, turn_compaction)
-        projected_records = [item for item in _project_rounds(records, scope) if item.number not in covered]
+        # Sharing changes only the read view. The compactor explicitly opts out.
+        scopes = [("normal", "main"), scope] if include_shared and scope == ("build", "clarify") else [scope]
+        summaries, projected_records = _project_turn_history(records, compaction, scopes)
         records = [item.record for item in projected_records]
 
         def reasoning_extras(record: Any, mode: Optional[str]) -> Dict[str, Any]:
@@ -1886,12 +1961,13 @@ class MainThink(CognitiveWorker):
                 break
 
         messages: List[Message] = []
-        if turn_compaction is not None and turn_compaction.turn_summary:
+        for source, turn_compaction in summaries:
             messages.append(self._compaction_summary_message(
                 "turn_history",
                 turn_compaction.turn_summary,
                 "through_round",
                 turn_compaction.turn_through_round,
+                owner=source if len(scopes) > 1 else None,
             ))
         for item in projected_records:
             index, record = item.number - 1, item.record
@@ -2582,7 +2658,7 @@ class BuildThink(MainThink):
 
 
 class ClarifyThink(BuildThink):
-    """Clarify requirements and maintain this build's task definition."""
+    """Clarify requirements, reading Normal's history without owning its compaction."""
 
     persona: str = CLARIFY_PERSONA
     allowed_tools = BuildThink.allowed_tools | {
@@ -2624,9 +2700,11 @@ class ClarifyThink(BuildThink):
             SYSTEM  clarify persona
                     + <context> containing transcript, skills, artifacts, memory,
                       Build workspace, and Session workspace
-            ...     persisted session messages in their native roles
+            ...     Normal and Clarify Session summaries and retained history,
+                    merged in journal order with independent coverage
             USER    current user input
-            ...     current-Clarify assistant and tool-result messages
+            ...     Normal and Clarify Turn summaries and retained rounds,
+                    each governed by its owner's compaction
 
         """
         ota_context.tools = list(self.select_tools(ota_context, context))

--- a/src/amphi_agent/_cognitive.py
+++ b/src/amphi_agent/_cognitive.py
@@ -23,6 +23,7 @@ from ._context import (
     AmphiContext,
     AmphiOTAContext,
     ContextUsageBreakdown,
+    ContextUsageReference,
     ContextUsageSnapshot,
     _view,
 )
@@ -751,14 +752,26 @@ class MainThink(CognitiveWorker):
         )
 
     def _project_context_usage(self, ota_context: AmphiOTAContext, request_estimate: int, model_id: str) -> Tuple[int, str]:
-        """Combine the last measured occupancy with newly estimated prompt growth."""
-        previous = ota_context.context_usage
-        if previous.used_tokens <= 0 or previous.model_id != model_id:
+        """Calibrate this request using only the active stage's same-model reference.
+
+        Never infer ownership from a legacy global snapshot: the stage may have
+        switched after its model call. Scaling the current estimate allows both
+        prompt growth and shrinkage without retaining an old absolute high-water mark.
+        """
+        think = ota_context.think_status
+        reference = ota_context.context_usage.stage_references.get(think.mode, {}).get(think.stage)
+        if (
+            reference is None
+            or reference.model_id != model_id
+            or reference.input_tokens <= 0
+            or reference.estimated_input_tokens <= 0
+        ):
             return request_estimate, "estimated"
-        growth = max(0, request_estimate - previous.estimated_occupied_tokens)
-        scale = max(1.0, previous.used_tokens / max(1, previous.estimated_occupied_tokens))
-        projected = previous.used_tokens + math.ceil(growth * scale)
-        return max(request_estimate, projected), previous.source
+        # Integer ceiling avoids rounding an unchanged reference over its threshold.
+        projected = (
+            request_estimate * reference.input_tokens + reference.estimated_input_tokens - 1
+        ) // reference.estimated_input_tokens
+        return max(request_estimate, projected), "provider"
 
     async def _prepare_context_window(self, messages: List[Message], tools: List[Any], ota_context: AmphiOTAContext, context: AmphiContext) -> Tuple[List[Message], int]:
         """Run the shared preflight after every worker has assembled its final request."""
@@ -803,13 +816,8 @@ class MainThink(CognitiveWorker):
         """Compact both growing history scopes with bounded rolling summaries."""
         before_tokens = self._estimate_request_tokens(messages, tools)
         input_capacity = context.llm_provider.input_capacity()
-        previous_usage = ota_context.context_usage
-        measured_over_target = (
-            previous_usage.model_id == context.llm_provider.model_id
-            and previous_usage.source == "provider"
-            and previous_usage.used_tokens > target
-        )
-        if before_tokens <= target and not measured_over_target:
+        projected_tokens, _ = self._project_context_usage(ota_context, before_tokens, context.llm_provider.model_id)
+        if projected_tokens <= target:
             return messages
 
         summary_input_tokens = (
@@ -1129,6 +1137,16 @@ class MainThink(CognitiveWorker):
             round(used_tokens / usable_tokens * 100, 1)
             if usable_tokens is not None else None
         )
+        # Keep compaction calibration separate from the latest UI snapshot and
+        # cumulative billing totals. Auxiliary summary calls do not update it.
+        references = {mode: dict(stages) for mode, stages in previous.stage_references.items()}
+        if has_provider_input and request_estimate > 0:
+            think = ota_context.think_status
+            references.setdefault(think.mode, {})[think.stage] = ContextUsageReference(
+                model_id=context.llm_provider.model_id,
+                input_tokens=provider_input_tokens,
+                estimated_input_tokens=request_estimate,
+            )
         snapshot = ContextUsageSnapshot(
             model_id=context.llm_provider.model_id,
             input_tokens=total_input_tokens,
@@ -1142,6 +1160,7 @@ class MainThink(CognitiveWorker):
             source=source,
             estimated_occupied_tokens=request_estimate,
             breakdown=scale_breakdown(input_tokens),
+            stage_references=references,
         )
         ota_context.context_usage = snapshot
         stream = getattr(ota_context, "stream", None)

--- a/src/amphi_agent/_context.py
+++ b/src/amphi_agent/_context.py
@@ -43,8 +43,16 @@ class ContextUsageBreakdown(BaseModel):
     current_input_tokens: int = 0
 
 
+class ContextUsageReference(BaseModel):
+    """A stage's latest provider input count and the estimate of that same request."""
+
+    model_id: str = ""
+    input_tokens: int = Field(default=0, ge=0)
+    estimated_input_tokens: int = Field(default=0, ge=0)
+
+
 class ContextUsageSnapshot(BaseModel):
-    """Turn totals plus the latest call's input occupancy and composition."""
+    """Turn totals, latest displayed occupancy, and stage-owned compaction references."""
 
     model_id: str = ""
     input_tokens: int = 0
@@ -58,6 +66,7 @@ class ContextUsageSnapshot(BaseModel):
     source: Literal["provider", "estimated"] = "estimated"
     estimated_occupied_tokens: int = 0
     breakdown: ContextUsageBreakdown = Field(default_factory=ContextUsageBreakdown)
+    stage_references: Dict[str, Dict[str, ContextUsageReference]] = Field(default_factory=dict)
 
 
 class AmphiOTAContext(OTAContext):

--- a/src/amphi_agent/_state.py
+++ b/src/amphi_agent/_state.py
@@ -9,7 +9,7 @@ __all__ = [
     "AwaitingWorkflowConfirm", "AwaitingBuildConfirm",
     "AwaitingBuildConflict", "AwaitingWorkflowRunChoice",
     "SubAgentCall", "AwaitingSubAgent", "SubAgentResult", "SubAgentsCompleted", "AgentResult",
-    "AgentState", "ContextCompactionState", "TurnCompactionState",
+    "AgentState", "ContextCompactionState", "TurnCompactionState", "SessionCompactionState",
     "CallVerdict", "RoundPermission",
 ]
 
@@ -273,13 +273,22 @@ class TurnCompactionState(BaseModel):
 
     turn_summary: str = ""
     turn_through_round: int = Field(default=0, ge=0)
+    turn_covered_rounds: Optional[List[int]] = Field(default=None, description="One-based positions in the durable Turn, not stage-local offsets.")
 
 
-class ContextCompactionState(BaseModel):
-    """Persisted prompt projection for compacted Session and current-Turn history."""
+class SessionCompactionState(BaseModel):
+    """One stage's summary of its historical Turns in this Session."""
 
     session_summary: str = ""
     session_through_ordinal: int = Field(default=-1, ge=-1)
+
+
+class ContextCompactionState(BaseModel):
+    """Stage-owned Session/current-Turn summaries; flat Session fields are legacy read-only data."""
+
+    session_summary: str = ""
+    session_through_ordinal: int = Field(default=-1, ge=-1)
+    session: Dict[str, Dict[str, SessionCompactionState]] = Field(default_factory=dict)
     turn: Dict[str, Dict[str, TurnCompactionState]] = Field(default_factory=dict)
 
 

--- a/tests/agent/cognitive/test_compaction.py
+++ b/tests/agent/cognitive/test_compaction.py
@@ -146,11 +146,12 @@ async def test_compacts_session_and_turn_together_while_protecting_recent_suffix
 
     state = ota_context.state.context_compaction
     assert state is not None
-    assert state.session_summary == "Compacted Session facts"
-    assert state.session_through_ordinal == 1
+    assert state.session["normal"]["main"].session_summary == "Compacted Session facts"
+    assert state.session["normal"]["main"].session_through_ordinal == 1
     turn_state = state.turn["normal"]["main"]
     assert turn_state.turn_summary == "Compacted current-Turn progress"
     assert turn_state.turn_through_round == 2
+    assert turn_state.turn_covered_rounds == [1, 2]
     assert len(llm.calls) == 2
     assert all(call[0].content.startswith("You turn historical agent context") for call in llm.calls)
     assert all("substantially shorter" in call[0].content for call in llm.calls)
@@ -213,6 +214,7 @@ async def test_turn_compaction_is_isolated_by_mode_and_stage(test_sandbox: Isola
     explore_state = compaction.turn["build"]["explore"]
     assert explore_state.turn_summary == "Compacted Explore history"
     assert explore_state.turn_through_round == 2
+    assert explore_state.turn_covered_rounds == [7, 8]
 
     ota_context.ota_record.append(record("clarify", 6))
     ota_context.transition_think(BuildStageState(stage="clarify"))
@@ -264,8 +266,9 @@ async def test_initial_build_stage_compaction_boundary_survives_stage_reentry(te
     compaction = ota_context.state.context_compaction
     assert compaction is not None
     clarify_state = compaction.turn["build"]["clarify"]
-    assert clarify_state.turn_through_round == 3
-    assert "normal/main round 0" in llm.calls[0][1].content
+    assert clarify_state.turn_through_round == 2
+    assert clarify_state.turn_covered_rounds == [2, 3]
+    assert "normal/main round 0" not in llm.calls[0][1].content
 
     handoff = record("build", "explore", 0)
     handoff.action_result = ActionResult(results=[ActionStepResult(
@@ -281,7 +284,8 @@ async def test_initial_build_stage_compaction_boundary_survives_stage_reentry(te
     contents = [message.content for message in messages]
     assert any("Compacted Clarify history" in content for content in contents)
     assert not any("build/clarify round 0" in content for content in contents)
-    assert any("build/explore round 0" in content for content in contents)
+    assert not any("build/explore round 0" in content for content in contents)
+    assert any("[stage handoff]" in content for content in contents)
     assert any("build/clarify round 2" in content for content in contents)
 
 
@@ -307,7 +311,7 @@ async def test_summary_input_is_bounded_when_one_atomic_turn_is_huge(test_sandbo
     assert worker._estimate_request_tokens(llm.calls[0], []) <= 10_000
     assert "bytes omitted during compaction" in llm.calls[0][1].content
     assert ota_context.state.context_compaction is not None
-    assert ota_context.state.context_compaction.session_through_ordinal == 0
+    assert ota_context.state.context_compaction.session["normal"]["main"].session_through_ordinal == 0
 
 
 async def test_summary_failure_uses_a_bounded_fallback_and_advances(test_sandbox: IsolatedPaths) -> None:
@@ -326,8 +330,8 @@ async def test_summary_failure_uses_a_bounded_fallback_and_advances(test_sandbox
 
     state = ota_context.state.context_compaction
     assert state is not None
-    assert state.session_through_ordinal == 0
-    assert state.session_summary
+    assert state.session["normal"]["main"].session_through_ordinal == 0
+    assert state.session["normal"]["main"].session_summary
     assert worker._estimate_request_tokens(compacted, []) < worker._estimate_request_tokens(original, [])
 
 

--- a/tests/agent/cognitive/test_compaction.py
+++ b/tests/agent/cognitive/test_compaction.py
@@ -8,15 +8,17 @@ from bridgic.amphibious import ActionResult, ActionStepResult, OTARecord
 from bridgic.core.model.types import Message
 
 from src.amphi_agent import (
+    AmphiAgent,
     AmphiContext,
     AmphiOTAContext,
+    ContextUsageBreakdown,
     ContextWindowExceededError,
     LlmProvider,
     MainThink,
     Session,
 )
-from src.amphi_agent._cognitive import ClarifyThink, ExploreThink
-from src.amphi_agent._state import BuildStageState
+from src.amphi_agent._cognitive import ClarifyThink, ExploreThink, VerifyThink
+from src.amphi_agent._state import BuildStageState, NormalStageState, WorkflowStageState
 from src.amphi_agent.prompts.compaction import (
     render_session_compaction_prompt,
     render_turn_compaction_prompt,
@@ -117,6 +119,160 @@ def _context(root: str, turns: list[SessionTurnRecord], capacity: int) -> AmphiC
             model_limits={"input": capacity},
         ),
     )
+
+
+def _record_usage(worker: MainThink, ota: AmphiOTAContext, context: AmphiContext, counts: tuple[int, int]) -> None:
+    provider_input, estimate = counts
+    result = StreamResult(content="Completed round", tool_calls=[], usage=SimpleNamespace(input_tokens=provider_input, output_tokens=3))
+    worker._record_model_usage(ota, context, result, estimate, ContextUsageBreakdown(dynamic_context_tokens=estimate))
+
+
+def test_usage_references_follow_stage_visits_without_changing_display(test_sandbox: IsolatedPaths) -> None:
+    """Each stage owns its calibration; visiting it does not rewrite the latest UI snapshot."""
+    context = _context(str(test_sandbox.sessions / "usage-scopes"), [], 200_000)
+    ota = AmphiOTAContext(stream=EventStream())
+    worker = MainThink()
+    visits = [
+        (NormalStageState(), (150_000, 100_000), 30_000),
+        (BuildStageState(stage="generate"), (190_000, 190_000), 20_000),
+        (BuildStageState(stage="verify"), (80_000, 40_000), 40_000),
+        (WorkflowStageState(workflow_id="workflow", generation="generation"), (100_000, 80_000), 25_000),
+    ]
+    for status, counts, expected in visits:
+        ota.transition_think(status)
+        assert worker._project_context_usage(ota, 20_000, context.llm_provider.model_id) == (20_000, "estimated")
+        _record_usage(worker, ota, context, counts)
+        assert worker._project_context_usage(ota, 20_000, context.llm_provider.model_id) == (expected, "provider")
+    latest = ota.context_usage.model_dump(mode="json")
+    events = deepcopy(ota.stream.events)
+    for status, _, expected in visits:
+        ota.transition_think(status)
+        assert worker._project_context_usage(ota, 20_000, context.llm_provider.model_id) == (expected, "provider")
+    assert ota.context_usage.model_dump(mode="json") == latest
+    assert ota.stream.events == events
+    assert len(events) == len(visits)
+    assert ota.context_usage.input_tokens == sum(counts[0] for _, counts, _ in visits)
+    assert ota.context_usage.output_tokens == 3 * len(visits)
+
+
+@pytest.mark.parametrize("provider_input,old_estimate,new_estimate,expected", [
+    (190_000, 190_000, 20_000, 20_000),
+    (190_000, 100_000, 20_000, 38_000),
+    (90_000, 100_000, 20_000, 20_000),
+    (190_000, 100_000, 120_000, 228_000),
+])
+def test_usage_projection_tracks_growth_and_shrinkage(test_sandbox: IsolatedPaths, provider_input: int, old_estimate: int, new_estimate: int, expected: int) -> None:
+    """Calibrate today's prompt size rather than retaining yesterday's absolute occupancy."""
+    context = _context(str(test_sandbox.sessions / "usage-size"), [], 200_000)
+    ota = AmphiOTAContext()
+    worker = MainThink()
+    _record_usage(worker, ota, context, (provider_input, old_estimate))
+    assert worker._project_context_usage(ota, new_estimate, context.llm_provider.model_id) == (expected, "provider")
+    assert ota.context_usage.used_tokens == provider_input
+
+
+def test_missing_provider_usage_does_not_overwrite_a_measured_reference(test_sandbox: IsolatedPaths) -> None:
+    """An estimated UI snapshot must not masquerade as a new provider calibration."""
+    context = _context(str(test_sandbox.sessions / "missing-counter"), [], 200_000)
+    ota = AmphiOTAContext()
+    worker = MainThink()
+    _record_usage(worker, ota, context, (80_000, 40_000))
+    previous = ota.context_usage.model_dump(mode="json")
+    result = StreamResult(content="No usage this time", tool_calls=[], usage=None)
+    worker._record_model_usage(ota, context, result, 20_000, ContextUsageBreakdown(dynamic_context_tokens=20_000))
+    assert ota.context_usage.source == "estimated"
+    assert ota.context_usage.used_tokens == 20_000
+    assert ota.context_usage.model_dump(mode="json")["stage_references"] == previous["stage_references"]
+    assert worker._project_context_usage(ota, 10_000, context.llm_provider.model_id) == (20_000, "provider")
+    assert ota.context_usage.input_tokens == previous["input_tokens"]
+    assert ota.context_usage.output_tokens == previous["output_tokens"]
+
+
+@pytest.mark.parametrize("reference", ["foreign_stage", "shrinking_stage", "legacy", "other_model", "zero_estimate"])
+async def test_small_stage_does_not_compact_from_an_unrelated_high_water_mark(test_sandbox: IsolatedPaths, reference: str) -> None:
+    """Both the preflight and compactor guard must reject a stale 95% trigger."""
+    records = []
+    for index in range(6):
+        record = OTARecord(think_result={"step_content": f"Verify {index}: " + "Known verification facts. " * 100, "tool_calls": []})
+        record.think_scope = {"mode": "build", "stage": "verify", "session_history": "stage_scoped_v2"}
+        records.append(record)
+    context = _context(str(test_sandbox.sessions / "small-stage"), [], 200_000)
+    ota = AmphiOTAContext(user_input="Continue", ota_record=records, state={"think": {"mode": "build", "stage": "verify"}})
+    llm = SummaryLlm("Unnecessary summary")
+    worker = VerifyThink(llm)
+    if reference == "foreign_stage":
+        ota.transition_think(BuildStageState(stage="generate"))
+    _record_usage(worker, ota, context, (190_000, 0 if reference == "zero_estimate" else 190_000))
+    ota.transition_think(BuildStageState(stage="verify"))
+    if reference == "legacy":
+        # Old snapshots have no reliable owner: the final Think cursor may already have switched.
+        dump = ota.context_usage.model_dump(mode="json")
+        dump.pop("stage_references", None)
+        ota.context_usage = type(ota.context_usage).model_validate(dump)
+    elif reference == "other_model":
+        context.llm_provider = LlmProvider(model_id="other-model", model_limits={"input": 200_000})
+    messages = await worker.assemble_messages(ota, context)
+    messages = await worker.append_runtime_state(messages, ota, context)
+    tools = [spec.to_tool() for spec in ota.tools]
+    estimate = worker._estimate_request_tokens(messages, tools)
+    assert estimate < 100_000
+    prepared, _ = await worker._prepare_context_window(messages, tools, ota, context)
+    assert prepared == messages
+    assert await worker.compact_messages(messages, tools, ota, context, target=120_000) == messages
+    assert not llm.calls
+    assert ota.state.context_compaction is None
+    assert ota.context_usage.used_tokens == 190_000
+
+
+async def test_current_stage_calibration_still_compacts_and_does_not_retrigger(test_sandbox: IsolatedPaths) -> None:
+    """A real 95% same-stage reference triggers once; the smaller rebuilt request can fall below it."""
+    records = []
+    for index in range(6):
+        record = OTARecord(think_result={"step_content": f"Verify {index}: " + "Known verification facts. " * 100, "tool_calls": []})
+        record.think_scope = {"mode": "build", "stage": "verify", "session_history": "stage_scoped_v2"}
+        records.append(record)
+    context = _context(str(test_sandbox.sessions / "large-stage"), [], 200_000)
+    ota = AmphiOTAContext(user_input="Continue", ota_record=records, state={"think": {"mode": "build", "stage": "verify"}})
+    llm = SummaryLlm("Earlier verification facts")
+    worker = VerifyThink(llm)
+    messages = await worker.assemble_messages(ota, context)
+    messages = await worker.append_runtime_state(messages, ota, context)
+    tools = [spec.to_tool() for spec in ota.tools]
+    estimate = worker._estimate_request_tokens(messages, tools)
+    _record_usage(worker, ota, context, (190_000, estimate))
+    references = deepcopy(ota.context_usage.stage_references)
+    rebuilt, reduced_estimate = await worker._prepare_context_window(messages, tools, ota, context)
+    assert len(llm.calls) == 1
+    assert ota.state.context_compaction.turn["build"]["verify"].turn_covered_rounds == [1, 2]
+    assert reduced_estimate < estimate
+    assert worker._project_context_usage(ota, reduced_estimate, context.llm_provider.model_id)[0] < 190_000
+    assert ota.context_usage.stage_references == references
+    assert ota.context_usage.used_tokens == 190_000
+    await worker._prepare_context_window(rebuilt, tools, ota, context)
+    assert len(llm.calls) == 1
+
+
+@pytest.mark.parametrize("status", [TurnStatus.COMPLETED, TurnStatus.FAILED, TurnStatus.CANCELLED])
+async def test_stage_usage_references_survive_new_turns(test_sandbox: IsolatedPaths, status: TurnStatus) -> None:
+    """Durable references survive terminal Turns while actual token totals still reset."""
+    context = _context(str(test_sandbox.sessions / "usage-resume"), [], 200_000)
+    ota = AmphiOTAContext()
+    worker = MainThink()
+    _record_usage(worker, ota, context, (150_000, 100_000))
+    ota.transition_think(BuildStageState(stage="verify"))
+    _record_usage(worker, ota, context, (80_000, 40_000))
+    ota.transition_think(NormalStageState())
+    previous = _turn(context.session.id, 0, "Previous turn")
+    previous.status = status
+    previous.agent_state = ota.state.model_dump(mode="json")
+    previous.context_usage = ota.context_usage.model_dump(mode="json")
+    context = _context(str(test_sandbox.sessions / "usage-resume"), [previous], 200_000)
+    current = AmphiOTAContext(user_input="Continue")
+    await AmphiAgent().init_state(current, context)
+    assert current.context_usage.input_tokens == current.context_usage.output_tokens == 0
+    assert worker._project_context_usage(current, 20_000, context.llm_provider.model_id) == (30_000, "provider")
+    current.transition_think(BuildStageState(stage="verify"))
+    assert worker._project_context_usage(current, 20_000, context.llm_provider.model_id) == (40_000, "provider")
 
 
 async def test_compacts_session_and_turn_together_while_protecting_recent_suffixes(test_sandbox: IsolatedPaths) -> None:

--- a/tests/agent/cognitive/test_compaction.py
+++ b/tests/agent/cognitive/test_compaction.py
@@ -1,3 +1,4 @@
+import asyncio
 from collections import deque
 from copy import deepcopy
 from types import SimpleNamespace
@@ -18,7 +19,8 @@ from src.amphi_agent import (
     Session,
 )
 from src.amphi_agent._cognitive import ClarifyThink, ExploreThink, VerifyThink
-from src.amphi_agent._state import BuildStageState, NormalStageState, WorkflowStageState
+from src.amphi_agent._invocation import AgentInvocation
+from src.amphi_agent._state import BuildStageState, ContextCompactionState, NormalStageState, WorkflowStageState
 from src.amphi_agent.prompts.compaction import (
     render_session_compaction_prompt,
     render_turn_compaction_prompt,
@@ -327,6 +329,118 @@ async def test_compacts_session_and_turn_together_while_protecting_recent_suffix
         ("context_compaction", {"active": True}),
         ("context_compaction", {"active": False}),
     ]
+
+
+@pytest.fixture(params=[False, True], ids=["fresh", "previous_summary"])
+async def compaction_attempt(request: pytest.FixtureRequest, test_sandbox: IsolatedPaths):
+    """Prepare both history scopes with optional previously committed summaries."""
+    content = "Historical task facts. " * 200
+    turns = [_turn("session-compaction-policy", index, content) for index in range(6)]
+    records = [OTARecord(think_result={"step_content": content, "tool_calls": []}) for _ in range(6)]
+    ota = AmphiOTAContext(user_input="Continue", ota_record=records, stream=EventStream())
+    if request.param:
+        ota.state.context_compaction = ContextCompactionState.model_validate({
+            "session": {"normal": {"main": {"session_summary": "Old Session summary", "session_through_ordinal": 0}}},
+            "turn": {"normal": {"main": {"turn_summary": "Old Turn summary", "turn_through_round": 1, "turn_covered_rounds": [1]}}},
+        })
+    context = _context(str(test_sandbox.sessions / "atomic-compaction"), turns, 200_000)
+    llm = SummaryLlm("New Session summary", "New Turn summary")
+    worker = MainThink(llm)
+    messages = await worker.assemble_messages(ota, context)
+    return worker, ota, context, messages
+
+
+@pytest.mark.parametrize("stop_at", ["session_summary", "turn_summary", "reassembly", "runtime_state"])
+async def test_compaction_stop_preserves_the_committed_state(compaction_attempt, monkeypatch: pytest.MonkeyPatch, stop_at: str) -> None:
+    """Stop at an actual await point; no candidate may leak into the cancellation checkpoint."""
+    worker, ota, context, messages = compaction_attempt
+    original = ota.state.context_compaction
+    checkpoint = AgentInvocation._ota_context_values(ota)
+    entered = asyncio.Event()
+    call_count = 0
+    if stop_at in {"session_summary", "turn_summary"}:
+        owner, method = worker._llm, "stream_turn"
+        stop_call = 1 if stop_at == "session_summary" else 2
+    else:
+        owner = worker
+        method = "assemble_messages" if stop_at == "reassembly" else "append_runtime_state"
+        stop_call = 1
+    original_method = getattr(owner, method)
+
+    async def pause(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == stop_call:
+            entered.set()
+            await asyncio.Future()
+        return await original_method(*args, **kwargs)
+
+    monkeypatch.setattr(owner, method, pause)
+    task = asyncio.create_task(worker.compact_messages(messages, [], ota, context, target=1))
+    try:
+        await asyncio.wait_for(entered.wait(), timeout=5)
+        assert ota.state.context_compaction is original
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    saved = AgentInvocation._ota_context_values(ota)
+    assert saved["agent_state"] == checkpoint["agent_state"]
+    assert saved["ota_records"] == checkpoint["ota_records"]
+    assert ota.state.context_compaction is original
+    # Completed summary calls still incur usage even when their results are discarded.
+    completed_calls = len(worker._llm.calls)
+    assert ota.context_usage.input_tokens == completed_calls * 5
+    assert ota.context_usage.output_tokens == completed_calls * 2
+    assert ota.stream.events == [
+        ("context_compaction", {"active": True}),
+        ("context_compaction", {"active": False}),
+    ]
+
+
+@pytest.mark.parametrize("outcome", ["reassembly_error", "runtime_error", "no_reduction", "hard_capacity", "success"])
+async def test_compaction_commits_only_after_validation(compaction_attempt, monkeypatch: pytest.MonkeyPatch, outcome: str) -> None:
+    """Only a fully rebuilt, smaller, usable request can publish both summaries together."""
+    worker, ota, context, messages = compaction_attempt
+    original = ota.state.context_compaction
+    checkpoint = AgentInvocation._ota_context_values(ota)
+    if outcome in {"reassembly_error", "runtime_error", "no_reduction"}:
+        async def rebuild(*args, **kwargs):
+            if outcome == "no_reduction":
+                return messages
+            raise RuntimeError("Rebuild failed")
+
+        method = "append_runtime_state" if outcome == "runtime_error" else "assemble_messages"
+        monkeypatch.setattr(worker, method, rebuild)
+    elif outcome == "hard_capacity":
+        # The protected current input remains oversized even after both histories shrink.
+        ota.user_input = "X" * 500_000
+        messages = await worker.assemble_messages(ota, context)
+
+    if outcome in {"reassembly_error", "runtime_error", "hard_capacity"}:
+        error = ContextWindowExceededError if outcome == "hard_capacity" else RuntimeError
+        with pytest.raises(error):
+            await worker.compact_messages(messages, [], ota, context, target=1)
+    else:
+        rebuilt = await worker.compact_messages(messages, [], ota, context, target=1)
+        if outcome == "success":
+            state = ota.state.context_compaction
+            assert state is not original
+            assert state.session["normal"]["main"].session_summary == "New Session summary"
+            assert state.session["normal"]["main"].session_through_ordinal == 1
+            assert state.turn["normal"]["main"].turn_summary == "New Turn summary"
+            assert state.turn["normal"]["main"].turn_covered_rounds == [1, 2]
+            assert worker._estimate_request_tokens(rebuilt, []) < worker._estimate_request_tokens(messages, [])
+        else:
+            assert rebuilt == messages
+
+    saved = AgentInvocation._ota_context_values(ota)
+    if outcome != "success":
+        assert ota.state.context_compaction is original
+        assert saved["agent_state"] == checkpoint["agent_state"]
+    assert saved["ota_records"] == checkpoint["ota_records"]
+    assert ota.stream.events[-1] == ("context_compaction", {"active": False})
 
 
 async def test_turn_compaction_is_isolated_by_mode_and_stage(test_sandbox: IsolatedPaths) -> None:

--- a/tests/agent/cognitive/test_stage_history.py
+++ b/tests/agent/cognitive/test_stage_history.py
@@ -1,0 +1,322 @@
+"""Regression contracts for Session-wide storage and stage-owned prompt views."""
+
+import json
+from copy import deepcopy
+
+import pytest
+from bridgic.amphibious import ActionResult, ActionStepResult, OTARecord
+from bridgic.core.model.types import ToolCallBlock, ToolResultBlock
+
+from src.amphi_agent import AmphiAgent, AmphiOTAContext, MainThink
+from src.amphi_agent._cognitive import _covered_rounds, _project_rounds
+from src.amphi_agent._state import AgentState, BuildStageState, ContextCompactionState, NormalStageState
+from src.amphi_agent._tools import TOOL_LIBRARY
+from src.amphi_store import SessionTurnRecord, TurnStatus, UserInput
+from tests._support.sandbox import IsolatedPaths
+from tests.agent.cognitive.test_compaction import SummaryLlm, _context
+
+
+def _round(mode: str, stage: str, text: str) -> OTARecord:
+    result = OTARecord(
+        think_result={"step_content": text, "tool_calls": [{"tool": "read_file", "arguments": {"file_path": "history.txt"}}]},
+        action_result=ActionResult(results=[ActionStepResult(tool_id="", tool_name="read_file", tool_arguments={"file_path": "history.txt"}, tool_result=text)]),
+    )
+    result.think_scope = {"mode": mode, "stage": stage, "session_history": "stage_scoped_v2"}
+    return result
+
+
+def _turn(ordinal: int, records: list[OTARecord], state: AgentState, status: TurnStatus = TurnStatus.COMPLETED) -> SessionTurnRecord:
+    return SessionTurnRecord(
+        id=f"turn-{ordinal}", user_id="local", session_id="session-compaction-policy", session_ordinal=ordinal,
+        user_input=UserInput(text=f"Request {ordinal}"), status=status,
+        ota_records=[record.model_dump(mode="json") for record in records], agent_state=state.model_dump(mode="json"),
+    )
+
+
+def _serialized(messages) -> str:
+    return str([message.model_dump(mode="json") for message in messages])
+
+
+@pytest.mark.parametrize("mode,stage", [("normal", "main"), ("build", "verify"), ("run_workflow", "execute")])
+@pytest.mark.parametrize("status", [TurnStatus.COMPLETED, TurnStatus.FAILED, TurnStatus.CANCELLED])
+async def test_compacted_turn_tail_does_not_expand_in_session_history(test_sandbox: IsolatedPaths, mode: str, stage: str, status: TurnStatus) -> None:
+    """A protected large-argument round keeps the same bounded replay in the next Turn."""
+    think = {"mode": mode, "stage": stage}
+    if mode == "run_workflow":
+        think.update(workflow_id="workflow-a", generation="generation-a")
+    state = AgentState.model_validate({"think": think, "context_compaction": {"turn": {mode: {stage: {
+        "turn_summary": "EARLIER ROUND SUMMARY", "turn_through_round": 1, "turn_covered_rounds": [1],
+    }}}}})
+    large = "x" * 120_000
+    args = {"file_path": "generated.txt", "content": large}
+    retained = _round(mode, stage, "Write the artifact")
+    retained.think_result["tool_calls"] = [{"tool": "write_file", "arguments": args}]
+    retained.action_result = ActionResult(results=[ActionStepResult(
+        tool_id="write-result", tool_name="write_file", tool_arguments=args, tool_result="Wrote generated.txt",
+    )])
+    retained.reasoning_content = "Private reasoning must not enter Session history"
+    current = AmphiOTAContext(user_input="Write", state=state, ota_record=[_round(mode, stage, "COVERED RAW"), retained])
+    current.tools = TOOL_LIBRARY.select(["write_file"])
+    context = _context(str(test_sandbox.sessions / "bounded-replay"), [], 50_000)
+    llm = SummaryLlm()
+    worker = MainThink(llm)
+    live = worker.turn_messages_block(current, context)
+    previous = _turn(0, current.ota_record, state, status)
+    raw_before = deepcopy(previous.model_dump(mode="json"))
+    historical_context = _context(str(test_sandbox.sessions / "bounded-replay"), [previous], 50_000)
+    next_turn = AmphiOTAContext(user_input="Continue", state={"think": think})
+    next_turn.tools = current.tools
+    history = await worker.session_messages_block(next_turn, historical_context)
+    replay = history[1:3]
+    assert [message.blocks for message in replay] == [message.blocks for message in live]
+    assert all(not message.extras for message in replay)
+    assert large not in _serialized(history)
+    assert "COVERED RAW" not in _serialized(history)
+    assert "120000 characters" in _serialized(history)
+    assert "Wrote generated.txt" in _serialized(history)
+    assert previous.model_dump(mode="json") == raw_before
+    # A new request must fit without trying to compact the protected last Turn.
+    messages = await worker.assemble_messages(next_turn, historical_context)
+    await worker._prepare_context_window(messages, next_turn.tools, next_turn, historical_context)
+    assert not llm.calls
+
+
+@pytest.mark.parametrize("case", ["safe", "oversized", "structured", "missing", "partial", "steps_only", "choice", "large_choice"])
+async def test_session_tool_replay_matches_completed_action_steps(test_sandbox: IsolatedPaths, case: str) -> None:
+    """Use executed arguments, preserve every completed pair, and omit old reasoning."""
+    args = {"file_path": "actual.txt", "content": "small"}
+    if case == "oversized":
+        args["content"] = "x" * 1201
+    elif case == "structured":
+        args["content"] = {"nested": "x" * 1201}
+    elif case == "missing":
+        args.pop("file_path")
+    tool_name = "write_file"
+    if case in {"choice", "large_choice"}:
+        question = {"header": "Choice", "question": "Choose an option", "options": [
+            {"label": f"Option {i}", "description": "d" * (200 if case == "large_choice" else 1)} for i in range(3)
+        ]}
+        args = {"questions": json.dumps([question] * (3 if case == "large_choice" else 1)), "prompt": "Choose the next action"}
+        tool_name = "request_human_choice"
+    record = _round("normal", "main", "Executed tools")
+    record.think_result["tool_calls"] = [
+        {"tool": "write_file", "arguments": {"file_path": "unrepaired.txt", "content": "z" * 120_000}},
+        {"tool": "read_file", "arguments": {"file_path": "actual.txt"}},
+    ]
+    record.action_result = ActionResult(results=[
+        ActionStepResult(tool_id="write-id", tool_name=tool_name, tool_arguments=args, tool_result="" if "choice" in case else "written"),
+        ActionStepResult(tool_id="read-id", tool_name="read_file", tool_arguments={"file_path": "actual.txt"}, tool_result=None, success=False, error="read failed"),
+    ])
+    if case == "partial":
+        record.action_result.results.pop()
+    elif case == "steps_only":
+        record.think_result["tool_calls"] = []
+    record.reasoning_content = "Private reasoning"
+    record.thought_signatures = ["signature"] * len(record.action_result.results)
+    current = AmphiOTAContext(user_input="Act", ota_record=[record])
+    current.tools = TOOL_LIBRARY.select(["write_file", "read_file", "request_human_choice"])
+    previous = _turn(0, [record], current.state)
+    before = deepcopy(previous.model_dump(mode="json"))
+    context = _context(str(test_sandbox.sessions / "same-tool-round"), [previous], 100_000)
+    worker = MainThink()
+    live = worker.turn_messages_block(current, context)
+    history = (await worker.session_messages_block(current, context))[1:]
+    assert [message.blocks for message in history] == [message.blocks for message in live]
+    assert all(not message.extras for message in history)
+    assert "unrepaired.txt" not in _serialized(history)
+    assert previous.model_dump(mode="json") == before
+    calls = [block for message in history for block in message.blocks if isinstance(block, ToolCallBlock)]
+    results = [block for message in history for block in message.blocks if isinstance(block, ToolResultBlock)]
+    assert [call.id for call in calls] == [result.id for result in results]
+    assert len(calls) == (0 if case in {"oversized", "structured", "missing", "large_choice"} else 1 if case == "partial" else 2)
+
+
+@pytest.mark.parametrize("mode,stage", [("normal", "main"), ("build", "clarify"), ("build", "verify"), ("run_workflow", "execute")])
+@pytest.mark.parametrize("status", [TurnStatus.COMPLETED, TurnStatus.FAILED, TurnStatus.CANCELLED])
+async def test_new_turn_keeps_stage_session_summary_and_compacted_tail(test_sandbox: IsolatedPaths, mode: str, stage: str, status: TurnStatus) -> None:
+    """Terminal Turns start a fresh loop, retaining every stage's Session checkpoint."""
+    think = {"mode": mode, "stage": stage}
+    if mode == "run_workflow":
+        think.update(workflow_id="workflow-a", generation="generation-a")
+    state = AgentState.model_validate({
+        "think": think,
+        "context_compaction": {
+            "session": {mode: {stage: {"session_summary": "OLDER STAGE SUMMARY", "session_through_ordinal": 0}}},
+            "turn": {mode: {stage: {"turn_summary": "LATEST TURN SUMMARY", "turn_through_round": 1, "turn_covered_rounds": [1]}}},
+        },
+    })
+    turns = [
+        _turn(0, [_round(mode, stage, "OLD RAW")], AgentState()),
+        _turn(1, [_round(mode, stage, "COVERED RAW"), _round(mode, stage, "RETAINED RESULT")], state, status),
+    ]
+    context = _context(str(test_sandbox.sessions / "new-turn"), turns, 100_000)
+    current = AmphiOTAContext(user_input="Continue")
+    # Hydrating a Workflow requires its actual package; state propagation is
+    # mode-independent, so isolate that filesystem binding from this contract.
+    if mode == "run_workflow":
+        turns[-1].agent_state["think"] = {"mode": "normal", "stage": "main"}
+    await AmphiAgent().init_state(current, context)
+    current.state.think = AgentState.model_validate({"think": think}).think
+    assert current.ota_record == []
+    assert current.state.context_compaction.turn == {}
+    assert current.state.context_compaction.session == state.context_compaction.session
+    worker = MainThink()
+    messages = await worker.assemble_messages(current, context)
+    text = _serialized(messages)
+    assert "OLDER STAGE SUMMARY" in text
+    assert "LATEST TURN SUMMARY" in text
+    assert "RETAINED RESULT" in text
+    assert "OLD RAW" not in text
+    assert "COVERED RAW" not in text
+    calls = [block for message in messages for block in message.blocks if isinstance(block, ToolCallBlock)]
+    results = [block for message in messages for block in message.blocks if isinstance(block, ToolResultBlock)]
+    assert len(calls) == len(results) == 1
+    assert calls[0].id == results[0].id == "hist_call_1_1_0"
+    current.ota_record.append(_round(mode, stage, "CURRENT ROUND"))
+    assert "CURRENT ROUND" in _serialized(await worker.assemble_messages(current, context))
+
+
+async def test_switch_restores_target_stage_without_reexpanding_foreign_rounds(test_sandbox: IsolatedPaths) -> None:
+    records = [
+        _round("normal", "main", "NORMAL PRIVATE"),
+        _round("build", "clarify", "CLARIFY COVERED"),
+        _round("build", "explore", "EXPLORE PRIVATE"),
+        _round("build", "clarify", "CLARIFY RECENT"),
+    ]
+    records[2].observation_result = "[stage handoff] `build/explore` → `build/clarify`\nNeed the missing decision."
+    current = AmphiOTAContext(user_input="Keep the original requirement", ota_record=records, state={
+        "think": {"mode": "build", "stage": "clarify"},
+        "context_compaction": {"turn": {"build": {"clarify": {
+            "turn_summary": "CLARIFY SUMMARY", "turn_through_round": 1, "turn_covered_rounds": [2],
+        }}}},
+    })
+    context = _context(str(test_sandbox.sessions / "switch"), [], 100_000)
+    before = current.model_dump(mode="json", exclude={"tools"})
+    worker = MainThink()
+    clarify = _serialized(await worker.assemble_messages(current, context))
+    assert "CLARIFY SUMMARY" in clarify and "CLARIFY RECENT" in clarify
+    assert "Need the missing decision" in clarify
+    assert "CLARIFY COVERED" not in clarify and "EXPLORE PRIVATE" not in clarify and "NORMAL PRIVATE" not in clarify
+    current.transition_think(BuildStageState(stage="explore"))
+    explore = _serialized(await worker.assemble_messages(current, context))
+    assert "EXPLORE PRIVATE" in explore and "CLARIFY SUMMARY" not in explore
+    current.transition_think(BuildStageState(stage="clarify"))
+    assert _serialized(await worker.assemble_messages(current, context)) == clarify
+    assert current.model_dump(mode="json", exclude={"tools"}) == before
+
+
+async def test_normal_receives_build_exit_and_artifact_paths_not_build_logs(test_sandbox: IsolatedPaths) -> None:
+    current = AmphiOTAContext(user_input="Build and report the result", ota_record=[
+        _round("normal", "main", "NORMAL COVERED"),
+        _round("build", "generate", "HUGE BUILD LOG " * 200),
+        _round("build", "verify", "PRIVATE VERIFY TRACE"),
+    ], state={"context_compaction": {"turn": {
+        "normal": {"main": {"turn_summary": "NORMAL SUMMARY", "turn_through_round": 1, "turn_covered_rounds": [1]}},
+        "build": {"generate": {"turn_summary": "BUILD SUMMARY", "turn_through_round": 1, "turn_covered_rounds": [2]}},
+    }}})
+    AmphiAgent._stamp_mode_exit(current, BuildStageState(stage="verify"), "Validated successfully; report completion.")
+    AmphiAgent._stamp_published_directory_handoff(
+        current, publication="Workflow published", published_directory=test_sandbox.root / "published",
+        relative_paths="workflow/WORKFLOW.md", temporary_workspace=".build",
+    )
+    context = _context(str(test_sandbox.sessions / "normal-return"), [], 100_000)
+    text = _serialized(await MainThink().assemble_messages(current, context))
+    assert "NORMAL SUMMARY" in text and "Validated successfully" in text
+    assert "workflow/WORKFLOW.md" in text and str(test_sandbox.root / "published") in text
+    assert "HUGE BUILD LOG" not in text and "PRIVATE VERIFY TRACE" not in text and "BUILD SUMMARY" not in text
+
+
+async def test_session_retention_and_compaction_are_independent_per_stage(test_sandbox: IsolatedPaths) -> None:
+    turns = []
+    for index in range(12):
+        stage = "clarify" if index % 2 == 0 else "explore"
+        turns.append(_turn(index, [_round("build", stage, f"{stage.upper()} HISTORY {index} " * 100)], AgentState()))
+    context = _context(str(test_sandbox.sessions / "session-scopes"), turns, 200_000)
+    llm = SummaryLlm("CLARIFY SESSION SUMMARY", "EXPLORE SESSION SUMMARY")
+    worker = MainThink(llm)
+    current = AmphiOTAContext(user_input="Continue", state={"think": {"mode": "build", "stage": "clarify"}})
+    before = deepcopy([turn.model_dump(mode="json") for turn in turns])
+    original = await worker.assemble_messages(current, context)
+    await worker.compact_messages(original, [], current, context, target=1)
+    first = current.state.context_compaction.session["build"]["clarify"].model_copy(deep=True)
+    assert first.session_through_ordinal == 2
+    assert "CLARIFY HISTORY 0" in llm.calls[0][1].content and "CLARIFY HISTORY 2" in llm.calls[0][1].content
+    assert "CLARIFY HISTORY 4" not in llm.calls[0][1].content and "EXPLORE HISTORY" not in llm.calls[0][1].content
+    current.transition_think(BuildStageState(stage="explore"))
+    original = await worker.assemble_messages(current, context)
+    await worker.compact_messages(original, [], current, context, target=1)
+    assert current.state.context_compaction.session["build"]["clarify"] == first
+    assert current.state.context_compaction.session["build"]["explore"].session_through_ordinal == 3
+    current.transition_think(BuildStageState(stage="clarify"))
+    text = _serialized(await worker.assemble_messages(current, context))
+    assert "CLARIFY SESSION SUMMARY" in text and "EXPLORE SESSION SUMMARY" not in text
+    assert "CLARIFY HISTORY 0" not in text and "CLARIFY HISTORY 4" in text
+    assert [turn.model_dump(mode="json") for turn in turns] == before
+
+
+async def test_incremental_compaction_keeps_exact_interleaved_coverage(test_sandbox: IsolatedPaths) -> None:
+    records = []
+    for index in range(6):
+        records.extend([_round("normal", "main", f"FOREIGN {index}"), _round("build", "verify", f"VERIFY {index} " * 200)])
+    current = AmphiOTAContext(user_input="Verify", ota_record=records, state={"think": {"mode": "build", "stage": "verify"}})
+    llm = SummaryLlm("First verify summary", "Second verify summary")
+    worker = MainThink(llm)
+    context = _context(str(test_sandbox.sessions / "incremental"), [], 200_000)
+    original = await worker.assemble_messages(current, context)
+    await worker.compact_messages(original, [], current, context, target=1)
+    assert current.state.context_compaction.turn["build"]["verify"].turn_covered_rounds == [2, 4]
+    current.ota_record.extend([_round("normal", "main", "FOREIGN LATER"), _round("build", "verify", "VERIFY LATER")])
+    original = await worker.assemble_messages(current, context)
+    await worker.compact_messages(original, [], current, context, target=1)
+    assert current.state.context_compaction.turn["build"]["verify"].turn_covered_rounds == [2, 4, 6]
+    assert "First verify summary" in llm.calls[1][1].content
+    assert "VERIFY 0" not in llm.calls[1][1].content and "VERIFY 2" in llm.calls[1][1].content
+    assert all("FOREIGN" not in call[1].content for call in llm.calls)
+
+
+async def test_foreign_session_summary_is_not_reused_for_target_stage(test_sandbox: IsolatedPaths) -> None:
+    turn = _turn(0, [_round("build", "verify", "RECOVER VERIFICATION")], AgentState())
+    context = _context(str(test_sandbox.sessions / "legacy"), [turn], 100_000)
+    current = AmphiOTAContext(user_input="Verify", state={
+        "think": {"mode": "build", "stage": "verify"},
+        "context_compaction": {"session_summary": "MIXED LEGACY SUMMARY", "session_through_ordinal": 0},
+    })
+    text = _serialized(await MainThink().assemble_messages(current, context))
+    assert "MIXED LEGACY SUMMARY" not in text and "RECOVER VERIFICATION" in text
+
+
+def test_legacy_compaction_uses_original_projection_coordinates() -> None:
+    records = [_round("normal", "main", "entry"), _round("build", "clarify", "covered"), _round("build", "clarify", "keep")]
+    compaction = ContextCompactionState(turn={"build": {"clarify": {"turn_summary": "Legacy", "turn_through_round": 2}}})
+    covered = _covered_rounds(records, ("build", "clarify"), compaction.turn["build"]["clarify"])
+    assert covered == {1, 2}
+    assert [item.number for item in _project_rounds(records, ("build", "clarify")) if item.number not in covered] == [3]
+
+
+@pytest.mark.parametrize("status", ["started", "resumed", "restarted", "pending"])
+def test_workflow_entry_shares_resolution_not_normal_trace(status: str) -> None:
+    record = _round("normal", "main", "PRIVATE NORMAL TRACE")
+    record.action_result = {"results": [{
+        "tool_name": "request_run_workflow", "success": True,
+        "tool_arguments": {"reason": "Use the existing Run"},
+        "tool_result": {"workflow_id": "workflow-a", "status": status},
+    }]}
+    projected = _project_rounds([record], ("run_workflow", "execute"))
+    if status == "pending":
+        assert projected == []
+    else:
+        text = str(projected[0].record)
+        assert "Use the existing Run" in text and f"{status}." in text
+        assert "PRIVATE NORMAL TRACE" not in text
+        assert "action_result" not in projected[0].record
+
+
+def test_confirmed_build_entry_keeps_proposed_goal() -> None:
+    record = _round("normal", "main", "PRIVATE NORMAL TRACE")
+    record.action_result = {"results": [{
+        "tool_name": "request_build", "success": True,
+        "tool_result": {"mode": "ask", "status": "confirmed", "goal": "Turn the earlier task into a reusable workflow"},
+    }]}
+    text = str(_project_rounds([record], ("build", "clarify"))[0].record)
+    assert "Turn the earlier task into a reusable workflow" in text
+    assert "PRIVATE NORMAL TRACE" not in text

--- a/tests/agent/cognitive/test_stage_history.py
+++ b/tests/agent/cognitive/test_stage_history.py
@@ -1,5 +1,6 @@
 """Regression contracts for Session-wide storage and stage-owned prompt views."""
 
+import asyncio
 import json
 from copy import deepcopy
 
@@ -7,8 +8,8 @@ import pytest
 from bridgic.amphibious import ActionResult, ActionStepResult, OTARecord
 from bridgic.core.model.types import ToolCallBlock, ToolResultBlock
 
-from src.amphi_agent import AmphiAgent, AmphiOTAContext, MainThink
-from src.amphi_agent._cognitive import _covered_rounds, _project_rounds
+from src.amphi_agent import AmphiAgent, AmphiOTAContext, ContextWindowExceededError, MainThink
+from src.amphi_agent._cognitive import ClarifyThink, _covered_rounds, _project_rounds
 from src.amphi_agent._state import AgentState, BuildStageState, ContextCompactionState, NormalStageState
 from src.amphi_agent._tools import TOOL_LIBRARY
 from src.amphi_store import SessionTurnRecord, TurnStatus, UserInput
@@ -196,13 +197,219 @@ async def test_switch_restores_target_stage_without_reexpanding_foreign_rounds(t
     clarify = _serialized(await worker.assemble_messages(current, context))
     assert "CLARIFY SUMMARY" in clarify and "CLARIFY RECENT" in clarify
     assert "Need the missing decision" in clarify
-    assert "CLARIFY COVERED" not in clarify and "EXPLORE PRIVATE" not in clarify and "NORMAL PRIVATE" not in clarify
+    assert "NORMAL PRIVATE" in clarify
+    assert "CLARIFY COVERED" not in clarify and "EXPLORE PRIVATE" not in clarify
     current.transition_think(BuildStageState(stage="explore"))
     explore = _serialized(await worker.assemble_messages(current, context))
     assert "EXPLORE PRIVATE" in explore and "CLARIFY SUMMARY" not in explore
     current.transition_think(BuildStageState(stage="clarify"))
     assert _serialized(await worker.assemble_messages(current, context)) == clarify
     assert current.model_dump(mode="json", exclude={"tools"}) == before
+
+
+@pytest.mark.parametrize("status", [TurnStatus.COMPLETED, TurnStatus.FAILED, TurnStatus.CANCELLED])
+@pytest.mark.parametrize("normal_boundary,clarify_boundary", [(0, 1), (1, 0)])
+async def test_clarify_reads_independently_compacted_normal_history(test_sandbox: IsolatedPaths, status: TurnStatus, normal_boundary: int, clarify_boundary: int) -> None:
+    """Both Session and Turn checkpoints remain source-owned across terminal Turns."""
+    state = AgentState.model_validate({
+        "think": {"mode": "build", "stage": "clarify"},
+        "context_compaction": {
+            "session": {
+                "normal": {"main": {"session_summary": "NORMAL SESSION SUMMARY", "session_through_ordinal": normal_boundary}},
+                "build": {"clarify": {"session_summary": "CLARIFY SESSION SUMMARY", "session_through_ordinal": clarify_boundary}},
+            },
+            "turn": {
+                "normal": {"main": {"turn_summary": "NORMAL TURN SUMMARY", "turn_through_round": 1, "turn_covered_rounds": [1]}},
+                "build": {"clarify": {"turn_summary": "CLARIFY TURN SUMMARY", "turn_through_round": 1, "turn_covered_rounds": [2]}},
+            },
+        },
+    })
+    turns = [_turn(index, [
+        _round("normal", "main", f"NORMAL PAST {index}"),
+        _round("build", "clarify", f"CLARIFY PAST {index}"),
+    ], AgentState()) for index in range(2)]
+    records = [
+        _round("normal", "main", "NORMAL COVERED"),
+        _round("build", "clarify", "CLARIFY COVERED"),
+        _round("normal", "main", "NORMAL RETAINED"),
+        _round("build", "clarify", "CLARIFY RETAINED"),
+        _round("build", "verify", "VERIFY PRIVATE"),
+    ]
+    for index, record in enumerate(records):
+        record.action_result.results[0].tool_id = f"stable-call-{index}"
+    current = AmphiOTAContext(user_input="Continue", state=state, ota_record=records)
+    context = _context(str(test_sandbox.sessions / "shared-normal"), turns, 200_000)
+    worker = ClarifyThink()
+    await worker.assemble_messages(current, context)
+    live = worker.turn_messages_block(current, context)
+    previous = _turn(2, records, state, status)
+    before = deepcopy(previous.model_dump(mode="json"))
+    next_context = _context(str(test_sandbox.sessions / "shared-normal"), [*turns, previous], 200_000)
+    next_turn = AmphiOTAContext(user_input="Continue again")
+    await AmphiAgent().init_state(next_turn, next_context)
+    await worker.assemble_messages(next_turn, next_context)
+    history = await worker.session_messages_block(next_turn, next_context)
+    text = _serialized(history)
+    for marker in ("NORMAL SESSION SUMMARY", "CLARIFY SESSION SUMMARY", "NORMAL TURN SUMMARY", "CLARIFY TURN SUMMARY", "NORMAL RETAINED", "CLARIFY RETAINED"):
+        assert marker in text
+    for marker in ("NORMAL PAST 0", "CLARIFY PAST 0", "NORMAL COVERED", "CLARIFY COVERED", "VERIFY PRIVATE"):
+        assert marker not in text
+    assert ("NORMAL PAST 1" in text) == (normal_boundary == 0)
+    assert ("CLARIFY PAST 1" in text) == (clarify_boundary == 0)
+    assert sum(message.content == "Request 1" for message in history) == 1
+    last_input = next(index for index, message in enumerate(history) if message.content == "Request 2")
+    assert [message.blocks for message in history[last_input + 1:last_input + 1 + len(live)]] == [message.blocks for message in live]
+    assert text.index("NORMAL RETAINED") < text.index("CLARIFY RETAINED")
+    assert 'owner="normal/main"' in text and 'owner="build/clarify"' in text
+    assert previous.model_dump(mode="json") == before
+    assert next_turn.state.context_compaction.session == state.context_compaction.session
+    assert next_turn.state.context_compaction.turn == {}
+
+
+@pytest.mark.parametrize("cancel", [False, True])
+async def test_clarify_compacts_only_its_own_inputs_and_keeps_normal_unchanged(test_sandbox: IsolatedPaths, cancel: bool) -> None:
+    """Shared Normal Turns/Rounds never enter Clarify's retention window or summaries."""
+    turns = []
+    records = []
+    for index in range(6):
+        turns.extend([
+            _turn(index * 2, [_round("normal", "main", f"NORMAL SESSION {index} " * 100)], AgentState()),
+            _turn(index * 2 + 1, [_round("build", "clarify", f"CLARIFY SESSION {index} " * 100)], AgentState()),
+        ])
+        records.extend([
+            _round("normal", "main", f"NORMAL ROUND {index} " * 100),
+            _round("build", "clarify", f"CLARIFY ROUND {index} " * 100),
+        ])
+    current = AmphiOTAContext(user_input="Continue", ota_record=records, state={
+        "think": {"mode": "build", "stage": "clarify"},
+        "context_compaction": {
+            "session": {"normal": {"main": {"session_summary": "NORMAL SESSION CHECKPOINT", "session_through_ordinal": 0}}},
+            "turn": {"normal": {"main": {"turn_summary": "NORMAL TURN CHECKPOINT", "turn_through_round": 1, "turn_covered_rounds": [1]}}},
+        },
+    })
+    context = _context(str(test_sandbox.sessions / "shared-compaction"), turns, 200_000)
+    llm = SummaryLlm("CLARIFY SESSION SUMMARY", asyncio.CancelledError() if cancel else "CLARIFY TURN SUMMARY")
+    worker = ClarifyThink(llm)
+    original_state = current.state.model_dump(mode="json")
+    original_records = deepcopy([record.model_dump(mode="json") for record in records])
+    normal = current.model_copy(update={"state": current.state.model_copy(update={"think": NormalStageState()})})
+    normal_before = _serialized(await MainThink().assemble_messages(normal, context))
+    messages = await worker.assemble_messages(current, context)
+    if cancel:
+        with pytest.raises(asyncio.CancelledError):
+            await worker.compact_messages(messages, [], current, context, target=1)
+        assert current.state.model_dump(mode="json") == original_state
+    else:
+        rebuilt = await worker.compact_messages(messages, [], current, context, target=1)
+        compaction = current.state.context_compaction
+        assert compaction.session["build"]["clarify"].session_through_ordinal == 3
+        assert compaction.turn["build"]["clarify"].turn_covered_rounds == [2, 4]
+        assert compaction.session["normal"]["main"] == normal.state.context_compaction.session["normal"]["main"]
+        assert compaction.turn["normal"]["main"] == normal.state.context_compaction.turn["normal"]["main"]
+        text = _serialized(rebuilt)
+        assert "NORMAL SESSION 1" in text and "NORMAL ROUND 1" in text
+        assert "CLARIFY SESSION 0" not in text and "CLARIFY ROUND 0" not in text
+        assert "CLARIFY SESSION 2" in text and "CLARIFY ROUND 2" in text
+    assert len(llm.calls) == 2
+    assert all("NORMAL" not in _serialized(call) for call in llm.calls)
+    assert "CLARIFY SESSION 0" in _serialized(llm.calls[0])
+    assert "CLARIFY ROUND 0" in _serialized(llm.calls[1])
+    normal.state = current.state.model_copy(update={"think": NormalStageState()})
+    assert _serialized(await MainThink().assemble_messages(normal, context)) == normal_before
+    assert [record.model_dump(mode="json") for record in records] == original_records
+
+
+async def test_clarify_cannot_compact_normal_even_when_shared_history_exceeds_capacity(test_sandbox: IsolatedPaths) -> None:
+    current = AmphiOTAContext(user_input="Clarify", state={"think": {"mode": "build", "stage": "clarify"}}, ota_record=[
+        _round("normal", "main", f"NORMAL LARGE {index} " * 2_000) for index in range(8)
+    ])
+    context = _context(str(test_sandbox.sessions / "read-only-overflow"), [], 40_000)
+    llm = SummaryLlm()
+    worker = ClarifyThink(llm)
+    messages = await worker.assemble_messages(current, context)
+    with pytest.raises(ContextWindowExceededError):
+        await worker._prepare_context_window(messages, [], current, context)
+    assert not llm.calls
+    assert current.state.context_compaction is None
+
+
+@pytest.mark.parametrize("mode,stage", [("normal", "main"), ("build", "explore"), ("build", "generate"), ("build", "verify"), ("run_workflow", "execute")])
+async def test_clarify_sharing_does_not_change_other_stage_views(test_sandbox: IsolatedPaths, mode: str, stage: str) -> None:
+    records = [_round("normal", "main", "NORMAL ONLY"), _round("build", "clarify", "CLARIFY ONLY")]
+    context = _context(str(test_sandbox.sessions / "one-way-sharing"), [_turn(0, records, AgentState())], 100_000)
+    think = {"mode": mode, "stage": stage}
+    if mode == "run_workflow":
+        think.update(workflow_id="workflow", generation="generation")
+    current = AmphiOTAContext(user_input="Continue", ota_record=records, state={"think": think})
+    worker = MainThink()
+    text = _serialized([*await worker.session_messages_block(current, context), *worker.turn_messages_block(current, context)])
+    assert "CLARIFY ONLY" not in text
+    assert ("NORMAL ONLY" in text) == (mode == "normal")
+
+
+@pytest.mark.parametrize("compacted", [False, True])
+async def test_clarify_sharing_does_not_duplicate_or_reexpand_unscoped_legacy_rounds(test_sandbox: IsolatedPaths, compacted: bool) -> None:
+    record = OTARecord(action_result=ActionResult(results=[ActionStepResult(tool_id="legacy-call", tool_name="read_file", tool_arguments={"file_path": "old.txt"}, tool_result="LEGACY OUTPUT")]))
+    state = AgentState(think=BuildStageState(stage="clarify"))
+    if compacted:
+        state.context_compaction = ContextCompactionState(turn={"normal": {"main": {"turn_summary": "LEGACY SUMMARY", "turn_through_round": 1}}})
+    current = AmphiOTAContext(user_input="Continue", state=state, ota_record=[record])
+    context = _context(str(test_sandbox.sessions / "legacy-sharing"), [], 100_000)
+    messages = ClarifyThink().turn_messages_block(current, context)
+    calls = [block for message in messages for block in message.blocks if isinstance(block, ToolCallBlock)]
+    assert len(calls) == (0 if compacted else 1)
+    assert ("LEGACY OUTPUT" in _serialized(messages)) is not compacted
+    assert ("LEGACY SUMMARY" in _serialized(messages)) is compacted
+
+
+@pytest.mark.parametrize("summary_owner", [None, "normal", "clarify"])
+async def test_clarify_keeps_owned_handoff_alongside_shared_normal_result(test_sandbox: IsolatedPaths, summary_owner: str | None) -> None:
+    """Sharing adds the Normal view without replacing Clarify's existing handoff."""
+    record = _round("normal", "main", "NORMAL ENTRY")
+    record.action_result = ActionResult(results=[ActionStepResult(
+        tool_id="build-entry", tool_name="request_build", tool_arguments={"goal": "Create the report workflow", "mode": "start"},
+        tool_result={"mode": "start", "goal": "Create the report workflow", "message": "A new Build was created."},
+    )])
+    current = AmphiOTAContext(user_input="Build", state={"think": {"mode": "build", "stage": "clarify"}}, ota_record=[record])
+    if summary_owner:
+        mode, stage = ("normal", "main") if summary_owner == "normal" else ("build", "clarify")
+        current.state.context_compaction = ContextCompactionState(turn={mode: {stage: {
+            "turn_summary": "SOURCE SUMMARY", "turn_through_round": 1, "turn_covered_rounds": [1],
+        }}})
+    worker = ClarifyThink()
+    context = _context(str(test_sandbox.sessions / "shared-handoff"), [], 100_000)
+    await worker.assemble_messages(current, context)
+    live = worker.turn_messages_block(current, context)
+    calls = [block for message in live for block in message.blocks if isinstance(block, ToolCallBlock)]
+    results = [block for message in live for block in message.blocks if isinstance(block, ToolResultBlock)]
+    assert len(calls) == len(results) == (0 if summary_owner == "normal" else 1)
+    assert sum("[stage handoff]" in message.content for message in live) == (0 if summary_owner == "clarify" else 1)
+    previous = _turn(0, [record], current.state)
+    context = _context(str(test_sandbox.sessions / "shared-handoff"), [previous], 100_000)
+    history = (await worker.session_messages_block(current, context))[1:]
+    assert [message.blocks for message in history] == [message.blocks for message in live]
+
+
+@pytest.mark.parametrize("legacy_checkpoint", [False, True])
+async def test_clarify_does_not_reopen_unscoped_turns_covered_by_normal_session_summary(test_sandbox: IsolatedPaths, legacy_checkpoint: bool) -> None:
+    record = OTARecord(think_result={"step_content": "COVERED LEGACY RAW", "tool_calls": []})
+    previous = _turn(0, [record], AgentState())
+    summary = {"session_summary": "NORMAL SESSION CHECKPOINT", "session_through_ordinal": 0}
+    compaction = summary if legacy_checkpoint else {"session": {"normal": {"main": summary}}}
+    current = AmphiOTAContext(user_input="Clarify", state={"think": {"mode": "build", "stage": "clarify"}, "context_compaction": compaction})
+    context = _context(str(test_sandbox.sessions / "legacy-session-sharing"), [previous], 100_000)
+    messages = await ClarifyThink().session_messages_block(current, context)
+    assert len(messages) == 1
+    assert "NORMAL SESSION CHECKPOINT" in messages[0].content
+    assert "COVERED LEGACY RAW" not in _serialized(messages)
+    assert "Request 0" not in _serialized(messages)
+    if not legacy_checkpoint:
+        # A known Clarify round in the same Turn still belongs to Clarify.
+        previous.ota_records.append(_round("build", "clarify", "CLARIFY RETAINED").model_dump(mode="json"))
+        messages = await ClarifyThink().session_messages_block(current, context)
+        assert "CLARIFY RETAINED" in _serialized(messages)
+        assert "COVERED LEGACY RAW" not in _serialized(messages)
+        assert sum(message.content == "Request 0" for message in messages) == 1
 
 
 async def test_normal_receives_build_exit_and_artifact_paths_not_build_logs(test_sandbox: IsolatedPaths) -> None:
@@ -320,3 +527,42 @@ def test_confirmed_build_entry_keeps_proposed_goal() -> None:
     text = str(_project_rounds([record], ("build", "clarify"))[0].record)
     assert "Turn the earlier task into a reusable workflow" in text
     assert "PRIVATE NORMAL TRACE" not in text
+
+
+@pytest.mark.parametrize("status,action,target_stage", [
+    ("resolved", "keep", "verify"),
+    ("resolved", "merge", "clarify"),
+    ("resolved", "replace", "clarify"),
+    ("not_answered", "not_answered", "verify"),
+    ("pending", None, None),
+    ("cancelled", None, None),
+])
+def test_build_entry_hands_resolved_choice_to_actual_stage(status: str, action: str | None, target_stage: str | None) -> None:
+    record = _round("normal", "main", "PRIVATE NORMAL TRACE")
+    record.action_result = {"results": [{
+        "tool_name": "request_build", "success": True,
+        "tool_result": {
+            "mode": "ask", "status": status, "action": action, "existing_stage": "verify",
+            "goal": "COMPETING WORKFLOW GOAL", "message": "The user resolved the Build request.",
+            "response": "the second option", "reason": "Choose how to handle the unfinished Build.",
+            "questions": [{"question": "How should the new request affect this Build?", "options": [
+                {"label": "Keep", "preview": "PRIVATE FULL CARD"}, {"label": "Merge requirements"}, {"label": "Replace"},
+            ]}],
+        },
+    }]}
+    before = record.model_dump(mode="json")
+    for stage in ("clarify", "explore", "generate", "verify"):
+        projected = _project_rounds([record], ("build", stage))
+        if stage != target_stage:
+            assert projected == []
+            continue
+        text = projected[0].record["think_result"]["step_content"]
+        assert "The user resolved the Build request." in text and "the second option" in text
+        assert ("COMPETING WORKFLOW GOAL" in text) == (action in {"merge", "replace"})
+        assert "PRIVATE NORMAL TRACE" not in text and "PRIVATE FULL CARD" not in text
+        if status == "not_answered":
+            assert "Context: Choose how to handle the unfinished Build." in text
+            assert "Question: How should the new request affect this Build?" in text
+            assert "Options: 1. Keep; 2. Merge requirements; 3. Replace" in text
+        assert "action_result" not in projected[0].record
+    assert record.model_dump(mode="json") == before

--- a/tests/agent/cognitive/test_thinking.py
+++ b/tests/agent/cognitive/test_thinking.py
@@ -244,6 +244,7 @@ async def test_context_usage_falls_back_to_a_conservative_estimate(test_sandbox:
     assert ota_context.context_usage.output_tokens == 0
     assert ota_context.context_usage.occupied_input_tokens == events[0]["input_tokens"]
     assert ota_context.context_usage.occupied_output_tokens == events[0]["output_tokens"]
+    assert ota_context.context_usage.stage_references == {}
 
 
 @pytest.mark.parametrize(("source", "estimate", "target"), [
@@ -280,6 +281,11 @@ async def test_context_threshold_enters_the_compaction_hook(test_sandbox: Isolat
             "source": "provider",
             "used_tokens": estimate,
             "estimated_occupied_tokens": estimate,
+            "stage_references": {"normal": {"main": {
+                "model_id": "small-model",
+                "input_tokens": estimate,
+                "estimated_input_tokens": estimate,
+            }}},
         }
         if source == "provider"
         else {}

--- a/tests/agent/cognitive/test_thinking.py
+++ b/tests/agent/cognitive/test_thinking.py
@@ -21,7 +21,7 @@ async def test_live_round(test_sandbox: IsolatedPaths) -> None:
       "think_scope": {
         "mode": "build",
         "stage": "generate",
-        "session_history": "all_stages"
+        "session_history": "stage_scoped_v2"
       }
     }
 
@@ -146,7 +146,7 @@ async def test_live_round(test_sandbox: IsolatedPaths) -> None:
     expected_scope = {
         "mode": "build",
         "stage": "generate",
-        "session_history": "all_stages",
+        "session_history": "stage_scoped_v2",
     }
     assert llm.scope_at_call == expected_scope
     assert record.think_scope == expected_scope

--- a/tests/agent/core/test_orchestration.py
+++ b/tests/agent/core/test_orchestration.py
@@ -1,3 +1,4 @@
+import json
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from pathlib import Path
@@ -14,6 +15,7 @@ from src.amphi_agent import (
     WorkflowLibrary,
     WorkflowRunLibrary,
 )
+from src.amphi_agent._cognitive import ClarifyThink, GenerateThink
 from src.amphi_agent._state import (
     AwaitingBuildConflict,
     AwaitingTaskConfirm,
@@ -358,6 +360,115 @@ async def test_build_switch(orchestration: _Harness) -> None:
     assert "unfinished Build workspace was retained" in str(leave.ota_record[-1].observation_result)
 
 
+@pytest.mark.parametrize("status", [TurnStatus.COMPLETED, TurnStatus.FAILED, TurnStatus.CANCELLED])
+@pytest.mark.parametrize("reply", ["second option", "Choose the delivery method: second option"])
+async def test_switch_carries_saved_human_outcomes(orchestration: _Harness, status: TurnStatus, reply: str) -> None:
+    """Carry shared human outcomes, including referential replies, without foreign logs."""
+    await _prepare_build(orchestration, "explore")
+    choice = _step("request_human_choice", reply)
+    choice.tool_arguments = {
+        "prompt": "Where should the report go?",
+        "questions": json.dumps([{
+            "question": "Choose the delivery method",
+            "options": [{"label": "Email result"}, {"label": "Local result"}],
+        }]),
+    }
+    approved = "Only generate a local report."
+    ignored = _step("request_human_choice", "FAILED CHOICE RESULT")
+    ignored.success = False
+    ignored.error = "The interaction did not complete."
+    historical = AmphiOTAContext(
+        user_input="Review the report requirements",
+        ota_record=[OTARecord(
+            think_scope={"mode": "build", "stage": "verify"},
+            think_result={"step_content": "PRIVATE VERIFY TRACE", "tool_calls": []},
+            action_result=ActionResult(results=[
+                _step("request_human_task_confirm", {
+                    "status": "confirmed", "message": approved,
+                    "task_markdown": "PRIVATE CONFIRMATION CARD",
+                }),
+                choice.model_copy(deep=True),
+                _step("request_human_task_confirm", {"status": "pending", "message": "PENDING CONFIRMATION"}),
+                ignored,
+                _step("exec_command", "PRIVATE TOOL OUTPUT"),
+            ]),
+        )],
+    )
+    saved = _turn(historical, "turn-saved-human-outcomes", status)
+    orchestration.context.session = Session(orchestration.record, [saved])
+    reason = "Exploration is complete; implement the report."
+    advance = _ota(
+        "Continue the report workflow",
+        _step("switch", {"mode": "build", "stage": "generate", "reason": reason}),
+        BuildStageState(stage="explore"),
+    )
+    advance.ota_record[0].think_scope = {"mode": "build", "stage": "explore"}
+    advance.ota_record.insert(0, OTARecord(
+        think_scope={"mode": "build", "stage": "explore"},
+        think_result={"step_content": "PRIVATE EXPLORE TRACE", "tool_calls": []},
+        action_result=ActionResult(results=[choice]),
+    ))
+
+    await _apply(orchestration, advance)
+
+    assert advance.think_status == BuildStageState(stage="generate")
+    handoff = _payload(advance, "switch")["reason"]
+    assert handoff.startswith(reason)
+    assert handoff.count("second option") == 1
+    assert f"- request_human_choice: Answer: {reply}" in handoff
+    assert "Question: Choose the delivery method Options: 1. Email result; 2. Local result" in handoff
+    assert not any(key in handoff for key in ('"reply":', '"questions":', '"status":', '"message":'))
+    persisted = _turn(advance, "turn-switched", TurnStatus.COMPLETED)
+    assert persisted.ota_records[-1]["action_result"]["results"][0]["tool_result"]["reason"] == handoff
+    messages = await GenerateThink().assemble_messages(advance, orchestration.context)
+    prompt = "\n".join(message.content for message in messages)
+    for expected in (reason, approved, "Where should the report go?", "Choose the delivery method", "Email result", "Local result", "second option"):
+        assert expected in handoff
+        assert expected in prompt
+    for excluded in ("PRIVATE VERIFY TRACE", "PRIVATE EXPLORE TRACE", "PRIVATE TOOL OUTPUT", "PRIVATE CONFIRMATION CARD", "PENDING CONFIRMATION", "FAILED CHOICE RESULT"):
+        assert excluded not in handoff
+        assert excluded not in prompt
+
+
+@pytest.mark.parametrize("context_size", [1_500, 19_500])
+async def test_switch_keeps_complete_prompt_and_distinct_decisions(orchestration: _Harness, context_size: int) -> None:
+    """Preserve prompt tails and deduplicate only identical contextual decisions."""
+    await _prepare_build(orchestration, "explore")
+    contexts = ["C" * context_size + suffix for suffix in (" Subject: file A.", " Subject: file B.")]
+    advance = _ota(
+        "Continue implementation",
+        _step("switch", {"mode": "build", "stage": "generate", "reason": "Implement the decisions."}),
+        BuildStageState(stage="explore"),
+    )
+    advance.ota_record[0].think_scope = {"mode": "build", "stage": "explore"}
+    choices = []
+    for prompt in contexts:
+        choice = _step("request_human_choice", "Proceed")
+        choice.tool_arguments = {
+            "prompt": prompt,
+            "questions": json.dumps([{"question": "Proceed?", "options": [{"label": "Proceed"}, {"label": "Cancel"}]}]),
+        }
+        choices.append(choice)
+    choices.append(choices[-1].model_copy(deep=True))
+    advance.ota_record.insert(0, OTARecord(
+        think_scope={"mode": "build", "stage": "explore"},
+        action_result=ActionResult(results=choices),
+    ))
+
+    await _apply(orchestration, advance)
+
+    handoff = _payload(advance, "switch")["reason"]
+    prompt = "\n".join(message.content for message in await GenerateThink().assemble_messages(advance, orchestration.context))
+    assert contexts[-1] in handoff and contexts[-1] in prompt
+    assert handoff.count(contexts[-1]) == 1
+    assert "[truncated;" not in handoff
+    if context_size == 1_500:
+        assert contexts[0] in handoff and handoff.count("- request_human_choice:") == 2
+    else:
+        assert contexts[0] not in handoff and handoff.count("- request_human_choice:") == 1
+        assert "Additional details omitted" in handoff
+
+
 async def test_terminal_rehydration(orchestration: _Harness) -> None:
     """Final state after a terminal Turn:
 
@@ -512,9 +623,15 @@ async def test_workflow_edit(orchestration: _Harness) -> None:
             "Edit the saved report Workflow",
             _step("edit_workflow", EditWorkflow(saved.workflow_id)),
         )
+        edit.ota_record[0].think_scope = {"mode": "normal", "stage": "main"}
+        edit.action_result.results[0].tool_arguments = {"workflow_id": saved.workflow_id}
         await _apply(orchestration, edit)
         assert edit.think_status == BuildStageState(stage="clarify", workflow_id=saved.workflow_id)
         assert orchestration.workspace.build is not None
+        messages = await ClarifyThink().assemble_messages(edit, orchestration.context)
+        rendered = str([message.model_dump(mode="json") for message in messages])
+        assert _payload(edit, "edit_workflow")["message"] in rendered
+        assert saved.workflow_id in rendered
         return orchestration.workspace.build.root / "workflow" / "WORKFLOW.md"
 
     async def publish(request_id: str, action: str, name: str) -> AmphiOTAContext:

--- a/tests/agent/invocation/test_interactions.py
+++ b/tests/agent/invocation/test_interactions.py
@@ -212,7 +212,9 @@ async def test_build_confirm(interactions: _Harness) -> None:
     assert checkpoint.stage == "clarify"
 
 
-async def test_build_conflict(interactions: _Harness) -> None:
+@pytest.mark.parametrize("existing_stage", ["clarify", "verify"])
+@pytest.mark.parametrize("freeform", [False, True])
+async def test_build_conflict(interactions: _Harness, existing_stage: str, freeform: bool) -> None:
     """Final conflicting Build request:
 
     {
@@ -227,7 +229,9 @@ async def test_build_conflict(interactions: _Harness) -> None:
     """
     record = await interactions.create_session("build-conflict")
     workspace = await interactions.workspace(record)
-    build = await workspace.prepare_build_space("create", stage="clarify")
+    build = await workspace.prepare_build_space("create", stage=existing_stage)
+    if existing_stage == "verify":
+        _write_package(build.root)
     marker = build.root / "marker.txt"
     marker.write_text("original\n", encoding="utf-8")
     workspace.close_build_space()
@@ -253,11 +257,12 @@ async def test_build_conflict(interactions: _Harness) -> None:
         call_id="call-leave-retained-build",
     )
     interactions.llm.enqueue_text("I kept the original unfinished Build.")
-    completed = await interactions.run(record.id, {
+    answer = "the second option" if freeform else {
         "type": "choice_answer",
         "request_id": conflict.interaction.request_id,
         "answers": [{"index": 0, "option_id": "keep"}],
-    })
+    }
+    completed = await interactions.run(record.id, answer)
 
     # Check 2: The selected stable option resolves the held tool result and retained state.
     assert completed.outcome.disposition is InvocationDisposition.COMPLETED
@@ -266,9 +271,21 @@ async def test_build_conflict(interactions: _Harness) -> None:
     assert turns[0].status is TurnStatus.COMPLETED
     assert turns[0].session_ordinal == 0
     result = _tool_result(turns[0], "request_build")
-    assert (result["status"], result["action"]) == ("resolved", "keep")
+    assert (result["status"], result["action"]) == (("not_answered", "not_answered") if freeform else ("resolved", "keep"))
     assert marker.read_text(encoding="utf-8") == "original\n"
-    assert workspace.build_checkpoint() is not None
+    checkpoint = workspace.build_checkpoint()
+    assert checkpoint is not None and checkpoint.stage == existing_stage
+    # The very first model call after the choice receives the resolved tool outcome.
+    prompt = "\n".join(message.content for message in interactions.llm.turn_calls[1].messages)
+    assert f"# Current stage: {existing_stage}" in prompt
+    assert result["message"] in prompt and result["response"] in prompt
+    if freeform:
+        handoff = _tool_result(turns[0], "switch")["reason"]
+        question = conflict.interaction.questions[0]
+        for text in ("the second option", conflict.interaction.reason, question["question"], f"2. {question['options'][1]['label']}"):
+            assert text in prompt and text in handoff
+    else:
+        assert "Ignore the competing Build request that triggered this choice." in prompt
 
 
 async def test_workflow_confirm(interactions: _Harness, agent_model: str) -> None:

--- a/tests/agent/prompt/test_mode_prompts.py
+++ b/tests/agent/prompt/test_mode_prompts.py
@@ -226,7 +226,8 @@ async def test_build_stage_message_scope_uses_build_switch_policy() -> None:
     ]
     assert "Past request" in clarify_contents
     assert "Past answer" in clarify_contents
-    assert "Explore needs clarification" in clarify_contents
+    assert "Explore needs clarification" not in clarify_contents
+    assert any("A required decision is missing" in content for content in clarify_contents)
     assert "Clarify progress" in clarify_contents
 
     generate_ota = AmphiOTAContext(
@@ -258,27 +259,16 @@ async def test_build_stage_message_scope_uses_build_switch_policy() -> None:
     generate_contents = [message.content for message in generate_messages]
     assert "Earlier generation history" in generate_contents
     assert "Verification intermediate work" not in generate_contents
-    assert "Verification history" in generate_contents
+    assert "Verification history" not in generate_contents
     assert any("mishandles empty input" in content for content in generate_contents)
     assert any("user confirmed" in content for content in generate_contents)
     assert any("input-normalization branch" in content for content in generate_contents)
     assert any("No other verified path" in content for content in generate_contents)
     assert "Generate retry progress" in generate_contents
-    switch_call = next(
-        block
-        for message in generate_messages
-        for block in message.blocks
-        if getattr(block, "id", None) == "call-verify-to-generate"
+    assert not any(
+        getattr(block, "id", None) == "call-verify-to-generate"
+        for message in generate_messages for block in message.blocks
     )
-    assert switch_call.id == "call-verify-to-generate"
-    assert switch_call.arguments == {"stage": "generate", "reason": switch_reason}
-    switch_result = next(
-        block
-        for message in generate_messages
-        for block in message.blocks
-        if getattr(block, "id", None) == "call-verify-to-generate" and hasattr(block, "content")
-    )
-    assert switch_reason in switch_result.content
 
     generation_handoff = switch_record(
         "generate",
@@ -303,7 +293,8 @@ async def test_build_stage_message_scope_uses_build_switch_policy() -> None:
     assert "Verification intermediate work" in verify_again_contents
     assert "Verification history" in verify_again_contents
     assert "Generate retry progress" not in verify_again_contents
-    assert "Generate retry completed" in verify_again_contents
+    assert "Generate retry completed" not in verify_again_contents
+    assert any("The corrected implementation is ready" in content for content in verify_again_contents)
     assert "Second verification progress" in verify_again_contents
 
 

--- a/tests/agent/test_state_context.py
+++ b/tests/agent/test_state_context.py
@@ -80,11 +80,13 @@ def test_context_compaction_round_trip() -> None:
     state = AgentState(context_compaction=ContextCompactionState(
         session_summary="Earlier Session work",
         session_through_ordinal=4,
+        session={"build": {"verify": {"session_summary": "Verify history", "session_through_ordinal": 7}}},
         turn={
             "build": {
                 "clarify": {
                     "turn_summary": "Earlier rounds in this Turn",
                     "turn_through_round": 3,
+                    "turn_covered_rounds": [1, 3, 5],
                 },
             },
         },


### PR DESCRIPTION
## Summary

Prevent compacted history from expanding again when a new Turn starts or the agent switches stages. Align history assembly, compaction ownership, and usage calibration around the same stage boundaries.

## Changes

- Manage Session and Turn history summaries independently for each `agent mode + stage`. Track exact coverage using original round positions and retain compatibility with legacy compaction records.
- Reuse saved Turn summaries and uncompacted records when assembling subsequent Session history, including after failed or cancelled Turns.
- Unify tool-history replay within and across Turns using the arguments and results of completed actions. Bound large arguments and omit historical reasoning content.
- Commit compaction state only after summary generation, context reassembly, and validation all complete. Cancellation or validation failure leaves previously committed summaries intact.
- Calibrate compaction triggers using the active stage's same-model usage reference, avoiding interference from other stages and allowing estimates to decrease as context shrinks.
- Enrich switch handoffs with key human-interaction questions, options, answers, and complete prompts. Use deduplicated, bounded natural-language notes and carry request_build decisions into the actual target stage.
- Allow Clarify to read Normal's summaries and uncovered history without modifying or compacting Normal's context. Clarify still compacts only its own history; other stages remain isolated.

## Validation

- After merging main at `798a70f`, ran `.venv/bin/python -m pytest -m 'not process' -q --tb=short`: **622 passed, 2 deselected**.
- `git diff --check` passed.
- Regression coverage includes cross-Turn replay, stage switching, independent stage compaction, cancellation atomicity, usage calibration, interaction handoffs, and Clarify's shared history view.
- Additionally exercised the real Session persistence and invocation path with scripted model responses: compaction succeeds, the main model call fails, a subsequent Turn continues, and Clarify reuses the saved summaries without re-expanding covered raw history.

## Scope

- Excludes local Lab changes.
- Leaves the existing frontend context-occupancy display behavior unchanged.
