### PR TITLE
chore(release): bump version to 0.1.5

### DIFF
--- a/desktop/apps/electron/package.json
+++ b/desktop/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amphi",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Bridgic Agent desktop app",
   "repository": {
     "type": "git",

--- a/desktop/apps/electron/src/shared/app-meta.ts
+++ b/desktop/apps/electron/src/shared/app-meta.ts
@@ -84,7 +84,7 @@ export const APP_BUNDLE_ID = 'ai.bridgic.agent'
 export const APP_DEEPLINK_SCHEME = 'amphi'
 
 /** App version — keep in sync with root and apps/electron package.json. */
-export const APP_VERSION = '0.1.4'
+export const APP_VERSION = '0.1.5'
 
 /** GitHub page used for user-confirmed issue reports from the desktop app. */
 export const APP_NEW_ISSUE_URL = 'https://github.com/bitsky-tech/bridgic-agent/issues/new'

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bridgic-agent-desktop",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "license": "SEE LICENSE IN ../LICENSE",
   "description": "Bridgic Agent — Electron GUI client for the Bridgic Agent backend daemon",

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -11,7 +11,7 @@ The command-line entry is ``python -m src <subcommand>`` (see
 :mod:`.amphi_cli`).
 """
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 
 
 __all__ = ["__version__"]


### PR DESCRIPTION
Bump the backend and desktop application from 0.1.4 to 0.1.5 so installers, the update feeds, application metadata, and the backend compatibility manifest advertise the same release. This PR changes only the four version declarations using `bun --cwd=desktop run set-version 0.1.5`.

The release baseline is `d7f0ab9bad29da6377496584f8816c1878dbc085`, which includes PRs #38–#41 after 0.1.4. Packaging workflows, installer configuration, and dependency declarations are unchanged from 0.1.4.

### Validation

- Desktop suite: 1,404 passed, 6 skipped, 0 failed.
- Backend suite: 632 passed; coverage 76.51% (required minimum 70%).
- Desktop ESLint, all TypeScript checks, naming, documentation links, locale parity, and comment-language checks passed.
- Generated compatibility manifest: desktop 0.1.5 requires backend 0.1.5. All four source version declarations agree; `pyproject.toml` still uses the backend's dynamic version.
- Temporary database checks using a reconstructed legacy users schema verified existing-user loading and updates, fresh-schema initialization, and both documented database compatibility limitations below. These checks did not touch the installed application's database.
- `git diff --check` passed. Local tools: Bun 1.3.14 and uv 0.8.11; this PR's Validate workflow reruns the full checks using the pinned CI toolchain (Bun 1.3.10 and uv 0.9.5).
- PR Validate passed on head `8963977cb61de054bb49ed4026401e58a311a96d`: [desktop and backend checks](https://github.com/bitsky-tech/bridgic-agent/actions/runs/34680165354).
- Baseline main Validate and all three nightly packaging jobs passed. That nightly skipped the Windows installer smoke suite; the formal tag build must run it.
- No manual installer or end-to-end client-update test has been performed for 0.1.5 yet.

### Release scope and known limitations

File-read pagination and code-controlled invocation limits (#38), legacy Workflow package compatibility (#39), stage-scoped compaction and context handoffs (#40), and durable Workflow stage display across exits, restarts, and history pages (#41).

Known limitations retained from the merged changes:

- New databases omit `default_max_rounds` and cannot be opened by 0.1.4. Existing local users upgrade normally; reseeding a missing user in an old database still fails that legacy column's NOT NULL constraint (#38).
- Verify uses the last standalone PASS/FAIL outside code fences, so a later per-check PASS can override an earlier overall FAIL (#39).
- A retained legacy validation-stage Turn awaiting a Workflow resume/restart choice can leave the choice unresolved and overwrite an earlier ordinary answer in the same Turn (#39).

Merge after Validate passes, the required GitHub review is approved, and the release owner confirms the merge checkpoint. Verify the exact merge commit on main, then obtain the release owner's separate confirmation before pushing its annotated `0.1.5` tag. Wait for every Package job, verify all installers and both update feeds, and publish the prepared Release Notes before reporting completion.
